### PR TITLE
Use Red Hat UBI8 OpenJDK container base image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
   <maven.compiler.source>${java.version}</maven.compiler.source>
 
   <imageBuilder>/usr/bin/podman</imageBuilder>
+  <baseImage>registry.access.redhat.com/ubi8/openjdk-11</baseImage>
   <node.version>v12.5.0</node.version>
   <npm.version>6.13.4</npm.version>
 
@@ -276,7 +277,7 @@
           <executable>${imageBuilder}</executable>
         </dockerClient>
         <from>
-          <image>gcr.io/distroless/java:11</image>
+          <image>${baseImage}</image>
         </from>
         <to>
           <image>${containerjfr.imageStream}</image>


### PR DESCRIPTION
Replaces the gcr.io distroless base image with the new UBI8 OpenJDK base image.

https://access.redhat.com/errata/RHEA-2020:2018

0.18.0 is a pair of images built from current `master`, and 0.19.0 is from this PR:

```
quay.io/rh-jmc-team/container-jfr            0.19.0           7dcb84b88ca5   6 minutes ago    614 MB
quay.io/rh-jmc-team/container-jfr            latest           7dcb84b88ca5   6 minutes ago    614 MB
quay.io/rh-jmc-team/container-jfr            0.19.0-minimal   268b254e9d1f   8 minutes ago    600 MB
quay.io/rh-jmc-team/container-jfr            0.18.0           db729e3bdc57   10 minutes ago   286 MB
quay.io/rh-jmc-team/container-jfr            0.18.0-minimal   533720d7fe38   11 minutes ago   272 MB
```

There's obviously quite a significant image size increase from this change, but there should be no other ill effects. Some of that size difference is likely to be taken up by UBI image layers which are likely to also be shared with other containers in a given OpenShift deployment, so the actual impact upon a deployment's total disk consumption is likely to be negligible.