### PR TITLE
Add JaCoCo configuration to exclude Dagger classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,15 @@
       <groupId>org.jacoco</groupId>
       <artifactId>jacoco-maven-plugin</artifactId>
       <version>${org.jacoco.maven.plugin.version}</version>
+      <configuration>
+        <excludes>
+          <exclude>**/*_Factory.*</exclude>
+          <exclude>**/*_Provide*Factory.*</exclude>
+          <exclude>**/Dagger*.*</exclude>
+          <exclude>**/*Module_*Factory.*</exclude>
+          <exclude>**/*Module.*</exclude>
+        </excludes>
+      </configuration>
       <reportSets>
         <reportSet>
           <reports>


### PR DESCRIPTION
Exclude Dagger module classes, which don't contain any useful testable
code, as well as Dagger generated classes for dependency injection