### PR TITLE
Podman build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,9 @@ jib {
             '-Dcom.sun.management.jmxremote.authenticate=false',
         ]
     }
+    dockerClient {
+        executable = 'podman'
+    }
 }
 
 applicationDefaultJvmArgs = jib.container.jvmFlags


### PR DESCRIPTION
Based on top of #120 , this just configures the jib plugin to use podman for building images, rather than docker.