### PR TITLE
Allow re-uploading recordings from clients

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebModule.java
@@ -8,6 +8,7 @@ import javax.inject.Singleton;
 import com.redhat.rhjmc.containerjfr.ExecutionMode;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.ConnectionListener;
 import com.redhat.rhjmc.containerjfr.net.HttpServer;
@@ -36,6 +37,7 @@ public abstract class WebModule {
             NetworkConfiguration netConf,
             Environment env,
             @Named("RECORDINGS_PATH") Path recordingsPath,
+            FileSystem fs,
             ReportGenerator reportGenerator,
             AuthManager authManager,
             Gson gson,
@@ -45,6 +47,7 @@ public abstract class WebModule {
                 netConf,
                 env,
                 recordingsPath,
+                fs,
                 authManager,
                 gson,
                 reportGenerator,

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -24,8 +24,6 @@ import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
-import io.vertx.core.AsyncResult;
 import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
 import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
 import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
@@ -35,6 +33,7 @@ import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.ConnectionListener;
 import com.redhat.rhjmc.containerjfr.net.HttpServer;
@@ -42,6 +41,7 @@ import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
 import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportGenerator;
 
 import com.google.gson.Gson;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
@@ -69,7 +69,8 @@ public class WebServer implements ConnectionListener {
 
     private static final int WRITE_BUFFER_SIZE = 64 * 1024; // 64 KB
 
-    private static final Pattern RECORDING_FILENAME_PATTERN = Pattern.compile("([A-Za-z\\d-]*)_([A-Za-z\\d-_]*)_([\\d]*T[\\d]*Z)(.[\\d]+)?");
+    private static final Pattern RECORDING_FILENAME_PATTERN =
+            Pattern.compile("([A-Za-z\\d-]*)_([A-Za-z\\d-_]*)_([\\d]*T[\\d]*Z)(.[\\d]+)?");
 
     private final HttpServer server;
     private final NetworkConfiguration netConf;
@@ -170,19 +171,20 @@ public class WebServer implements ConnectionListener {
                                     : exception.getMessage();
 
                     ctx.response()
-                        .setStatusCode(exception.getStatusCode())
-                        .setStatusMessage(exception.getMessage());
+                            .setStatusCode(exception.getStatusCode())
+                            .setStatusMessage(exception.getMessage());
 
                     String accept = ctx.request().getHeader(HttpHeaders.ACCEPT);
-                    if (accept.contains(MIME_TYPE_JSON) && accept.indexOf(MIME_TYPE_JSON) < accept.indexOf(MIME_TYPE_PLAINTEXT)) {
-                        ctx.response()
-                            .putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_JSON);
+                    if (accept.contains(MIME_TYPE_JSON)
+                            && accept.indexOf(MIME_TYPE_JSON)
+                                    < accept.indexOf(MIME_TYPE_PLAINTEXT)) {
+                        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_JSON);
                         endWithJsonKeyValue("message", payload, ctx.response());
                         return;
                     }
 
                     ctx.response()
-                        .putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_PLAINTEXT)
+                            .putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_PLAINTEXT)
                             .end(payload);
                 };
 
@@ -216,9 +218,9 @@ public class WebServer implements ConnectionListener {
                 .failureHandler(failureHandler);
 
         router.post("/recordings")
-            .handler(BodyHandler.create(true))
-            .handler(this::handleRecordingUploadRequest)
-            .failureHandler(failureHandler);
+                .handler(BodyHandler.create(true))
+                .handler(this::handleRecordingUploadRequest)
+                .failureHandler(failureHandler);
 
         router.get("/reports/:name")
                 .blockingHandler(ctx -> this.handleReportPageRequest(ctx.pathParam("name"), ctx))
@@ -455,7 +457,6 @@ public class WebServer implements ConnectionListener {
         }
 
         FileUpload upload = null;
-
         for (FileUpload fu : ctx.fileUploads()) {
             // ignore unrecognized form fields
             if ("recording".equals(fu.name())) {
@@ -482,87 +483,36 @@ public class WebServer implements ConnectionListener {
             throw new HttpStatusException(400, "Incorrect recording file name pattern");
         }
 
-        String targetName  = m.group(1);
+        String targetName = m.group(1);
         String recordingName = m.group(2);
         String timestamp = m.group(3);
-        int count = m.group(4) == null || m.group(4).isEmpty() ? 0 : Integer.parseInt(m.group(4).substring(1));
+        int count =
+                m.group(4) == null || m.group(4).isEmpty()
+                        ? 0
+                        : Integer.parseInt(m.group(4).substring(1));
 
-        final String destination = String.format("%s_%s_%s", targetName, recordingName, timestamp);
+        final String basename = String.format("%s_%s_%s", targetName, recordingName, timestamp);
         final String uploadedFileName = upload.uploadedFileName();
-        final Runnable saveFileRunnable = new Runnable() {
-            String baseName = savedRecordingsPath.resolve(destination).toString();
-            int counter = count;
+        validateRecording(
+                upload.uploadedFileName(),
+                (res) ->
+                        saveRecording(
+                                basename,
+                                uploadedFileName,
+                                count,
+                                (res2) -> {
+                                    if (res2.failed()) {
+                                        ctx.fail(res2.cause());
+                                        return;
+                                    }
 
-            @Override
-            public void run() {
-                // TODO byte-sized rename limit is arbitrary. Probably plenty since recordings
-                // are also differentiated by second-resolution timestamp
-                if (counter >= Byte.MAX_VALUE) {
-                    ctx.fail(
-                        new IOException(
-                            "Recording could not be saved. File already exists and rename attempts were exhausted."));
-                    return;
-                }
-
-                final String file =
-                    counter > 1 ? baseName + "." + counter + ".jfr" : baseName + ".jfr";
-
-                server.getVertx()
-                    .fileSystem()
-                    .exists(
-                        file,
-                        (res) -> {
-                            if (res.failed()) {
-                                ctx.fail(res.cause());
-                                return;
-                            }
-
-                            if (res.result()) {
-                                counter++;
-                                run();
-                                return;
-                            }
-
-                            server.getVertx()
-                                .fileSystem()
-                                .move(
-                                    uploadedFileName,
-                                    file,
-                                    (res2) -> {
-                                        if (res2.failed()) {
-                                            ctx.fail(res2.cause());
-                                            return;
-                                        }
-
-                                        ctx.response()
+                                    ctx.response()
                                             .putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_JSON);
-                                        endWithJsonKeyValue("name", file, ctx.response());
+                                    endWithJsonKeyValue("name", res2.result(), ctx.response());
 
-                                        logger.info(String.format("Recording saved as %s", file));
-                                    });
-                        });
-            }
-        };
-
-        server.getVertx().executeBlocking(event -> {
-            try {
-                JfrLoaderToolkit.loadEvents(new File(uploadedFileName)); // try loading events to see if it's a valid file
-                event.complete();
-            } catch (CouldNotLoadRecordingException | IOException e) {
-                event.fail(e);
-            }
-        }, (Handler<AsyncResult<Void>>) event -> {
-            if (event.failed()) {
-                if (event.cause() instanceof CouldNotLoadRecordingException) {
-                    ctx.fail(new HttpStatusException(400, "Not a valid JFR recording file",event.cause()));
-                } else {
-                    ctx.fail(event.cause());
-                }
-                return;
-            }
-
-            saveFileRunnable.run();
-        });
+                                    logger.info(
+                                            String.format("Recording saved as %s", res2.result()));
+                                }));
     }
 
     void handleRecordingDownloadRequest(String recordingName, RoutingContext ctx) {
@@ -647,6 +597,135 @@ public class WebServer implements ConnectionListener {
                     }
                     return matcher.group(1);
                 });
+    }
+
+    private <T> AsyncResult<T> makeAsyncResult(T result) {
+        return new AsyncResult<>() {
+            @Override
+            public T result() {
+                return result;
+            }
+
+            @Override
+            public Throwable cause() {
+                return null;
+            }
+
+            @Override
+            public boolean succeeded() {
+                return true;
+            }
+
+            @Override
+            public boolean failed() {
+                return false;
+            }
+        };
+    }
+
+    private <T> AsyncResult<T> makeFailedAsyncResult(Throwable cause) {
+        return new AsyncResult<>() {
+            @Override
+            public T result() {
+                return null;
+            }
+
+            @Override
+            public Throwable cause() {
+                return cause;
+            }
+
+            @Override
+            public boolean succeeded() {
+                return false;
+            }
+
+            @Override
+            public boolean failed() {
+                return true;
+            }
+        };
+    }
+
+    private void validateRecording(String recordingFile, Handler<AsyncResult<Void>> handler) {
+        server.getVertx()
+                .executeBlocking(
+                        event -> {
+                            try {
+                                JfrLoaderToolkit.loadEvents(
+                                        new File(recordingFile)); // try loading events to see if
+                                // it's a valid file
+                                event.complete();
+                            } catch (CouldNotLoadRecordingException | IOException e) {
+                                event.fail(e);
+                            }
+                        },
+                        res -> {
+                            if (res.failed()) {
+                                Throwable t;
+                                if (res.cause() instanceof CouldNotLoadRecordingException) {
+                                    t =
+                                            new HttpStatusException(
+                                                    400,
+                                                    "Not a valid JFR recording file",
+                                                    res.cause());
+                                } else {
+                                    t = res.cause();
+                                }
+
+                                handler.handle(makeFailedAsyncResult(t));
+                                return;
+                            }
+
+                            handler.handle(makeAsyncResult(null));
+                        });
+    }
+
+    private void saveRecording(
+            String basename, String tmpFile, int counter, Handler<AsyncResult<String>> handler) {
+        // TODO byte-sized rename limit is arbitrary. Probably plenty since recordings
+        // are also differentiated by second-resolution timestamp
+        if (counter >= Byte.MAX_VALUE) {
+            handler.handle(
+                    makeFailedAsyncResult(
+                            new IOException(
+                                    "Recording could not be saved. File already exists and rename attempts were exhausted.")));
+            return;
+        }
+
+        String filename = counter > 1 ? basename + "." + counter + ".jfr" : basename + ".jfr";
+
+        server.getVertx()
+                .fileSystem()
+                .exists(
+                        savedRecordingsPath.resolve(filename).toString(),
+                        (res) -> {
+                            if (res.failed()) {
+                                handler.handle(makeFailedAsyncResult(res.cause()));
+                                return;
+                            }
+
+                            if (res.result()) {
+                                saveRecording(basename, tmpFile, counter + 1, handler);
+                                return;
+                            }
+
+                            // verified no name clash at this time
+                            server.getVertx()
+                                    .fileSystem()
+                                    .move(
+                                            tmpFile,
+                                            savedRecordingsPath.resolve(filename).toString(),
+                                            (res2) -> {
+                                                if (res2.failed()) {
+                                                    handler.handle(
+                                                            makeFailedAsyncResult(res2.cause()));
+                                                    return;
+                                                }
+
+                                                handler.handle(makeAsyncResult(filename));
+                                            });
+                        });
     }
 
     private static class DownloadDescriptor {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -164,10 +164,21 @@ public class WebServer implements ConnectionListener {
                             exception.getPayload() != null
                                     ? exception.getPayload()
                                     : exception.getMessage();
+
                     ctx.response()
-                            .putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_PLAINTEXT)
-                            .setStatusCode(exception.getStatusCode())
-                            .setStatusMessage(exception.getMessage())
+                        .setStatusCode(exception.getStatusCode())
+                        .setStatusMessage(exception.getMessage());
+
+                    String accept = ctx.request().getHeader(HttpHeaders.ACCEPT);
+                    if (accept.contains(MIME_TYPE_JSON) && accept.indexOf(MIME_TYPE_JSON) < accept.indexOf(MIME_TYPE_PLAINTEXT)) {
+                        ctx.response()
+                            .putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_JSON);
+                        endWithJsonKeyValue("message", payload, ctx.response());
+                        return;
+                    }
+
+                    ctx.response()
+                        .putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_PLAINTEXT)
                             .end(payload);
                 };
 
@@ -507,11 +518,11 @@ public class WebServer implements ConnectionListener {
                                             return;
                                         }
 
-                                        String msg = "Recording saved as " + file;
                                         ctx.response()
-                                            .end(msg);
+                                            .putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_JSON);
+                                        endWithJsonKeyValue("name", file, ctx.response());
 
-                                        logger.info(msg);
+                                        logger.info(String.format("Recording saved as %s", file));
                                     });
                         });
             }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import io.vertx.core.AsyncResult;
 import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
 import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
@@ -74,6 +75,7 @@ public class WebServer implements ConnectionListener {
     private final NetworkConfiguration netConf;
     private final Environment env;
     private final Path savedRecordingsPath;
+    private final FileSystem fs;
     private final AuthManager auth;
     private final Gson gson;
     private final Logger logger;
@@ -88,6 +90,7 @@ public class WebServer implements ConnectionListener {
             NetworkConfiguration netConf,
             Environment env,
             Path savedRecordingsPath,
+            FileSystem fs,
             AuthManager auth,
             Gson gson,
             ReportGenerator reportGenerator,
@@ -96,6 +99,7 @@ public class WebServer implements ConnectionListener {
         this.netConf = netConf;
         this.env = env;
         this.savedRecordingsPath = savedRecordingsPath;
+        this.fs = fs;
         this.auth = auth;
         this.gson = gson;
         this.logger = logger;
@@ -444,6 +448,10 @@ public class WebServer implements ConnectionListener {
             }
         } catch (Exception e) {
             throw new HttpStatusException(500, e);
+        }
+
+        if (!fs.isDirectory(savedRecordingsPath)) {
+            throw new HttpStatusException(503, "Recording saving not available");
         }
 
         FileUpload upload = null;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -438,6 +438,14 @@ public class WebServer implements ConnectionListener {
     }
 
     void handleRecordingUploadRequest(RoutingContext ctx) {
+        try {
+            if (!validateRequestAuthorization(ctx.request()).get()) {
+                throw new HttpStatusException(401);
+            }
+        } catch (Exception e) {
+            throw new HttpStatusException(500, e);
+        }
+
         FileUpload upload = null;
 
         for (FileUpload fu : ctx.fileUploads()) {

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
@@ -359,12 +359,17 @@ class WebServerTest {
     }
 
     @Test
-    void shouldHandleRecordingUploadRequest() {
+    void shouldHandleRecordingUploadRequest() throws Exception {
         String basename = "localhost_test_20191219T213834Z";
         String filename = basename + ".jfr";
         String savePath = "/some/path/";
 
         RoutingContext ctx = mock(RoutingContext.class);
+
+        when(authManager.validateToken(any())).thenReturn(CompletableFuture.completedFuture(true));
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
         Set<FileUpload> uploads = new HashSet<>();
         FileUpload upload = mock(FileUpload.class);
         uploads.add(upload);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
@@ -22,16 +22,9 @@ import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Random;
-import java.util.concurrent.CompletableFuture;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.file.FileSystem;
-import io.vertx.ext.web.FileUpload;
-import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
-import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
@@ -45,10 +38,15 @@ import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
 import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportGenerator;
 
 import com.google.gson.Gson;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -383,9 +381,9 @@ class WebServerTest {
         when(upload.fileName()).thenReturn(filename);
         when(upload.uploadedFileName()).thenReturn("foo");
 
-        Path basePath = mock(Path.class);
-        when(basePath.toString()).thenReturn(savePath + basename);
-        when(recordingsPath.resolve(basename)).thenReturn(basePath);
+        Path filePath = mock(Path.class);
+        when(filePath.toString()).thenReturn(savePath + filename);
+        when(recordingsPath.resolve(filename)).thenReturn(filePath);
 
         Vertx vertx = mock(Vertx.class);
         when(httpServer.getVertx()).thenReturn(vertx);
@@ -393,88 +391,96 @@ class WebServerTest {
         FileSystem fs = mock(FileSystem.class);
         when(vertx.fileSystem()).thenReturn(fs);
 
-        doAnswer(invocation -> {
-            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(1);
-            handler.handle(new AsyncResult<>() {
-                @Override
-                public Boolean result() {
-                    return false;
-                }
+        doAnswer(
+                        invocation -> {
+                            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(1);
+                            handler.handle(
+                                    new AsyncResult<>() {
+                                        @Override
+                                        public Boolean result() {
+                                            return false;
+                                        }
 
-                @Override
-                public Throwable cause() {
-                    return null;
-                }
+                                        @Override
+                                        public Throwable cause() {
+                                            return null;
+                                        }
 
-                @Override
-                public boolean succeeded() {
-                    return true;
-                }
+                                        @Override
+                                        public boolean succeeded() {
+                                            return true;
+                                        }
 
-                @Override
-                public boolean failed() {
-                    return false;
-                }
-            });
+                                        @Override
+                                        public boolean failed() {
+                                            return false;
+                                        }
+                                    });
 
-            return null;
-        }).when(vertx).executeBlocking(any(Handler.class), any(Handler.class));
+                            return null;
+                        })
+                .when(vertx)
+                .executeBlocking(any(Handler.class), any(Handler.class));
 
         when(fs.exists(eq(savePath + filename), any(Handler.class)))
-            .thenAnswer(invocation -> {
-                Handler<AsyncResult<Boolean>> handler = invocation.getArgument(1);
-                handler.handle(new AsyncResult<>() {
-                    @Override
-                    public Boolean result() {
-                        return false;
-                    }
+                .thenAnswer(
+                        invocation -> {
+                            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(1);
+                            handler.handle(
+                                    new AsyncResult<>() {
+                                        @Override
+                                        public Boolean result() {
+                                            return false;
+                                        }
 
-                    @Override
-                    public Throwable cause() {
-                        return null;
-                    }
+                                        @Override
+                                        public Throwable cause() {
+                                            return null;
+                                        }
 
-                    @Override
-                    public boolean succeeded() {
-                        return true;
-                    }
+                                        @Override
+                                        public boolean succeeded() {
+                                            return true;
+                                        }
 
-                    @Override
-                    public boolean failed() {
-                        return false;
-                    }
-                });
+                                        @Override
+                                        public boolean failed() {
+                                            return false;
+                                        }
+                                    });
 
-                return null;
-            });
+                            return null;
+                        });
 
         when(fs.move(eq("foo"), eq(savePath + filename), any(Handler.class)))
-            .thenAnswer(invocation -> {
-                Handler<AsyncResult<Boolean>> handler = invocation.getArgument(2);
-                handler.handle(new AsyncResult<>() {
-                    @Override
-                    public Boolean result() {
-                        return true;
-                    }
+                .thenAnswer(
+                        invocation -> {
+                            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(2);
+                            handler.handle(
+                                    new AsyncResult<>() {
+                                        @Override
+                                        public Boolean result() {
+                                            return true;
+                                        }
 
-                    @Override
-                    public Throwable cause() {
-                        return null;
-                    }
+                                        @Override
+                                        public Throwable cause() {
+                                            return null;
+                                        }
 
-                    @Override
-                    public boolean succeeded() {
-                        return true;
-                    }
+                                        @Override
+                                        public boolean succeeded() {
+                                            return true;
+                                        }
 
-                    @Override
-                    public boolean failed() {
-                        return false;
-                    }
-                });
+                                        @Override
+                                        public boolean failed() {
+                                            return false;
+                                        }
+                                    });
 
-                return null;
-            });
+                            return null;
+                        });
 
         HttpServerResponse rep = mock(HttpServerResponse.class);
         when(ctx.response()).thenReturn(rep);
@@ -482,7 +488,7 @@ class WebServerTest {
         exporter.handleRecordingUploadRequest(ctx);
 
         verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
-        verify(rep).end("{\"name\":\""+ savePath + filename + "\"}");
+        verify(rep).end("{\"name\":\"" + filename + "\"}");
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
@@ -68,6 +68,7 @@ class WebServerTest {
     @Mock NetworkConfiguration netConf;
     @Mock Environment env;
     @Mock Path recordingsPath;
+    @Mock com.redhat.rhjmc.containerjfr.core.sys.FileSystem fs;
     @Mock AuthManager authManager;
     Gson gson = MainModule.provideGson();
     @Mock Logger logger;
@@ -83,6 +84,7 @@ class WebServerTest {
                         netConf,
                         env,
                         recordingsPath,
+                        fs,
                         authManager,
                         gson,
                         reportGenerator,
@@ -105,6 +107,7 @@ class WebServerTest {
                                 netConf,
                                 env,
                                 recordingsPath,
+                                fs,
                                 authManager,
                                 gson,
                                 reportGenerator,
@@ -369,6 +372,8 @@ class WebServerTest {
         when(authManager.validateToken(any())).thenReturn(CompletableFuture.completedFuture(true));
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
+
+        when(fs.isDirectory(recordingsPath)).thenReturn(true);
 
         Set<FileUpload> uploads = new HashSet<>();
         FileUpload upload = mock(FileUpload.class);


### PR DESCRIPTION
This patch allows JFR recordings to be (re-)uploaded to container-jfr from clients. The implement expects a recording with its name in form of *`<target-name>_<recording_name>_<timestamp>[.\d+].jfr`* and rejects otherwise.

**RFC**: Looking at the JMC API, I was unable to find a way which just simply validates a recording. Therefore, I called `JfrLoaderToolkit.loadEvents()` to verify the file uploaded is a valid JFR recording. This could lead to degraded performance.  

Closes rh-jmc-team#55. Blocked by rh-jmc-team/container-jfr-web#24 (needs sub-module commit hash).