### PR TITLE
Fix code comment in StartRecordingCommand

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommand.java
@@ -30,9 +30,8 @@ class StartRecordingCommand extends AbstractRecordingCommand implements Serializ
     }
 
     /**
-     * Two args expected. First argument is recording name, second argument is recording length in
-     * seconds. Second argument is comma-separated event options list, ex.
-     * jdk.SocketWrite:enabled=true,com.foo:ratio=95.2
+     * Two args expected. First argument is recording name, second argument is comma-separated event
+     * options list, ex. jdk.SocketWrite:enabled=true,com.foo:ratio=95.2
      */
     @Override
     public void execute(String[] args) throws Exception {


### PR DESCRIPTION
Adjusts the comment to be accurate. Another possibility is to remove these kinds of comments and make the variable names more verbose, but they can be useful, e.g. the events list sample. I don't have a strong opinion either way.