### PR TITLE
Correct unit test assertions

### DIFF
--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ConnectCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ConnectCommandTest.java
@@ -64,7 +64,7 @@ class ConnectCommandTest {
         assertFalse(command.validate(new String[0]));
         assertTrue(command.validate(new String[]{ "foo" }));
         assertFalse(command.validate(new String[2]));
-        verify(cw, Mockito.times(2)).println("Expected one argument: host name/URL");
+        verify(cw, Mockito.times(2)).println("Expected one argument: hostname:port, ip:port, or JMX service URL");
     }
 
     @ParameterizedTest
@@ -75,19 +75,19 @@ class ConnectCommandTest {
     })
     void shouldNotValidateInvalidIdentifiers(String id) {
         assertFalse(command.validate(new String[] { id }), id);
-        verify(cw).println(id + " is an invalid host name/URL");
+        verify(cw).println(id + " is an invalid connection specifier");
     }
 
     @Test
     void shouldNotValidateNull() {
         assertFalse(command.validate(new String[] { null }));
-        verify(cw).println("Expected one argument: host name/URL");
+        verify(cw).println("Expected one argument: hostname:port, ip:port, or JMX service URL");
     }
 
     @Test
     void shouldNotValidateEmptyString() {
         assertFalse(command.validate(new String[] { " " }));
-        verify(cw).println("Expected one argument: host name/URL");
+        verify(cw).println("Expected one argument: hostname:port, ip:port, or JMX service URL");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Strings printed by ConnectCommand on invalid input were changed but the
tests not modified to match.

Fixes #45