### PR TITLE
Report download and reports links with appropriate protocol

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -198,7 +198,7 @@ public class WebServer implements ConnectionListener {
     }
 
     public URL getHostUrl() throws UnknownHostException, MalformedURLException, SocketException {
-        return new URL("http", netConf.getWebServerHost(), netConf.getExternalWebServerPort(), "");
+        return new URL("http" + (server.isSsl() ? "s" : ""), netConf.getWebServerHost(), netConf.getExternalWebServerPort(), "");
     }
 
     public String getDownloadURL(String recordingName)


### PR DESCRIPTION
When SSL is enabled, use HTTPS protocol for recording download and
reports links. Fallback to plain HTTP if SSL is not enabled.

Fixes #75