### PR TITLE
Improve tests for SocketClientReaderWriter and NetworkResolver

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/tcp/SocketClientReaderWriter.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/tcp/SocketClientReaderWriter.java
@@ -5,6 +5,7 @@ import java.io.OutputStreamWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 import java.util.concurrent.Semaphore;
 
@@ -17,7 +18,7 @@ class SocketClientReaderWriter implements ClientReader, ClientWriter {
     private final Logger logger;
     private final Thread listenerThread;
     private final ServerSocket ss;
-    private final Semaphore semaphore = new Semaphore(0, true);
+    private final Semaphore semaphore;
     private volatile Socket s;
     private volatile Scanner scanner;
     private volatile OutputStreamWriter writer;
@@ -25,6 +26,7 @@ class SocketClientReaderWriter implements ClientReader, ClientWriter {
     SocketClientReaderWriter(Logger logger, int port) throws IOException {
         this.logger = logger;
         ss = new ServerSocket(port);
+        semaphore = new Semaphore(0, true);
         listenerThread = new Thread(() -> {
             System.out.println(String.format("Listening on port %d", port));
             while (true) {
@@ -38,8 +40,8 @@ class SocketClientReaderWriter implements ClientReader, ClientWriter {
                     System.out.println(String.format("Connected: %s", sock.getRemoteSocketAddress().toString()));
                     try {
                         s = sock;
-                        scanner = new Scanner(sock.getInputStream(), "utf-8");
-                        writer = new OutputStreamWriter(sock.getOutputStream(), "utf-8");
+                        scanner = new Scanner(sock.getInputStream(), StandardCharsets.UTF_8);
+                        writer = new OutputStreamWriter(sock.getOutputStream(), StandardCharsets.UTF_8);
                     } finally {
                         semaphore.release();
                     }
@@ -51,6 +53,20 @@ class SocketClientReaderWriter implements ClientReader, ClientWriter {
             }
         });
         listenerThread.start();
+    }
+
+    // Testing-only constructor
+    SocketClientReaderWriter(Logger logger, Semaphore semaphore, Socket s, Scanner scanner, OutputStreamWriter writer) {
+        this.logger = logger;
+        this.semaphore = semaphore;
+        this.scanner = scanner;
+        this.writer = writer;
+        this.listenerThread = null;
+        this.ss = null;
+        this.s = s;
+
+
+        semaphore.release();
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/tcp/SocketClientReaderWriter.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/tcp/SocketClientReaderWriter.java
@@ -64,8 +64,6 @@ class SocketClientReaderWriter implements ClientReader, ClientWriter {
         this.listenerThread = null;
         this.serverSocket = null;
         this.socket = socket;
-
-        semaphore.release();
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/tcp/SocketClientReaderWriter.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/tcp/SocketClientReaderWriter.java
@@ -17,21 +17,21 @@ class SocketClientReaderWriter implements ClientReader, ClientWriter {
 
     private final Logger logger;
     private final Thread listenerThread;
-    private final ServerSocket ss;
+    private final ServerSocket serverSocket;
     private final Semaphore semaphore;
-    private volatile Socket s;
+    private volatile Socket socket;
     private volatile Scanner scanner;
     private volatile OutputStreamWriter writer;
 
     SocketClientReaderWriter(Logger logger, int port) throws IOException {
         this.logger = logger;
-        ss = new ServerSocket(port);
+        serverSocket = new ServerSocket(port);
         semaphore = new Semaphore(0, true);
         listenerThread = new Thread(() -> {
             System.out.println(String.format("Listening on port %d", port));
             while (true) {
                 try {
-                    Socket sock = ss.accept();
+                    Socket sock = serverSocket.accept();
                     try {
                         close();
                     } catch (IOException e) {
@@ -39,7 +39,7 @@ class SocketClientReaderWriter implements ClientReader, ClientWriter {
                     }
                     System.out.println(String.format("Connected: %s", sock.getRemoteSocketAddress().toString()));
                     try {
-                        s = sock;
+                        socket = sock;
                         scanner = new Scanner(sock.getInputStream(), StandardCharsets.UTF_8);
                         writer = new OutputStreamWriter(sock.getOutputStream(), StandardCharsets.UTF_8);
                     } finally {
@@ -56,15 +56,14 @@ class SocketClientReaderWriter implements ClientReader, ClientWriter {
     }
 
     // Testing-only constructor
-    SocketClientReaderWriter(Logger logger, Semaphore semaphore, Socket s, Scanner scanner, OutputStreamWriter writer) {
+    SocketClientReaderWriter(Logger logger, Semaphore semaphore, Socket socket, Scanner scanner, OutputStreamWriter writer) {
         this.logger = logger;
         this.semaphore = semaphore;
         this.scanner = scanner;
         this.writer = writer;
         this.listenerThread = null;
-        this.ss = null;
-        this.s = s;
-
+        this.serverSocket = null;
+        this.socket = socket;
 
         semaphore.release();
     }
@@ -78,8 +77,8 @@ class SocketClientReaderWriter implements ClientReader, ClientWriter {
         if (writer != null) {
             writer.close();
         }
-        if (s != null) {
-            s.close();
+        if (socket != null) {
+            socket.close();
         }
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/NetworkResolverTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/NetworkResolverTest.java
@@ -49,4 +49,37 @@ class NetworkResolverTest {
         MatcherAssert.assertThat(resolver.getHostAddress(), Matchers.equalTo(hostAddress));
     }
 
+    @Test
+    void shouldUseSocketRawHostAddress() throws Exception {
+        byte[] rawHostAddress = new byte[]{1, 2, 3, 4};
+        when(socket.getLocalAddress()).thenReturn(address);
+        when(address.getAddress()).thenReturn(rawHostAddress);
+
+        MatcherAssert.assertThat(resolver.getRawHostAddress(), Matchers.equalTo(rawHostAddress));
+    }
+
+    @Test
+    void shouldResolveAddress() throws Exception {
+        MatcherAssert.assertThat(resolver.resolveAddress(new byte[]{127, 0, 0, 1}).getHostName(),
+                Matchers.equalTo("localhost"));
+    }
+
+    @Test
+    void shouldLookup() throws Exception {
+        MatcherAssert
+                .assertThat(resolver.lookup("localhost").getAddress(), Matchers.equalTo(new byte[]{127, 0, 0, 1}));
+    }
+
+    @Test
+    void shouldUseInetAddressCanonicalHostName() {
+        String canonicalHostName = "canonical-host-name";
+        when(address.getCanonicalHostName()).thenReturn(canonicalHostName);
+
+        MatcherAssert.assertThat(resolver.resolveCanonicalHostName(address), Matchers.equalTo(canonicalHostName));
+    }
+
+    @Test
+    void testResolveCanonicalHostName() throws Exception {
+        MatcherAssert.assertThat(resolver.resolveCanonicalHostName("127.0.0.1"), Matchers.equalTo("localhost"));
+    }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/tui/tcp/SocketClientReaderWriterTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/tui/tcp/SocketClientReaderWriterTest.java
@@ -1,0 +1,120 @@
+package com.redhat.rhjmc.containerjfr.tui.tcp;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.net.Socket;
+import java.util.Scanner;
+import java.util.concurrent.Semaphore;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SocketClientReaderWriterTest {
+    @Mock
+    Logger logger;
+
+    @Mock
+    Semaphore semaphore;
+
+    @Mock
+    Socket s;
+
+    @Mock
+    Scanner scanner;
+
+    @Mock
+    OutputStreamWriter writer;
+
+    SocketClientReaderWriter scrw;
+
+    @BeforeEach
+    void setup() throws Exception {
+        scrw = new SocketClientReaderWriter(logger, semaphore, s, scanner, writer);
+    }
+
+    @Test
+    void shouldClose() throws Exception {
+        scrw.close();
+
+        verify(scanner).close();
+        verify(writer).close();
+        verify(s).close();
+    }
+
+    @Test
+    void shouldReadLine() throws Exception {
+        String result = "read line result";
+        when(scanner.nextLine()).thenReturn(result);
+
+        reset(semaphore);
+
+        MatcherAssert.assertThat(scrw.readLine(), Matchers.equalTo(result));
+
+        verify(semaphore).acquire();
+        verify(semaphore).release();
+    }
+
+    @Test
+    void shouldReadLineWarnOnException() throws Exception {
+        InterruptedException e = new InterruptedException();
+        doThrow(e).when(semaphore).acquire();
+
+        scrw.readLine();
+
+        verify(logger).warn(e);
+    }
+
+    @Test
+    void shouldReadLineReleaseOnException() throws Exception {
+        RuntimeException e = new RuntimeException();
+        when(scanner.nextLine()).thenThrow(e);
+
+        reset(semaphore);
+        Assertions.assertThrows(RuntimeException.class, scrw::readLine);
+
+        verify(semaphore).acquire();
+        verify(semaphore).release();
+    }
+
+    @Test
+    void shouldPrint() throws Exception {
+        String content = "printed content";
+
+        scrw.print(content);
+
+        verify(writer).write(content);
+        verify(writer).flush();
+    }
+
+    @Test
+    void shouldPrintWarnOnException() throws Exception {
+        IOException e = new IOException();
+        doThrow(e).when(writer).flush();
+
+        scrw.print("some content");
+
+        verify(logger).warn(e);
+    }
+
+    @Test
+    void shouldPrintReleaseOnException() throws Exception {
+        IOException e = new IOException();
+        doThrow(e).when(writer).flush();
+
+        reset(semaphore);
+        scrw.print("some content");
+
+        verify(semaphore).acquire();
+        verify(semaphore).release();
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/tui/tcp/SocketClientReaderWriterTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/tui/tcp/SocketClientReaderWriterTest.java
@@ -56,8 +56,6 @@ class SocketClientReaderWriterTest {
         String result = "read line result";
         when(scanner.nextLine()).thenReturn(result);
 
-        reset(semaphore);
-
         MatcherAssert.assertThat(scrw.readLine(), Matchers.equalTo(result));
 
         verify(semaphore).acquire();
@@ -79,7 +77,6 @@ class SocketClientReaderWriterTest {
         RuntimeException e = new RuntimeException();
         when(scanner.nextLine()).thenThrow(e);
 
-        reset(semaphore);
         Assertions.assertThrows(RuntimeException.class, scrw::readLine);
 
         verify(semaphore).acquire();
@@ -111,7 +108,6 @@ class SocketClientReaderWriterTest {
         IOException e = new IOException();
         doThrow(e).when(writer).flush();
 
-        reset(semaphore);
         scrw.print("some content");
 
         verify(semaphore).acquire();

--- a/src/test/java/com/redhat/rhjmc/containerjfr/tui/tcp/SocketClientReaderWriterTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/tui/tcp/SocketClientReaderWriterTest.java
@@ -27,7 +27,7 @@ class SocketClientReaderWriterTest {
     Semaphore semaphore;
 
     @Mock
-    Socket s;
+    Socket socket;
 
     @Mock
     Scanner scanner;
@@ -38,8 +38,8 @@ class SocketClientReaderWriterTest {
     SocketClientReaderWriter scrw;
 
     @BeforeEach
-    void setup() throws Exception {
-        scrw = new SocketClientReaderWriter(logger, semaphore, s, scanner, writer);
+    void setup() {
+        scrw = new SocketClientReaderWriter(logger, semaphore, socket, scanner, writer);
     }
 
     @Test
@@ -48,7 +48,7 @@ class SocketClientReaderWriterTest {
 
         verify(scanner).close();
         verify(writer).close();
-        verify(s).close();
+        verify(socket).close();
     }
 
     @Test


### PR DESCRIPTION
This PR improves #6.

For `NetworkResolver::testConnection`, I'm unsure how to mock the internal Socket and InetSocketAddress. The function is therefore untested.

As for the WebServer, it's better to refactor it, making it easier to adapts arbitrary HTTP server implementations. I'm currently working on this.