### PR TITLE
Test libs upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,13 +34,13 @@ dependencies {
 
     implementation 'com.google.code.gson:gson:2.8.5'
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.1'
-    testImplementation 'org.hamcrest:hamcrest:2.1'
-    testImplementation 'org.mockito:mockito-junit-jupiter:2.25.1'
-    testImplementation 'org.mockito:mockito-inline:2.25.1'
-    implementation 'com.github.spotbugs:spotbugs-annotations:4.0.0-beta1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
+    testImplementation 'org.mockito:mockito-junit-jupiter:3.2.4'
+    testImplementation 'org.mockito:mockito-inline:3.2.4'
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.0.0-RC1'
 }
 
 mainClassName = 'com.redhat.rhjmc.containerjfr.ContainerJfr'

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandRegistryImplTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandRegistryImplTest.java
@@ -20,6 +20,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -128,12 +131,11 @@ public class CommandRegistryImplTest extends TestBase {
             assertThat(stdout(), equalTo("Command \"baz\" not recognized\n"));
         }
 
-        @Test
-        public void shouldNotValidateInvalidCommands() throws Exception {
-            assertFalse(registry.validate("bar", new String[0]));
-            assertFalse(registry.validate(null, new String[0]));
-            assertFalse(registry.validate("", new String[0]));
-            assertFalse(registry.validate("  ", new String[0]));
+        @ParameterizedTest
+        @ValueSource(strings = {"bar", "", "  "})
+        @NullSource
+        public void shouldNotValidateInvalidCommands(String cmd) throws Exception {
+            assertFalse(registry.validate(cmd, new String[0]));
         }
 
         @Test
@@ -141,19 +143,11 @@ public class CommandRegistryImplTest extends TestBase {
             assertTrue(registry.validate("foo", new String[0]));
         }
 
-        @Test
-        public void shouldHandleNullCommandAvailability() throws Exception {
-            assertFalse(registry.isCommandAvailable(null));
-        }
-
-        @Test
-        public void shouldHandleEmptyCommandAvailability() throws Exception {
-            assertFalse(registry.isCommandAvailable(""));
-        }
-
-        @Test
-        public void shouldHandleBlankCommandAvailability() throws Exception {
-            assertFalse(registry.isCommandAvailable("  "));
+        @ParameterizedTest
+        @ValueSource(strings = {"", "  "})
+        @NullSource
+        public void shouldHandleBlankOrNullCommandAvailability(String cmd) throws Exception {
+            assertFalse(registry.isCommandAvailable(cmd));
         }
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/BasicAuthManagerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/BasicAuthManagerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -242,13 +243,9 @@ class BasicAuthManagerTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"", "Bearer sometoken", "Basic (not_b64)"})
+        @NullSource
         void shouldFailBadCredentials(String s) throws Exception {
             Assertions.assertFalse(mgr.validateHttpHeader(() -> s).get());
-        }
-
-        @Test
-        void shouldFailNullHeader() throws Exception {
-            Assertions.assertFalse(mgr.validateHttpHeader(() -> null).get());
         }
     }
 
@@ -304,13 +301,9 @@ class BasicAuthManagerTest {
                     "basic.credentials.foo",
                     "basic.authorization.containerjfr.user:pass"
                 })
+        @NullSource
         void shouldFailBadCredentials(String s) throws Exception {
             Assertions.assertFalse(mgr.validateWebSocketSubProtocol(() -> s).get());
-        }
-
-        @Test
-        void shouldFailNullProtocol() throws Exception {
-            Assertions.assertFalse(mgr.validateWebSocketSubProtocol(() -> null).get());
         }
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/tui/ws/WsCommandExecutorTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/tui/ws/WsCommandExecutorTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
@@ -327,26 +328,9 @@ class WsCommandExecutorTest {
         MatcherAssert.assertThat(response.getValue().payload, Matchers.equalTo("internal error"));
     }
 
-    @Test
-    void shouldRespondToNullLines() throws Exception {
-        when(cr.readLine())
-                .thenAnswer(
-                        new Answer<String>() {
-                            @Override
-                            public String answer(InvocationOnMock invocation) throws Throwable {
-                                executor.shutdown();
-                                return null;
-                            }
-                        });
-
-        executor.run(null);
-
-        verifyZeroInteractions(commandRegistry);
-        verify(server).flush(Mockito.any(MalformedMessageResponseMessage.class));
-    }
-
     @ParameterizedTest
     @ValueSource(strings = {"", "\t", "  ", "\n", "null", " null ", "null\n", "\r\n"})
+    @NullSource
     void shouldRespondToBlankLines(String s) throws Exception {
         when(cr.readLine())
                 .thenAnswer(


### PR DESCRIPTION
This upgrades test-only library versions to the latest, and makes use of a JUnit 5 feature I stumbled across which cleans up a couple of tests I wrote recently. This should be pretty safe since it's testing only, and all tests continue passing on my machine.