### PR TITLE
upload-recording command enhancements and fixes

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -102,7 +102,7 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
             return false;
         }
         if (!validateRecordingName(args[0])) {
-            cw.println("%s is an invalid recording name");
+            cw.println(String.format("%s is an invalid recording name", args[0]));
             return false;
         }
         return true;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -1,8 +1,6 @@
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Map;
@@ -118,7 +116,7 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
     // returned stream should be cleaned up by HttpClient
     @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
     Optional<InputStream> getBestRecordingForName(String recordingName)
-            throws FlightRecorderException, JMXConnectionException, FileNotFoundException {
+            throws FlightRecorderException, JMXConnectionException, IOException {
         if (super.isAvailable()) {
             Optional<IRecordingDescriptor> currentRecording = getDescriptorByName(recordingName);
             if (currentRecording.isPresent()) {
@@ -126,9 +124,9 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
             }
         }
 
-        File archivedRecording = recordingsPath.resolve(recordingName).toFile();
-        if (archivedRecording.isFile()) {
-            return Optional.of(new FileInputStream(archivedRecording));
+        Path archivedRecording = recordingsPath.resolve(recordingName);
+        if (fs.isRegularFile(archivedRecording) && fs.isReadable(archivedRecording)) {
+            return Optional.of(fs.newInputStream(archivedRecording));
         }
 
         return Optional.empty();

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -120,7 +120,7 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
         if (super.isAvailable()) {
             Optional<IRecordingDescriptor> currentRecording = getDescriptorByName(recordingName);
             if (currentRecording.isPresent()) {
-                return Optional.of(getService().openStream(currentRecording.get(), true));
+                return Optional.of(getService().openStream(currentRecording.get(), false));
             }
         }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -1,5 +1,6 @@
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -126,7 +127,7 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
 
         Path archivedRecording = recordingsPath.resolve(recordingName);
         if (fs.isRegularFile(archivedRecording) && fs.isReadable(archivedRecording)) {
-            return Optional.of(fs.newInputStream(archivedRecording));
+            return Optional.of(new BufferedInputStream(fs.newInputStream(archivedRecording)));
         }
 
         return Optional.empty();

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
@@ -1,0 +1,209 @@
+package com.redhat.rhjmc.containerjfr.commands.internal;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Provider;
+
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.commands.SerializableCommand.ExceptionOutput;
+import com.redhat.rhjmc.containerjfr.commands.SerializableCommand.Output;
+import com.redhat.rhjmc.containerjfr.commands.internal.UploadRecordingCommand.RecordingNotFoundException;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UploadRecordingCommandTest {
+
+    static final String UPLOAD_URL = "http://example.com/";
+
+    @Mock ClientWriter cw;
+    @Mock FileSystem fs;
+    @Mock Path path;
+    @Mock Provider<CloseableHttpClient> httpProvider;
+    @Mock JFRConnection conn;
+    UploadRecordingCommand cmd;
+
+    @BeforeEach
+    void setup() {
+        this.cmd = new UploadRecordingCommand(cw, fs, path, httpProvider);
+    }
+
+    @Test
+    void shouldBeNamedUploadRecording() {
+        MatcherAssert.assertThat(cmd.getName(), Matchers.equalTo("upload-recording"));
+    }
+
+    @Test
+    void shouldNotBeAvailableWhenDisconnected() {
+        Assertions.assertFalse(cmd.isAvailable());
+    }
+
+    @Test
+    void shouldBeAvailableWhenConnectedButNoRecordingsPath() {
+        cmd.connectionChanged(conn);
+        Assertions.assertTrue(cmd.isAvailable());
+    }
+
+    @Test
+    void shouldBeAvailableWhenDisConnectedWithRecordingsPath() {
+        Mockito.when(fs.isDirectory(path)).thenReturn(true);
+        Assertions.assertTrue(cmd.isAvailable());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 3})
+    void shouldNotValidateWrongArgc(int c) {
+        Assertions.assertFalse(cmd.validate(new String[c]));
+        Mockito.verify(cw).println("Expected two arguments: recording name and upload URL");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {"foo", "foo.jfr", "recording", "some-name", "another_name", "123", "abc123"})
+    void shouldValidateRecordingNames(String recordingName) {
+        Assertions.assertTrue(cmd.validate(new String[] {recordingName, UPLOAD_URL}));
+    }
+
+    @Disabled("Bug #111")
+    @ParameterizedTest
+    @ValueSource(strings = {".", "some recording", ""})
+    void shouldNotValidateInvalidRecordingNames(String recordingName) {
+        Assertions.assertFalse(cmd.validate(new String[] {recordingName, UPLOAD_URL}));
+        Mockito.verify(cw).println(recordingName + " is an invalid recording name");
+    }
+
+    @Nested
+    class RecordingSelection {
+
+        @Test
+        void shouldSelectInMemoryIfAvailable() throws Exception {
+            IFlightRecorderService svc = Mockito.mock(IFlightRecorderService.class);
+            IRecordingDescriptor rec = Mockito.mock(IRecordingDescriptor.class);
+            InputStream stream = Mockito.mock(InputStream.class);
+            Mockito.when(conn.getService()).thenReturn(svc);
+            Mockito.when(svc.getAvailableRecordings()).thenReturn(List.of(rec));
+            Mockito.when(rec.getName()).thenReturn("foo");
+            Mockito.when(svc.openStream(Mockito.any(), Mockito.anyBoolean())).thenReturn(stream);
+
+            cmd.connectionChanged(conn);
+            Optional<InputStream> res = cmd.getBestRecordingForName(rec.getName());
+
+            Assertions.assertTrue(res.isPresent());
+            MatcherAssert.assertThat(res.get(), Matchers.sameInstance(stream));
+            Mockito.verify(svc).openStream(rec, true);
+        }
+
+        @Test
+        void shouldReadFromDiskIfNotConnected() throws Exception {
+            Path rec = Mockito.mock(Path.class);
+            InputStream stream = Mockito.mock(InputStream.class);
+            Mockito.when(path.resolve(Mockito.anyString())).thenReturn(rec);
+            Mockito.when(fs.isRegularFile(rec)).thenReturn(true);
+            Mockito.when(fs.isReadable(rec)).thenReturn(true);
+            Mockito.when(fs.newInputStream(rec)).thenReturn(stream);
+
+            Optional<InputStream> res = cmd.getBestRecordingForName("foo");
+
+            Assertions.assertTrue(res.isPresent());
+            MatcherAssert.assertThat(res.get(), Matchers.sameInstance(stream));
+        }
+
+        @Test
+        void shouldFallThroughToDiskIfNotInMemory() throws Exception {
+            IFlightRecorderService svc = Mockito.mock(IFlightRecorderService.class);
+            InputStream stream = Mockito.mock(InputStream.class);
+            Mockito.when(conn.getService()).thenReturn(svc);
+            Mockito.when(svc.getAvailableRecordings()).thenReturn(Collections.emptyList());
+
+            Path rec = Mockito.mock(Path.class);
+            Mockito.when(path.resolve(Mockito.anyString())).thenReturn(rec);
+            Mockito.when(fs.isRegularFile(rec)).thenReturn(true);
+            Mockito.when(fs.isReadable(rec)).thenReturn(true);
+            Mockito.when(fs.newInputStream(rec)).thenReturn(stream);
+
+            cmd.connectionChanged(conn);
+            Optional<InputStream> res = cmd.getBestRecordingForName("foo");
+
+            Assertions.assertTrue(res.isPresent());
+            MatcherAssert.assertThat(res.get(), Matchers.sameInstance(stream));
+        }
+
+        @Test
+        void shouldReturnEmptyIfNotInMemoryAndNotFile() throws Exception {
+            Path rec = Mockito.mock(Path.class);
+            Mockito.when(path.resolve(Mockito.anyString())).thenReturn(rec);
+            Mockito.when(fs.isRegularFile(rec)).thenReturn(false);
+
+            Optional<InputStream> res = cmd.getBestRecordingForName("foo");
+            Assertions.assertFalse(res.isPresent());
+        }
+
+        @Test
+        void shouldReturnEmptyIfNotInMemoryAndNotReadable() throws Exception {
+            Path rec = Mockito.mock(Path.class);
+            Mockito.when(path.resolve(Mockito.anyString())).thenReturn(rec);
+            Mockito.when(fs.isRegularFile(rec)).thenReturn(true);
+            Mockito.when(fs.isReadable(rec)).thenReturn(false);
+
+            Optional<InputStream> res = cmd.getBestRecordingForName("foo");
+            Assertions.assertFalse(res.isPresent());
+        }
+    }
+
+    @Nested
+    class ExecutionTest {
+
+        @Test
+        void shouldThrowExceptionIfRecordingNotFound() throws Exception {
+            IFlightRecorderService svc = Mockito.mock(IFlightRecorderService.class);
+            IRecordingDescriptor rec = Mockito.mock(IRecordingDescriptor.class);
+            Mockito.when(conn.getService()).thenReturn(svc);
+            Mockito.when(svc.getAvailableRecordings()).thenReturn(Collections.emptyList());
+            Mockito.when(rec.getName()).thenReturn("foo");
+
+            cmd.connectionChanged(conn);
+            Assertions.assertThrows(
+                    RecordingNotFoundException.class,
+                    () -> cmd.execute(new String[] {rec.getName(), UPLOAD_URL}));
+        }
+    }
+
+    @Nested
+    class SerializableExecutionTest {
+
+        @Test
+        void shouldReturnExceptionIfRecordingNotFound() throws Exception {
+            IFlightRecorderService svc = Mockito.mock(IFlightRecorderService.class);
+            IRecordingDescriptor rec = Mockito.mock(IRecordingDescriptor.class);
+            Mockito.when(conn.getService()).thenReturn(svc);
+            Mockito.when(svc.getAvailableRecordings()).thenReturn(Collections.emptyList());
+            Mockito.when(rec.getName()).thenReturn("foo");
+
+            cmd.connectionChanged(conn);
+            Output<?> out = cmd.serializableExecute(new String[] {rec.getName(), UPLOAD_URL});
+            MatcherAssert.assertThat(out, Matchers.instanceOf(ExceptionOutput.class));
+        }
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
@@ -28,7 +28,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -92,7 +91,6 @@ class UploadRecordingCommandTest {
         Assertions.assertTrue(cmd.validate(new String[] {recordingName, UPLOAD_URL}));
     }
 
-    @Disabled("Bug #111")
     @ParameterizedTest
     @ValueSource(strings = {".", "some recording", ""})
     void shouldNotValidateInvalidRecordingNames(String recordingName) {

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
@@ -116,7 +116,7 @@ class UploadRecordingCommandTest {
 
             Assertions.assertTrue(res.isPresent());
             MatcherAssert.assertThat(res.get(), Matchers.sameInstance(stream));
-            Mockito.verify(svc).openStream(rec, true);
+            Mockito.verify(svc).openStream(rec, false);
         }
 
         @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
@@ -1,5 +1,6 @@
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -131,7 +132,7 @@ class UploadRecordingCommandTest {
             Optional<InputStream> res = cmd.getBestRecordingForName("foo");
 
             Assertions.assertTrue(res.isPresent());
-            MatcherAssert.assertThat(res.get(), Matchers.sameInstance(stream));
+            MatcherAssert.assertThat(res.get(), Matchers.instanceOf(BufferedInputStream.class));
         }
 
         @Test
@@ -151,7 +152,7 @@ class UploadRecordingCommandTest {
             Optional<InputStream> res = cmd.getBestRecordingForName("foo");
 
             Assertions.assertTrue(res.isPresent());
-            MatcherAssert.assertThat(res.get(), Matchers.sameInstance(stream));
+            MatcherAssert.assertThat(res.get(), Matchers.instanceOf(BufferedInputStream.class));
         }
 
         @Test


### PR DESCRIPTION
These commits add tests for the upload-recording command, fix a bug where in-memory recordings were closed after upload, fix a validation failure output message format bug, and add buffering to disk reads for better upload speeds when uploading archived recordings.