### PR TITLE
Configurable platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ of this variable should be set to the fully-qualified class name of the
 auth manager implementation to use, ex.
 `com.redhat.rhjmc.containerjfr.net.BasicAuthManager`.
 
+The environment variable `CONTAINER_JFR_PLATFORM` is used to configure which
+platform client will be used for performing platform-specific actions, such as
+listing available target JVMs. If `CONTAINER_JFR_AUTH_MANAGER` is not specified
+then a default auth manager will also be selected corresponding to the platform,
+whether that platform is specified by the user or automatically detected. The
+value of this variable should be set to the fully-qualified name of the
+platform detection strategy implementation to use, ex.
+`com.redhat.rhjmc.containerjfr.platform.internal.KubeEnvPlatformStrategy`.
+
 The embedded webserver can be optionally configured to enable low memory
 pressure mode. By setting `USE_LOW_MEM_PRESSURE_STREAMING` to any non-empty
 value, the webserver uses a single buffer when serving recording download

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/NetworkModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/NetworkModule.java
@@ -120,7 +120,7 @@ public abstract class NetworkModule {
                 return cons.newInstance(logger, fs);
             }
         } catch (Exception e) {
-            logger.error(e);
+            throw new RuntimeException(e);
         }
         logger.info("Selecting platform default AuthManager");
         switch (mode) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/PlatformModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/PlatformModule.java
@@ -1,11 +1,13 @@
 package com.redhat.rhjmc.containerjfr.platform;
 
+import java.util.Objects;
 import java.util.Set;
 
 import javax.inject.Singleton;
 
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.discovery.JvmDiscoveryClient;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.platform.internal.PlatformDetectionStrategy;
 import com.redhat.rhjmc.containerjfr.platform.internal.PlatformStrategyModule;
 
@@ -14,9 +16,26 @@ import dagger.Provides;
 
 @Module(includes = {PlatformStrategyModule.class})
 public abstract class PlatformModule {
+
+    static final String PLATFORM_STRATEGY_ENV_VAR = "CONTAINER_JFR_PLATFORM";
+
     @Provides
     @Singleton
-    static PlatformClient providePlatformClient(Set<PlatformDetectionStrategy<?>> strategies) {
+    static PlatformClient providePlatformClient(
+            Set<PlatformDetectionStrategy<?>> strategies, Environment env, Logger logger) {
+        if (env.hasEnv(PLATFORM_STRATEGY_ENV_VAR)) {
+            String platform = env.getEnv(PLATFORM_STRATEGY_ENV_VAR);
+            logger.info(
+                    String.format(
+                            "Selecting configured PlatformDetectionStrategy \"%s\"", platform));
+            for (PlatformDetectionStrategy<?> strat : strategies) {
+                if (Objects.equals(platform, strat.getClass().getCanonicalName())) {
+                    return new SelfDiscoveryPlatformClient(strat.get());
+                }
+            }
+            throw new RuntimeException(
+                    String.format("Selected PlatformDetectionStrategy \"%s\" not found", platform));
+        }
         return new SelfDiscoveryPlatformClient(
                 strategies.stream()
                         .sorted()


### PR DESCRIPTION
This PR:

- makes container-jfr exit early if the user has specified a non-existent AuthManager, rather than falling back to automatic detection

- adds similar environment variable-based configurability to PlatformDetectionStrategy , which will also exit early if a non-existent strategy is configured

PlatformDetectionStrategies provide the PlatformClients, which are what provide the default AuthManager implementations for their respective platforms, so if a user specifies a Platform without specifying an AuthManager, then (assuming the Platform is successfully configured) they will still get the default AuthManager for that platform. Both variables can also be set and to normally unrelated values, ex. KubeEnv platform with Basic auth.