### PR TITLE
Use Kubernetes environment variables to find IP addresses

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandsInternalModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandsInternalModule.java
@@ -34,7 +34,7 @@ public abstract class CommandsInternalModule {
     @Binds @IntoSet abstract Command bindListRecordingOptionsCommand(ListRecordingOptionsCommand command);
     @Binds @IntoSet abstract Command bindListSavedRecordingsCommand(ListSavedRecordingsCommand command);
     @Binds @IntoSet abstract Command bindPingCommand(PingCommand command);
-    @Binds @IntoSet abstract Command bindPortScanCommand(PortScanCommand command);
+    @Binds @IntoSet abstract Command bindPortScanCommand(ScanTargetsCommand command);
     @Binds @IntoSet abstract Command bindPrintUrlCommand(PrintUrlCommand command);
     @Binds @IntoSet abstract Command bindRecordingOptionsCustomizerCommand(RecordingOptionsCustomizerCommand command);
     @Binds @IntoSet abstract Command bindSaveRecordingCommand(SaveRecordingCommand command);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ScanTargetsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ScanTargetsCommand.java
@@ -20,7 +20,7 @@ import com.redhat.rhjmc.containerjfr.sys.Environment;
 import com.redhat.rhjmc.containerjfr.tui.ClientWriter;
 
 @Singleton
-class PortScanCommand implements SerializableCommand {
+class ScanTargetsCommand implements SerializableCommand {
 
     private static final String KUBERNETES_ENV_SUFFIX = "_PORT_9091_TCP_ADDR";
 
@@ -28,14 +28,14 @@ class PortScanCommand implements SerializableCommand {
     private final Environment env;
 
     @Inject
-    PortScanCommand(ClientWriter cw, Environment env) {
+    ScanTargetsCommand(ClientWriter cw, Environment env) {
         this.cw = cw;
         this.env = env;
     }
 
     @Override
     public String getName() {
-        return "port-scan";
+        return "scan-targets";
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/sys/Environment.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/sys/Environment.java
@@ -1,5 +1,7 @@
 package com.redhat.rhjmc.containerjfr.sys;
 
+import java.util.Map;
+
 public class Environment {
 
     public String getEnv(String key) {
@@ -12,6 +14,10 @@ public class Environment {
             return def;
         }
         return res;
+    }
+
+    public Map<String, String> getEnv() {
+        return System.getenv();
     }
 
     public String getProperty(String key) {


### PR DESCRIPTION
Kubernetes/OpenShift automatically populates certain environment variables in containers to help detect local services those containers may want to communicate with [1]. This PR uses those environment variables to find services that are listening on TCP port 9091. If no such environment variables are found, it will fall back to using the port scanning approach.

Example from robotcontroller pod [2]:
```bash
$ env | grep ROBOTMAKER | sort
ROBOTMAKER_PORT=tcp://172.30.95.111:9091
ROBOTMAKER_PORT_8080_TCP=tcp://172.30.95.111:8080
ROBOTMAKER_PORT_8080_TCP_ADDR=172.30.95.111
ROBOTMAKER_PORT_8080_TCP_PORT=8080
ROBOTMAKER_PORT_8080_TCP_PROTO=tcp
ROBOTMAKER_PORT_8778_TCP=tcp://172.30.95.111:8778
ROBOTMAKER_PORT_8778_TCP_ADDR=172.30.95.111
ROBOTMAKER_PORT_8778_TCP_PORT=8778
ROBOTMAKER_PORT_8778_TCP_PROTO=tcp
ROBOTMAKER_PORT_9091_TCP=tcp://172.30.95.111:9091
ROBOTMAKER_PORT_9091_TCP_ADDR=172.30.95.111
ROBOTMAKER_PORT_9091_TCP_PORT=9091
ROBOTMAKER_PORT_9091_TCP_PROTO=tcp
ROBOTMAKER_PORT_9779_TCP=tcp://172.30.95.111:9779
ROBOTMAKER_PORT_9779_TCP_ADDR=172.30.95.111
ROBOTMAKER_PORT_9779_TCP_PORT=9779
ROBOTMAKER_PORT_9779_TCP_PROTO=tcp
ROBOTMAKER_SERVICE_HOST=172.30.95.111
ROBOTMAKER_SERVICE_PORT=9091
ROBOTMAKER_SERVICE_PORT_8080_TCP=8080
ROBOTMAKER_SERVICE_PORT_8778_TCP=8778
ROBOTMAKER_SERVICE_PORT_9091_TCP=9091
ROBOTMAKER_SERVICE_PORT_9779_TCP=9779
```

[1] https://kubernetes.io/docs/concepts/containers/container-environment-variables/
[2] https://github.com/rh-jmc-team/jmc-robots-demo