### PR TITLE
Add "id" field to command and response messages

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/CommandExceptionResponseMessage.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/CommandExceptionResponseMessage.java
@@ -3,11 +3,11 @@ package com.redhat.rhjmc.containerjfr.tui.ws;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class CommandExceptionResponseMessage extends ResponseMessage<String> {
-    CommandExceptionResponseMessage(String commandName, Exception e) {
-        this(commandName, ExceptionUtils.getMessage(e));
+    CommandExceptionResponseMessage(String id, String commandName, Exception e) {
+        this(id, commandName, ExceptionUtils.getMessage(e));
     }
 
-    CommandExceptionResponseMessage(String commandName, String message) {
-        super(commandName, -2, message);
+    CommandExceptionResponseMessage(String id, String commandName, String message) {
+        super(id, -2, commandName, message);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/CommandMessage.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/CommandMessage.java
@@ -9,6 +9,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
         justification =
                 "This class will be (de)serialized by Gson, so not all fields may be accessed directly")
 class CommandMessage extends WsMessage {
+    String id;
     String command;
     List<String> args;
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/CommandUnavailableMessage.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/CommandUnavailableMessage.java
@@ -1,8 +1,8 @@
 package com.redhat.rhjmc.containerjfr.tui.ws;
 
 class CommandUnavailableMessage extends InvalidCommandResponseMessage {
-    CommandUnavailableMessage(String commandName) {
-        super(commandName);
+    CommandUnavailableMessage(String id, String commandName) {
+        super(id, commandName);
         this.payload = String.format("Command %s unavailable", commandName);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/FailureResponseMessage.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/FailureResponseMessage.java
@@ -1,7 +1,7 @@
 package com.redhat.rhjmc.containerjfr.tui.ws;
 
 class FailureResponseMessage extends ResponseMessage<String> {
-    FailureResponseMessage(String commandName, String message) {
-        super(commandName, -1, message);
+    FailureResponseMessage(String id, String commandName, String message) {
+        super(id, -1, commandName, message);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/InvalidCommandArgumentsResponseMessage.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/InvalidCommandArgumentsResponseMessage.java
@@ -3,10 +3,11 @@ package com.redhat.rhjmc.containerjfr.tui.ws;
 import java.util.Arrays;
 
 class InvalidCommandArgumentsResponseMessage extends ResponseMessage<String> {
-    InvalidCommandArgumentsResponseMessage(String commandName, String[] args) {
+    InvalidCommandArgumentsResponseMessage(String id, String commandName, String[] args) {
         super(
-                commandName,
+                id,
                 -1,
+                commandName,
                 String.format("%s are invalid arguments to %s", Arrays.asList(args), commandName));
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/InvalidCommandResponseMessage.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/InvalidCommandResponseMessage.java
@@ -1,7 +1,11 @@
 package com.redhat.rhjmc.containerjfr.tui.ws;
 
 class InvalidCommandResponseMessage extends ResponseMessage<String> {
-    InvalidCommandResponseMessage(String commandName) {
-        super(commandName, -1, String.format("Command %s is unrecognized", commandName));
+    InvalidCommandResponseMessage(String id, String commandName) {
+        super(
+                id,
+                -1,
+                commandName,
+                String.format("[%s] command %s is unrecognized", id, commandName));
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/MalformedMessageResponseMessage.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/MalformedMessageResponseMessage.java
@@ -3,8 +3,9 @@ package com.redhat.rhjmc.containerjfr.tui.ws;
 class MalformedMessageResponseMessage extends ResponseMessage<String> {
     MalformedMessageResponseMessage(String commandName) {
         super(
-                commandName,
+                null,
                 -2,
+                commandName,
                 String.format("Message \"%s\" appears to be malformed", commandName));
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/ResponseMessage.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/ResponseMessage.java
@@ -8,18 +8,25 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
         justification =
                 "This class will be (de)serialized by Gson, so not all fields may be accessed directly")
 abstract class ResponseMessage<T> extends WsMessage {
+    String id;
     String commandName;
     int status;
     T payload;
 
-    ResponseMessage(String commandName, int status, T payload) {
-        this.commandName = commandName;
+    ResponseMessage(String id, int status, String commandName, T payload) {
+        this.id = id;
         this.status = status;
+        this.commandName = commandName;
         this.payload = payload;
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).append(status).append(commandName).append(payload).build();
+        return new ToStringBuilder(this)
+                .append(id)
+                .append(status)
+                .append(commandName)
+                .append(payload)
+                .build();
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/SuccessResponseMessage.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/SuccessResponseMessage.java
@@ -1,7 +1,7 @@
 package com.redhat.rhjmc.containerjfr.tui.ws;
 
 class SuccessResponseMessage<T> extends ResponseMessage<T> {
-    SuccessResponseMessage(String commandName, T t) {
-        super(commandName, 0, t);
+    SuccessResponseMessage(String id, String commandName, T t) {
+        super(id, 0, commandName, t);
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/tui/ws/MessagingServerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/tui/ws/MessagingServerTest.java
@@ -144,7 +144,7 @@ class MessagingServerTest {
         verify(crw2).readLine();
 
         ResponseMessage<String> successResponseMessage =
-                new SuccessResponseMessage<>("test", "message");
+                new SuccessResponseMessage<>("msgId", "test", "message");
         server.flush(successResponseMessage);
 
         verify(crw1).flush(successResponseMessage);
@@ -161,7 +161,7 @@ class MessagingServerTest {
         verifyNoMoreInteractions(crw2);
 
         ResponseMessage<String> failureResponseMessage =
-                new FailureResponseMessage("test", "failure");
+                new FailureResponseMessage("msgId", "test", "failure");
         server.flush(failureResponseMessage);
 
         verify(crw1).flush(failureResponseMessage);
@@ -189,7 +189,7 @@ class MessagingServerTest {
     void serverFlushShouldDelegateToAllClientWriters() {
         server.addConnection(crw1);
         server.addConnection(crw2);
-        ResponseMessage<String> message = new SuccessResponseMessage<>("test", "message");
+        ResponseMessage<String> message = new SuccessResponseMessage<>("msgId", "test", "message");
         server.flush(message);
         verify(crw1).flush(message);
         verify(crw2).flush(message);


### PR DESCRIPTION
id is copied from command request messages into the corresponding
response (assuming that the command message was well-formed and
understood) so that clients can provide some unique ID on request, and
identify the correct associated response in the interleaved broadcasts
from the server

Fixes #116