### PR TITLE
Better WebSocket concurrency handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ flag in the `docker` or `podman` command invocation. If the `EXT` variables are
 unspecified then they default to the value of their non-EXT counterparts. If
 `LISTEN_HOST` is unspecified then it defaults to the value of `WEB_HOST`.
 
+The environment variable `CONTAINER_JFR_MAX_WS_CONNECTIONS` is used to
+configure the maximum number of concurrent WebSocket client connections that
+will be allowed. If this is not set then the default value is 2. Once the
+maximum number of concurrent connections is reached, the server will reject
+handshakes for any new incoming connections until a previous connection is
+closed. The maximum acceptable value is 64 and the minimum acceptable value is
+1. Values outside of this range will be ignored and the default value set
+instead.
+
 The environment variable `CONTAINER_JFR_LOG_LEVEL` is used to control the level
 of messages which will be printed by the logging facility. Acceptable values are
 `OFF`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, and `ALL`.

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/MessagingServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/MessagingServer.java
@@ -25,6 +25,8 @@ import com.google.gson.Gson;
 class MessagingServer {
 
     static final String MAX_CONNECTIONS_ENV_VAR = "CONTAINER_JFR_MAX_WS_CONNECTIONS";
+    static final int MIN_CONNECTIONS = 1;
+    static final int MAX_CONNECTIONS = 64;
     static final int DEFAULT_MAX_CONNECTIONS = 2;
 
     private final int maxConnections;
@@ -194,8 +196,19 @@ class MessagingServer {
                             env.getEnv(
                                     MAX_CONNECTIONS_ENV_VAR,
                                     String.valueOf(DEFAULT_MAX_CONNECTIONS)));
-            if (maxConn > 64 || maxConn < 1) {
-                return DEFAULT_MAX_CONNECTIONS;
+            if (maxConn > MAX_CONNECTIONS) {
+                logger.info(
+                        String.format(
+                                "Requested maximum WebSocket connections %d is too large.",
+                                maxConn));
+                return MAX_CONNECTIONS;
+            }
+            if (maxConn < MIN_CONNECTIONS) {
+                logger.info(
+                        String.format(
+                                "Requested maximum WebSocket connections %d is too small.",
+                                maxConn));
+                return MIN_CONNECTIONS;
             }
             return maxConn;
         } catch (NumberFormatException nfe) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/WsClientReaderWriter.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/WsClientReaderWriter.java
@@ -36,7 +36,7 @@ class WsClientReaderWriter implements ClientReader, ClientWriter, Handler<String
     @Override
     public void close() {
         inQ.clear();
-        synchronized(threadLock) {
+        synchronized (threadLock) {
             if (readingThread != null) {
                 readingThread.interrupt();
             }
@@ -61,14 +61,14 @@ class WsClientReaderWriter implements ClientReader, ClientWriter, Handler<String
     @Override
     public String readLine() {
         try {
-            synchronized(threadLock) {
+            synchronized (threadLock) {
                 readingThread = Thread.currentThread();
             }
             return inQ.take();
         } catch (InterruptedException e) {
             return null;
         } finally {
-            synchronized(threadLock) {
+            synchronized (threadLock) {
                 readingThread = null;
             }
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/WsModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/WsModule.java
@@ -5,6 +5,7 @@ import javax.inject.Singleton;
 import com.redhat.rhjmc.containerjfr.ExecutionMode;
 import com.redhat.rhjmc.containerjfr.commands.SerializableCommandRegistry;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientReader;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
@@ -48,10 +49,10 @@ public class WsModule {
     @Provides
     @Singleton
     static MessagingServer provideWebSocketMessagingServer(
-            HttpServer server, AuthManager authManager, Logger logger, Gson gson) {
+            HttpServer server, Environment env, AuthManager authManager, Logger logger, Gson gson) {
         try {
             MessagingServer messagingServer =
-                    new MessagingServer(server, authManager, logger, gson);
+                    new MessagingServer(server, env, authManager, logger, gson);
             messagingServer.start();
             return messagingServer;
         } catch (Exception e) {

--- a/src/test/java/com/redhat/rhjmc/containerjfr/tui/ws/WsClientReaderWriterTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/tui/ws/WsClientReaderWriterTest.java
@@ -75,15 +75,4 @@ class WsClientReaderWriterTest extends TestBase {
                     MatcherAssert.assertThat(crw.readLine(), Matchers.equalTo(expected));
                 });
     }
-
-    @Test
-    void testHasMessage() {
-        when(sws.remoteAddress()).thenReturn(mock(SocketAddress.class));
-
-        MatcherAssert.assertThat(crw.hasMessage(), Matchers.is(false));
-        crw.handle("hello world");
-        MatcherAssert.assertThat(crw.hasMessage(), Matchers.is(true));
-        crw.readLine();
-        MatcherAssert.assertThat(crw.hasMessage(), Matchers.is(false));
-    }
 }


### PR DESCRIPTION
Rewrite MessagingServer handling of concurrent WebSocket connections to
reduce latency, avoid polling, and fix a concurrent modification
exception bug. This also adds logic for limiting the maximum number of
WebSocket connections that can be simultaneously open, which is
configurable.

Fixes #114