### PR TITLE
Avoid NPE on nullable ServicePorts list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ copyWebClient.dependsOn buildWebClient
 processResources.dependsOn copyWebClient
 
 def baseImage = 'gcr.io/distroless/java:11';
-def version = '0.4.7';
+def version = '0.4.8';
 def debugBuild = System.getenv('CONTAINER_JFR_DEBUG') != null;
 if (debugBuild) {
     baseImage += '-debug'


### PR DESCRIPTION
While testing with OpenShift 4 and CodeReady Containers, I ran into a situation where a Kubernetes service was detected using the KubeApi discovery strategy, and this service had a null list of service ports. This caused an NPE on target discovery, since the streaming used to transform the API listing results into a list of ServiceRefs assumed non-null service port lists. For easier debugging of such potential issues in the future I've also added the trace-level logging of discovered services before any processing is performed.