### PR TITLE
Refactor WebServer and split behaviour into handlers

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/HttpMimeType.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/HttpMimeType.java
@@ -39,24 +39,21 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr.net.web.handlers;
+package com.redhat.rhjmc.containerjfr.net.web;
 
-import javax.inject.Inject;
+public enum HttpMimeType {
+    PLAINTEXT("text/plain"),
+    HTML("text/html"),
+    JSON("application/json"),
+    OCTET_STREAM("application/octet-stream");
 
-import com.google.gson.Gson;
-import io.vertx.core.http.HttpServerResponse;
+    private final String mime;
 
-class ResponseUtils {
-
-    static final String MIME_TYPE_JSON = "application/json";
-    private final Gson gson;
-
-    @Inject
-    ResponseUtils(Gson gson) {
-        this.gson = gson;
+    HttpMimeType(String mime) {
+        this.mime = mime;
     }
 
-    <T> void endWithJsonKeyValue(String key, T value, HttpServerResponse response) {
-        response.end(String.format("{\"%s\":%s}", key, gson.toJson(value)));
+    public String mime() {
+        return mime;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebModule.java
@@ -41,17 +41,14 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web;
 
-import java.nio.file.Path;
 import java.util.Set;
 
-import javax.inject.Named;
 import javax.inject.Singleton;
 
 import com.google.gson.Gson;
 
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
-import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.HttpServer;
 import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
@@ -70,21 +67,10 @@ public abstract class WebModule {
             HttpServer httpServer,
             NetworkConfiguration netConf,
             Environment env,
-            @Named("RECORDINGS_PATH") Path recordingsPath,
-            FileSystem fs,
             Set<RequestHandler> requestHandlers,
             Gson gson,
             AuthManager authManager,
             Logger logger) {
-        return new WebServer(
-                httpServer,
-                netConf,
-                env,
-                recordingsPath,
-                fs,
-                requestHandlers,
-                gson,
-                authManager,
-                logger);
+        return new WebServer(httpServer, netConf, env, requestHandlers, gson, authManager, logger);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebModule.java
@@ -50,14 +50,12 @@ import javax.inject.Singleton;
 import com.google.gson.Gson;
 
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
-import com.redhat.rhjmc.containerjfr.core.reports.ReportGenerator;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.HttpServer;
 import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
 import com.redhat.rhjmc.containerjfr.net.NetworkModule;
-import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.web.handlers.RequestHandler;
 import com.redhat.rhjmc.containerjfr.net.web.handlers.RequestHandlersModule;
 
@@ -77,8 +75,6 @@ public abstract class WebModule {
             Set<RequestHandler> requestHandlers,
             Gson gson,
             AuthManager authManager,
-            TargetConnectionManager targetConnectionManager,
-            ReportGenerator reportGenerator,
             Logger logger) {
         return new WebServer(
                 httpServer,
@@ -89,8 +85,6 @@ public abstract class WebModule {
                 requestHandlers,
                 gson,
                 authManager,
-                targetConnectionManager,
-                reportGenerator,
                 logger);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -172,17 +172,17 @@ public class WebServer {
                             String.format(
                                     "Registering request handler (priority %d) for [%s]\t%s",
                                     handler.getPriority(), handler.httpMethod(), handler.path()));
-                    if (!handler.isAvailable()) {
-                        logger.trace("Handler unavailable");
-                        return;
-                    }
                     Route route = router.route(handler.httpMethod(), handler.path());
                     if (handler.isAsync()) {
                         route = route.handler(handler);
                     } else {
                         route = route.blockingHandler(handler, handler.isOrdered());
                     }
-                    route.failureHandler(failureHandler);
+                    route = route.failureHandler(failureHandler);
+                    if (!handler.isAvailable()) {
+                        logger.trace("Handler disabled");
+                        route = route.disable();
+                    }
                 });
 
         if (isCorsEnabled()) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -216,6 +216,9 @@ public class WebServer {
 
         requestHandlers.forEach(
                 handler -> {
+                    if (!handler.isAvailable()) {
+                        return;
+                    }
                     Route route = getHandlerRoute(router, handler);
                     if (handler.isAsync()) {
                         route = route.handler(handler);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -112,8 +112,7 @@ public class WebServer {
         this.netConf = netConf;
         this.env = env;
         this.requestHandlers = new ArrayList<>(requestHandlers);
-        Collections.sort(
-                this.requestHandlers, (a, b) -> Integer.compare(a.getPriority(), b.getPriority()));
+        Collections.sort(this.requestHandlers, (a, b) -> a.path().compareTo(b.path()));
         this.gson = gson;
         this.auth = auth;
         this.logger = logger;
@@ -172,7 +171,8 @@ public class WebServer {
                             String.format(
                                     "Registering request handler (priority %d) for [%s]\t%s",
                                     handler.getPriority(), handler.httpMethod(), handler.path()));
-                    Route route = router.route(handler.httpMethod(), handler.path());
+                    Route route = router.route(handler.httpMethod(),
+                            handler.path()).order(handler.getPriority());
                     if (handler.isAsync()) {
                         route = route.handler(handler);
                     } else {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -41,7 +41,6 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -50,21 +49,18 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.Future;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.http.client.utils.URIBuilder;
 
-import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
-import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
 import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
 
 import com.google.gson.Gson;
@@ -72,23 +68,17 @@ import com.google.gson.Gson;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
-import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.HttpServer;
 import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
 import com.redhat.rhjmc.containerjfr.net.web.handlers.RequestHandler;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.BodyHandler;
-import io.vertx.ext.web.handler.StaticHandler;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 public class WebServer {
@@ -97,26 +87,18 @@ public class WebServer {
             WebServer.class.getPackageName().replaceAll("\\.", "/");
 
     private static final String ENABLE_CORS_ENV = "CONTAINER_JFR_ENABLE_CORS";
-    private static final String USE_LOW_MEM_PRESSURE_STREAMING_ENV =
-            "USE_LOW_MEM_PRESSURE_STREAMING";
 
-    private static final String MIME_TYPE_JSON = "application/json";
+    public static final String MIME_TYPE_JSON = "application/json";
     public static final String MIME_TYPE_HTML = "text/html";
     private static final String MIME_TYPE_PLAINTEXT = "text/plain";
-    private static final String MIME_TYPE_OCTET_STREAM = "application/octet-stream";
 
     // Use X- prefix so as to not trigger web-browser auth dialogs
     private static final String AUTH_SCHEME_HEADER = "X-WWW-Authenticate";
 
-    private static final Pattern RECORDING_FILENAME_PATTERN =
-            Pattern.compile("([A-Za-z\\d-]*)_([A-Za-z\\d-_]*)_([\\d]*T[\\d]*Z)(.[\\d]+)?");
-
     private final HttpServer server;
     private final NetworkConfiguration netConf;
     private final Environment env;
-    private final Path savedRecordingsPath;
-    private final FileSystem fs;
-    private final Set<RequestHandler> requestHandlers;
+    private final List<RequestHandler> requestHandlers;
     private final Gson gson;
     private final AuthManager auth;
     private final Logger logger;
@@ -125,8 +107,6 @@ public class WebServer {
             HttpServer server,
             NetworkConfiguration netConf,
             Environment env,
-            Path savedRecordingsPath,
-            FileSystem fs,
             Set<RequestHandler> requestHandlers,
             Gson gson,
             AuthManager auth,
@@ -134,9 +114,9 @@ public class WebServer {
         this.server = server;
         this.netConf = netConf;
         this.env = env;
-        this.savedRecordingsPath = savedRecordingsPath;
-        this.fs = fs;
-        this.requestHandlers = requestHandlers;
+        this.requestHandlers = new ArrayList<>(requestHandlers);
+        Collections.sort(
+                this.requestHandlers, (a, b) -> Integer.compare(a.getPriority(), b.getPriority()));
         this.gson = gson;
         this.auth = auth;
         this.logger = logger;
@@ -191,7 +171,12 @@ public class WebServer {
 
         requestHandlers.forEach(
                 handler -> {
+                    logger.trace(
+                            String.format(
+                                    "Registering request handler (priority %d) for [%s]\t%s",
+                                    handler.getPriority(), handler.httpMethod(), handler.path()));
                     if (!handler.isAvailable()) {
+                        logger.trace("Handler unavailable");
                         return;
                     }
                     Route route = getHandlerRoute(router, handler);
@@ -213,11 +198,6 @@ public class WebServer {
                             false)
                     .failureHandler(failureHandler);
         }
-
-        router.post("/api/v1/recordings")
-                .handler(BodyHandler.create(true))
-                .handler(this::handleRecordingUploadRequest)
-                .failureHandler(failureHandler);
 
         router.get("/*")
                 .handler(StaticHandler.create(WEB_CLIENT_ASSETS_BASE))
@@ -348,82 +328,6 @@ public class WebServer {
         ctx.response().sendFile(WEB_CLIENT_ASSETS_BASE + "/index.html");
     }
 
-    void handleRecordingUploadRequest(RoutingContext ctx) {
-        try {
-            if (!validateRequestAuthorization(ctx.request()).get()) {
-                throw new HttpStatusException(401);
-            }
-        } catch (Exception e) {
-            throw new HttpStatusException(500, e);
-        }
-
-        if (!fs.isDirectory(savedRecordingsPath)) {
-            throw new HttpStatusException(503, "Recording saving not available");
-        }
-
-        FileUpload upload = null;
-        for (FileUpload fu : ctx.fileUploads()) {
-            // ignore unrecognized form fields
-            if ("recording".equals(fu.name())) {
-                upload = fu;
-                break;
-            }
-        }
-
-        if (upload == null) {
-            throw new HttpStatusException(400, "No recording submission");
-        }
-
-        String fileName = upload.fileName();
-        if (fileName == null || fileName.isEmpty()) {
-            throw new HttpStatusException(400, "Recording name must not be empty");
-        }
-
-        if (fileName.endsWith(".jfr")) {
-            fileName = fileName.substring(0, fileName.length() - 4);
-        }
-
-        Matcher m = RECORDING_FILENAME_PATTERN.matcher(fileName);
-        if (!m.matches()) {
-            throw new HttpStatusException(400, "Incorrect recording file name pattern");
-        }
-
-        String targetName = m.group(1);
-        String recordingName = m.group(2);
-        String timestamp = m.group(3);
-        int count =
-                m.group(4) == null || m.group(4).isEmpty()
-                        ? 0
-                        : Integer.parseInt(m.group(4).substring(1));
-
-        final String basename = String.format("%s_%s_%s", targetName, recordingName, timestamp);
-        final String uploadedFileName = upload.uploadedFileName();
-        validateRecording(
-                upload.uploadedFileName(),
-                (res) ->
-                        saveRecording(
-                                basename,
-                                uploadedFileName,
-                                count,
-                                (res2) -> {
-                                    if (res2.failed()) {
-                                        ctx.fail(res2.cause());
-                                        return;
-                                    }
-
-                                    ctx.response()
-                                            .putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_JSON);
-                                    endWithJsonKeyValue("name", res2.result(), ctx.response());
-
-                                    logger.info(
-                                            String.format("Recording saved as %s", res2.result()));
-                                }));
-    }
-
-    private Future<Boolean> validateRequestAuthorization(HttpServerRequest req) throws Exception {
-        return auth.validateHttpHeader(() -> req.getHeader(HttpHeaders.AUTHORIZATION));
-    }
-
     private boolean isCorsEnabled() {
         return this.env.hasEnv(ENABLE_CORS_ENV);
     }
@@ -442,135 +346,6 @@ public class WebServer {
                     HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
                     String.join(", ", Arrays.asList(AUTH_SCHEME_HEADER)));
         }
-    }
-
-    private <T> AsyncResult<T> makeAsyncResult(T result) {
-        return new AsyncResult<>() {
-            @Override
-            public T result() {
-                return result;
-            }
-
-            @Override
-            public Throwable cause() {
-                return null;
-            }
-
-            @Override
-            public boolean succeeded() {
-                return true;
-            }
-
-            @Override
-            public boolean failed() {
-                return false;
-            }
-        };
-    }
-
-    private <T> AsyncResult<T> makeFailedAsyncResult(Throwable cause) {
-        return new AsyncResult<>() {
-            @Override
-            public T result() {
-                return null;
-            }
-
-            @Override
-            public Throwable cause() {
-                return cause;
-            }
-
-            @Override
-            public boolean succeeded() {
-                return false;
-            }
-
-            @Override
-            public boolean failed() {
-                return true;
-            }
-        };
-    }
-
-    private void validateRecording(String recordingFile, Handler<AsyncResult<Void>> handler) {
-        server.getVertx()
-                .executeBlocking(
-                        event -> {
-                            try {
-                                JfrLoaderToolkit.loadEvents(
-                                        new File(recordingFile)); // try loading events to see if
-                                // it's a valid file
-                                event.complete();
-                            } catch (CouldNotLoadRecordingException | IOException e) {
-                                event.fail(e);
-                            }
-                        },
-                        res -> {
-                            if (res.failed()) {
-                                Throwable t;
-                                if (res.cause() instanceof CouldNotLoadRecordingException) {
-                                    t =
-                                            new HttpStatusException(
-                                                    400,
-                                                    "Not a valid JFR recording file",
-                                                    res.cause());
-                                } else {
-                                    t = res.cause();
-                                }
-
-                                handler.handle(makeFailedAsyncResult(t));
-                                return;
-                            }
-
-                            handler.handle(makeAsyncResult(null));
-                        });
-    }
-
-    private void saveRecording(
-            String basename, String tmpFile, int counter, Handler<AsyncResult<String>> handler) {
-        // TODO byte-sized rename limit is arbitrary. Probably plenty since recordings
-        // are also differentiated by second-resolution timestamp
-        if (counter >= Byte.MAX_VALUE) {
-            handler.handle(
-                    makeFailedAsyncResult(
-                            new IOException(
-                                    "Recording could not be saved. File already exists and rename attempts were exhausted.")));
-            return;
-        }
-
-        String filename = counter > 1 ? basename + "." + counter + ".jfr" : basename + ".jfr";
-
-        server.getVertx()
-                .fileSystem()
-                .exists(
-                        savedRecordingsPath.resolve(filename).toString(),
-                        (res) -> {
-                            if (res.failed()) {
-                                handler.handle(makeFailedAsyncResult(res.cause()));
-                                return;
-                            }
-
-                            if (res.result()) {
-                                saveRecording(basename, tmpFile, counter + 1, handler);
-                                return;
-                            }
-
-                            // verified no name clash at this time
-                            server.getVertx()
-                                    .fileSystem()
-                                    .move(
-                                            tmpFile,
-                                            savedRecordingsPath.resolve(filename).toString(),
-                                            (res2) -> {
-                                                if (res2.failed()) {
-                                                    handler.handle(
-                                                            makeFailedAsyncResult(res2.cause()));
-                                                    return;
-                                                }
-
-                                                handler.handle(makeAsyncResult(filename));
-                                            });
-                        });
     }
 
     public static class DownloadDescriptor {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -108,7 +108,6 @@ public class WebServer {
             WebServer.class.getPackageName().replaceAll("\\.", "/");
 
     private static final String ENABLE_CORS_ENV = "CONTAINER_JFR_ENABLE_CORS";
-    private static final String GRAFANA_DASHBOARD_ENV = "GRAFANA_DASHBOARD_URL";
     private static final String USE_LOW_MEM_PRESSURE_STREAMING_ENV =
             "USE_LOW_MEM_PRESSURE_STREAMING";
 
@@ -240,10 +239,6 @@ public class WebServer {
                             false)
                     .failureHandler(failureHandler);
         }
-
-        router.get("/api/v1/grafana_dashboard_url")
-                .handler(this::handleGrafanaDashboardUrlRequest)
-                .failureHandler(failureHandler);
 
         router.get("/api/v1/targets/:targetId/recordings/:recordingName")
                 .blockingHandler(
@@ -569,15 +564,6 @@ public class WebServer {
     void handleWebClientIndexRequest(RoutingContext ctx) {
         ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_HTML);
         ctx.response().sendFile(WEB_CLIENT_ASSETS_BASE + "/index.html");
-    }
-
-    void handleGrafanaDashboardUrlRequest(RoutingContext ctx) {
-        if (!this.env.hasEnv(GRAFANA_DASHBOARD_ENV)) {
-            throw new HttpStatusException(500, "Deployment has no Grafana configuration");
-        }
-        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_JSON);
-        endWithJsonKeyValue(
-                "grafanaDashboardUrl", env.getEnv(GRAFANA_DASHBOARD_ENV, ""), ctx.response());
     }
 
     void handleRecordingUploadRequest(RoutingContext ctx) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -242,10 +242,6 @@ public class WebServer {
                     .failureHandler(failureHandler);
         }
 
-        router.get("/api/v1/clienturl")
-                .handler(this::handleClientUrlRequest)
-                .failureHandler(failureHandler);
-
         router.get("/api/v1/grafana_datasource_url")
                 .handler(this::handleGrafanaDatasourceUrlRequest)
                 .failureHandler(failureHandler);
@@ -578,22 +574,6 @@ public class WebServer {
     void handleWebClientIndexRequest(RoutingContext ctx) {
         ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_HTML);
         ctx.response().sendFile(WEB_CLIENT_ASSETS_BASE + "/index.html");
-    }
-
-    void handleClientUrlRequest(RoutingContext ctx) {
-        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_JSON);
-        try {
-            endWithJsonKeyValue(
-                    "clientUrl",
-                    String.format(
-                            "%s://%s:%d/api/v1/command",
-                            server.isSsl() ? "wss" : "ws",
-                            netConf.getWebServerHost(),
-                            netConf.getExternalWebServerPort()),
-                    ctx.response());
-        } catch (SocketException | UnknownHostException e) {
-            throw new HttpStatusException(500, e);
-        }
     }
 
     void handleGrafanaDatasourceUrlRequest(RoutingContext ctx) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -171,8 +171,13 @@ public class WebServer {
                             String.format(
                                     "Registering request handler (priority %d) for [%s]\t%s",
                                     handler.getPriority(), handler.httpMethod(), handler.path()));
-                    Route route = router.route(handler.httpMethod(),
-                            handler.path()).order(handler.getPriority());
+                    Route route;
+                    if (RequestHandler.ALL_PATHS.equals(handler.path())) {
+                        route = router.route();
+                    } else {
+                        route = router.route(handler.httpMethod(), handler.path());
+                    }
+                    route = route.order(handler.getPriority());
                     if (handler.isAsync()) {
                         route = route.handler(handler);
                     } else {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -109,7 +109,6 @@ public class WebServer {
 
     private static final String ENABLE_CORS_ENV = "CONTAINER_JFR_ENABLE_CORS";
     private static final String GRAFANA_DASHBOARD_ENV = "GRAFANA_DASHBOARD_URL";
-    private static final String GRAFANA_DATASOURCE_ENV = "GRAFANA_DATASOURCE_URL";
     private static final String USE_LOW_MEM_PRESSURE_STREAMING_ENV =
             "USE_LOW_MEM_PRESSURE_STREAMING";
 
@@ -241,10 +240,6 @@ public class WebServer {
                             false)
                     .failureHandler(failureHandler);
         }
-
-        router.get("/api/v1/grafana_datasource_url")
-                .handler(this::handleGrafanaDatasourceUrlRequest)
-                .failureHandler(failureHandler);
 
         router.get("/api/v1/grafana_dashboard_url")
                 .handler(this::handleGrafanaDashboardUrlRequest)
@@ -574,15 +569,6 @@ public class WebServer {
     void handleWebClientIndexRequest(RoutingContext ctx) {
         ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_HTML);
         ctx.response().sendFile(WEB_CLIENT_ASSETS_BASE + "/index.html");
-    }
-
-    void handleGrafanaDatasourceUrlRequest(RoutingContext ctx) {
-        if (!this.env.hasEnv(GRAFANA_DATASOURCE_ENV)) {
-            throw new HttpStatusException(500, "Deployment has no Grafana configuration");
-        }
-        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_JSON);
-        endWithJsonKeyValue(
-                "grafanaDatasourceUrl", env.getEnv(GRAFANA_DATASOURCE_ENV, ""), ctx.response());
     }
 
     void handleGrafanaDashboardUrlRequest(RoutingContext ctx) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -178,7 +178,9 @@ public class WebServer {
                     }
                     route = route.failureHandler(failureHandler);
                     if (!handler.isAvailable()) {
-                        logger.trace("Handler disabled");
+                        logger.trace(
+                                String.format(
+                                        "%s handler disabled", handler.getClass().getSimpleName()));
                         route = route.disable();
                     }
                 });

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -203,10 +203,6 @@ public class WebServer {
                     route.failureHandler(failureHandler);
                 });
 
-        router.post("/api/v1/auth")
-                .blockingHandler(this::handleAuthRequest, false)
-                .failureHandler(failureHandler);
-
         if (isCorsEnabled()) {
             router.options("/*")
                     .blockingHandler(
@@ -345,21 +341,6 @@ public class WebServer {
 
     private <T> void endWithJsonKeyValue(String key, T value, HttpServerResponse response) {
         response.end(String.format("{\"%s\":%s}", key, gson.toJson(value)));
-    }
-
-    void handleAuthRequest(RoutingContext ctx) {
-        boolean authd = false;
-        try {
-            authd = validateRequestAuthorization(ctx.request()).get();
-        } catch (Exception e) {
-            throw new HttpStatusException(500, e);
-        }
-        if (authd) {
-            ctx.response().setStatusCode(200);
-            ctx.response().end();
-        } else {
-            throw new HttpStatusException(401);
-        }
     }
 
     void handleWebClientIndexRequest(RoutingContext ctx) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -176,7 +176,7 @@ public class WebServer {
                         logger.trace("Handler unavailable");
                         return;
                     }
-                    Route route = getHandlerRoute(router, handler);
+                    Route route = router.route(handler.httpMethod(), handler.path());
                     if (handler.isAsync()) {
                         route = route.handler(handler);
                     } else {
@@ -214,31 +214,6 @@ public class WebServer {
                     enableCors(req.response());
                     router.handle(req);
                 });
-    }
-
-    Route getHandlerRoute(Router router, RequestHandler handler) {
-        switch (handler.httpMethod()) {
-            case CONNECT:
-                return router.connect(handler.path());
-            case DELETE:
-                return router.delete(handler.path());
-            case GET:
-                return router.get(handler.path());
-            case HEAD:
-                return router.head(handler.path());
-            case OPTIONS:
-                return router.options(handler.path());
-            case PATCH:
-                return router.patch(handler.path());
-            case POST:
-                return router.post(handler.path());
-            case PUT:
-                return router.put(handler.path());
-            case TRACE:
-                return router.trace(handler.path());
-            default:
-                throw new IllegalArgumentException(handler.httpMethod().toString());
-        }
     }
 
     public void stop() {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -83,9 +83,6 @@ import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 public class WebServer {
 
-    private static final String WEB_CLIENT_ASSETS_BASE =
-            WebServer.class.getPackageName().replaceAll("\\.", "/");
-
     private static final String ENABLE_CORS_ENV = "CONTAINER_JFR_ENABLE_CORS";
 
     public static final String MIME_TYPE_JSON = "application/json";
@@ -198,11 +195,6 @@ public class WebServer {
                             false)
                     .failureHandler(failureHandler);
         }
-
-        router.get("/*")
-                .handler(StaticHandler.create(WEB_CLIENT_ASSETS_BASE))
-                .handler(this::handleWebClientIndexRequest)
-                .failureHandler(failureHandler);
 
         this.server.requestHandler(
                 req -> {
@@ -321,11 +313,6 @@ public class WebServer {
 
     private <T> void endWithJsonKeyValue(String key, T value, HttpServerResponse response) {
         response.end(String.format("{\"%s\":%s}", key, gson.toJson(value)));
-    }
-
-    void handleWebClientIndexRequest(RoutingContext ctx) {
-        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_HTML);
-        ctx.response().sendFile(WEB_CLIENT_ASSETS_BASE + "/index.html");
     }
 
     private boolean isCorsEnabled() {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AuthPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AuthPostHandler.java
@@ -47,7 +47,6 @@ import com.redhat.rhjmc.containerjfr.net.AuthManager;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 class AuthPostHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -67,21 +66,8 @@ class AuthPostHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
-    public void handle(RoutingContext ctx) {
-        boolean authd = false;
-        try {
-            authd = validateRequestAuthorization(ctx.request()).get();
-        } catch (Exception e) {
-            throw new HttpStatusException(500, e);
-        }
-        if (authd) {
-            ctx.response().setStatusCode(200);
-            ctx.response().end();
-        } else {
-            throw new HttpStatusException(401);
-        }
+    void handleAuthenticated(RoutingContext ctx) {
+        ctx.response().setStatusCode(200);
+        ctx.response().end();
     }
-
-    @Override
-    void handleAuthenticated(RoutingContext ctx) {}
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ClientUrlGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ClientUrlGetHandler.java
@@ -78,11 +78,6 @@ class ClientUrlGetHandler implements RequestHandler {
     }
 
     @Override
-    public boolean isAsync() {
-        return true;
-    }
-
-    @Override
     public void handle(RoutingContext ctx) {
         ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, ResponseUtils.MIME_TYPE_JSON);
         try {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsOptionsHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsOptionsHandler.java
@@ -39,36 +39,32 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr.net.web;
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import java.util.Set;
+import javax.inject.Inject;
 
-import javax.inject.Singleton;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import io.vertx.core.http.HttpMethod;
 
-import com.google.gson.Gson;
+class CorsOptionsHandler extends CorsEnablingHandler {
 
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
-import com.redhat.rhjmc.containerjfr.net.AuthManager;
-import com.redhat.rhjmc.containerjfr.net.HttpServer;
-import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
-import com.redhat.rhjmc.containerjfr.net.NetworkModule;
-import com.redhat.rhjmc.containerjfr.net.web.handlers.RequestHandler;
-import com.redhat.rhjmc.containerjfr.net.web.handlers.RequestHandlersModule;
+    @Inject
+    CorsOptionsHandler(Environment env) {
+        super(env);
+    }
 
-import dagger.Module;
-import dagger.Provides;
+    @Override
+    public int getPriority() {
+        return DEFAULT_PRIORITY - 10;
+    }
 
-@Module(includes = {NetworkModule.class, RequestHandlersModule.class})
-public abstract class WebModule {
-    @Provides
-    @Singleton
-    static WebServer provideWebServer(
-            HttpServer httpServer,
-            NetworkConfiguration netConf,
-            Set<RequestHandler> requestHandlers,
-            Gson gson,
-            AuthManager authManager,
-            Logger logger) {
-        return new WebServer(httpServer, netConf, requestHandlers, gson, authManager, logger);
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.OPTIONS;
+    }
+
+    @Override
+    public String path() {
+        return "/*";
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDashboardUrlGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDashboardUrlGetHandler.java
@@ -74,11 +74,6 @@ class GrafanaDashboardUrlGetHandler implements RequestHandler {
     }
 
     @Override
-    public boolean isAsync() {
-        return true;
-    }
-
-    @Override
     public void handle(RoutingContext ctx) {
         if (!this.env.hasEnv(GRAFANA_DASHBOARD_ENV)) {
             throw new HttpStatusException(500, "Deployment has no Grafana configuration");

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDashboardUrlGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDashboardUrlGetHandler.java
@@ -41,9 +41,14 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
+import java.util.Map;
+
 import javax.inject.Inject;
 
+import com.google.gson.Gson;
+
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -55,12 +60,12 @@ class GrafanaDashboardUrlGetHandler implements RequestHandler {
     static final String GRAFANA_DASHBOARD_ENV = "GRAFANA_DASHBOARD_URL";
 
     private final Environment env;
-    private final ResponseUtils responseUtils;
+    private final Gson gson;
 
     @Inject
-    GrafanaDashboardUrlGetHandler(Environment env, ResponseUtils responseUtils) {
+    GrafanaDashboardUrlGetHandler(Environment env, Gson gson) {
         this.env = env;
-        this.responseUtils = responseUtils;
+        this.gson = gson;
     }
 
     @Override
@@ -78,8 +83,8 @@ class GrafanaDashboardUrlGetHandler implements RequestHandler {
         if (!this.env.hasEnv(GRAFANA_DASHBOARD_ENV)) {
             throw new HttpStatusException(500, "Deployment has no Grafana configuration");
         }
-        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, ResponseUtils.MIME_TYPE_JSON);
-        responseUtils.endWithJsonKeyValue(
-                "grafanaDashboardUrl", env.getEnv(GRAFANA_DASHBOARD_ENV), ctx.response());
+        ctx.response()
+                .putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime())
+                .end(gson.toJson(Map.of("grafanaDashboardUrl", env.getEnv(GRAFANA_DASHBOARD_ENV))));
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDatasourceUrlGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDatasourceUrlGetHandler.java
@@ -74,11 +74,6 @@ class GrafanaDatasourceUrlGetHandler implements RequestHandler {
     }
 
     @Override
-    public boolean isAsync() {
-        return true;
-    }
-
-    @Override
     public void handle(RoutingContext ctx) {
         if (!this.env.hasEnv(GRAFANA_DATASOURCE_ENV)) {
             throw new HttpStatusException(500, "Deployment has no Grafana configuration");

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDatasourceUrlGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDatasourceUrlGetHandler.java
@@ -41,9 +41,14 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
+import java.util.Map;
+
 import javax.inject.Inject;
 
+import com.google.gson.Gson;
+
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -55,12 +60,12 @@ class GrafanaDatasourceUrlGetHandler implements RequestHandler {
     static final String GRAFANA_DATASOURCE_ENV = "GRAFANA_DATASOURCE_URL";
 
     private final Environment env;
-    private final ResponseUtils responseUtils;
+    private final Gson gson;
 
     @Inject
-    GrafanaDatasourceUrlGetHandler(Environment env, ResponseUtils responseUtils) {
+    GrafanaDatasourceUrlGetHandler(Environment env, Gson gson) {
         this.env = env;
-        this.responseUtils = responseUtils;
+        this.gson = gson;
     }
 
     @Override
@@ -78,8 +83,12 @@ class GrafanaDatasourceUrlGetHandler implements RequestHandler {
         if (!this.env.hasEnv(GRAFANA_DATASOURCE_ENV)) {
             throw new HttpStatusException(500, "Deployment has no Grafana configuration");
         }
-        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, ResponseUtils.MIME_TYPE_JSON);
-        responseUtils.endWithJsonKeyValue(
-                "grafanaDatasourceUrl", env.getEnv(GRAFANA_DATASOURCE_ENV), ctx.response());
+        ctx.response()
+                .putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime())
+                .end(
+                        gson.toJson(
+                                Map.of(
+                                        "grafanaDatasourceUrl",
+                                        env.getEnv(GRAFANA_DATASOURCE_ENV))));
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDatasourceUrlGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDatasourceUrlGetHandler.java
@@ -41,19 +41,50 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import dagger.Binds;
-import dagger.Module;
-import dagger.multibindings.IntoSet;
+import javax.inject.Inject;
 
-@Module
-public abstract class RequestHandlersModule {
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindClientUrlGetHandler(ClientUrlGetHandler handler);
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindGrafanaDatasourceUrlGetHandler(
-            GrafanaDatasourceUrlGetHandler handler);
+class GrafanaDatasourceUrlGetHandler implements RequestHandler {
+
+    static final String GRAFANA_DATASOURCE_ENV = "GRAFANA_DATASOURCE_URL";
+
+    private final Environment env;
+    private final ResponseUtils responseUtils;
+
+    @Inject
+    GrafanaDatasourceUrlGetHandler(Environment env, ResponseUtils responseUtils) {
+        this.env = env;
+        this.responseUtils = responseUtils;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/grafana_datasource_url";
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public boolean isAsync() {
+        return true;
+    }
+
+    @Override
+    public void handle(RoutingContext ctx) {
+        if (!this.env.hasEnv(GRAFANA_DATASOURCE_ENV)) {
+            throw new HttpStatusException(500, "Deployment has no Grafana configuration");
+        }
+        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, ResponseUtils.MIME_TYPE_JSON);
+        responseUtils.endWithJsonKeyValue(
+                "grafanaDatasourceUrl", env.getEnv(GRAFANA_DATASOURCE_ENV), ctx.response());
+    }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingGetHandler.java
@@ -75,6 +75,16 @@ class RecordingGetHandler extends TargetRecordingGetHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
+    public boolean isOrdered() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) {
         String recordingName = ctx.pathParam("recordingName");
         handleRecordingDownloadRequest(null, recordingName, ctx);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingGetHandler.java
@@ -1,0 +1,108 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.web.WebServer.DownloadDescriptor;
+import io.vertx.ext.web.RoutingContext;
+
+class RecordingGetHandler extends TargetRecordingGetHandler {
+
+    private final Path savedRecordingsPath;
+
+    @Inject
+    RecordingGetHandler(
+            AuthManager auth,
+            Environment env,
+            @Named("RECORDINGS_PATH") Path savedRecordingsPath,
+            Logger logger) {
+        super(auth, env, null, logger);
+        this.savedRecordingsPath = savedRecordingsPath;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/recordings/:recordingName";
+    }
+
+    @Override
+    public void handleAuthenticated(RoutingContext ctx) {
+        String recordingName = ctx.pathParam("recordingName");
+        handleRecordingDownloadRequest(null, recordingName, ctx);
+    }
+
+    @Override
+    Optional<DownloadDescriptor> getRecordingDescriptor(String targetId, String recordingName) {
+        try {
+            // TODO refactor Files calls into FileSystem for testability
+            Optional<Path> savedRecording =
+                    Files.list(savedRecordingsPath)
+                            .filter(
+                                    saved ->
+                                            saved.getFileName()
+                                                    .toFile()
+                                                    .getName()
+                                                    .equals(recordingName))
+                            .findFirst();
+            if (savedRecording.isPresent()) {
+                return Optional.of(
+                        new DownloadDescriptor(
+                                Files.newInputStream(savedRecording.get(), StandardOpenOption.READ),
+                                Files.size(savedRecording.get()),
+                                null));
+            }
+        } catch (Exception e) {
+            logger.error(e);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostBodyHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostBodyHandler.java
@@ -41,31 +41,36 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import io.vertx.core.Handler;
+import javax.inject.Inject;
+
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
 
-public interface RequestHandler extends Handler<RoutingContext> {
-    /** Lower number == higher priority handler */
-    static final int DEFAULT_PRIORITY = 100;
+class RecordingsPostBodyHandler extends AbstractAuthenticatedRequestHandler {
 
-    default int getPriority() {
-        return DEFAULT_PRIORITY;
+    private final BodyHandler bodyHandler;
+
+    @Inject
+    RecordingsPostBodyHandler(AuthManager auth) {
+        super(auth);
+        this.bodyHandler = BodyHandler.create(true);
     }
 
-    String path();
-
-    HttpMethod httpMethod();
-
-    default boolean isAvailable() {
-        return true;
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
     }
 
-    default boolean isAsync() {
-        return false;
+    @Override
+    public String path() {
+        return "/api/v1/recordings";
     }
 
-    default boolean isOrdered() {
-        return false;
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        this.bodyHandler.handle(ctx);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandler.java
@@ -44,6 +44,7 @@ package com.redhat.rhjmc.containerjfr.net.web.handlers;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -53,11 +54,13 @@ import javax.inject.Named;
 import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
 import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
 
+import com.google.gson.Gson;
+
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.HttpServer;
-import com.redhat.rhjmc.containerjfr.net.web.WebServer;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -76,7 +79,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
     private final Vertx vertx;
     private final FileSystem fs;
     private final Path savedRecordingsPath;
-    private final ResponseUtils utils;
+    private final Gson gson;
     private final Logger logger;
 
     @Inject
@@ -85,13 +88,13 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
             HttpServer httpServer,
             FileSystem fs,
             @Named("RECORDINGS_PATH") Path savedRecordingsPath,
-            ResponseUtils utils,
+            Gson gson,
             Logger logger) {
         super(auth);
         this.vertx = httpServer.getVertx();
         this.fs = fs;
         this.savedRecordingsPath = savedRecordingsPath;
-        this.utils = utils;
+        this.gson = gson;
         this.logger = logger;
     }
 
@@ -179,9 +182,8 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
                                     ctx.response()
                                             .putHeader(
                                                     HttpHeaders.CONTENT_TYPE,
-                                                    WebServer.MIME_TYPE_JSON);
-                                    utils.endWithJsonKeyValue(
-                                            "name", res2.result(), ctx.response());
+                                                    HttpMimeType.JSON.mime())
+                                            .end(gson.toJson(Map.of("name", res2.result())));
 
                                     logger.info(
                                             String.format("Recording saved as %s", res2.result()));

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandler.java
@@ -1,0 +1,304 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
+import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.HttpServer;
+import com.redhat.rhjmc.containerjfr.net.web.WebServer;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
+
+    private static final Pattern RECORDING_FILENAME_PATTERN =
+            Pattern.compile("([A-Za-z\\d-]*)_([A-Za-z\\d-_]*)_([\\d]*T[\\d]*Z)(.[\\d]+)?");
+
+    private final Vertx vertx;
+    private final FileSystem fs;
+    private final Path savedRecordingsPath;
+    private final ResponseUtils utils;
+    private final Logger logger;
+
+    @Inject
+    RecordingsPostHandler(
+            AuthManager auth,
+            HttpServer httpServer,
+            FileSystem fs,
+            @Named("RECORDINGS_PATH") Path savedRecordingsPath,
+            ResponseUtils utils,
+            Logger logger) {
+        super(auth);
+        this.vertx = httpServer.getVertx();
+        this.fs = fs;
+        this.savedRecordingsPath = savedRecordingsPath;
+        this.utils = utils;
+        this.logger = logger;
+    }
+
+    @Override
+    public int getPriority() {
+        return DEFAULT_PRIORITY + 10;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/recordings";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        if (!fs.isDirectory(savedRecordingsPath)) {
+            throw new HttpStatusException(503, "Recording saving not available");
+        }
+
+        FileUpload upload = null;
+        for (FileUpload fu : ctx.fileUploads()) {
+            // ignore unrecognized form fields
+            if ("recording".equals(fu.name())) {
+                upload = fu;
+                break;
+            }
+        }
+
+        if (upload == null) {
+            throw new HttpStatusException(400, "No recording submission");
+        }
+
+        String fileName = upload.fileName();
+        if (fileName == null || fileName.isEmpty()) {
+            throw new HttpStatusException(400, "Recording name must not be empty");
+        }
+
+        if (fileName.endsWith(".jfr")) {
+            fileName = fileName.substring(0, fileName.length() - 4);
+        }
+
+        Matcher m = RECORDING_FILENAME_PATTERN.matcher(fileName);
+        if (!m.matches()) {
+            throw new HttpStatusException(400, "Incorrect recording file name pattern");
+        }
+
+        String targetName = m.group(1);
+        String recordingName = m.group(2);
+        String timestamp = m.group(3);
+        int count =
+                m.group(4) == null || m.group(4).isEmpty()
+                        ? 0
+                        : Integer.parseInt(m.group(4).substring(1));
+
+        final String basename = String.format("%s_%s_%s", targetName, recordingName, timestamp);
+        final String uploadedFileName = upload.uploadedFileName();
+        validateRecording(
+                upload.uploadedFileName(),
+                (res) ->
+                        saveRecording(
+                                basename,
+                                uploadedFileName,
+                                count,
+                                (res2) -> {
+                                    if (res2.failed()) {
+                                        ctx.fail(res2.cause());
+                                        return;
+                                    }
+
+                                    ctx.response()
+                                            .putHeader(
+                                                    HttpHeaders.CONTENT_TYPE,
+                                                    WebServer.MIME_TYPE_JSON);
+                                    utils.endWithJsonKeyValue(
+                                            "name", res2.result(), ctx.response());
+
+                                    logger.info(
+                                            String.format("Recording saved as %s", res2.result()));
+                                }));
+    }
+
+    private void validateRecording(String recordingFile, Handler<AsyncResult<Void>> handler) {
+        vertx.executeBlocking(
+                event -> {
+                    try {
+                        JfrLoaderToolkit.loadEvents(
+                                new File(recordingFile)); // try loading events to see if
+                        // it's a valid file
+                        event.complete();
+                    } catch (CouldNotLoadRecordingException | IOException e) {
+                        event.fail(e);
+                    }
+                },
+                res -> {
+                    if (res.failed()) {
+                        Throwable t;
+                        if (res.cause() instanceof CouldNotLoadRecordingException) {
+                            t =
+                                    new HttpStatusException(
+                                            400, "Not a valid JFR recording file", res.cause());
+                        } else {
+                            t = res.cause();
+                        }
+
+                        handler.handle(makeFailedAsyncResult(t));
+                        return;
+                    }
+
+                    handler.handle(makeAsyncResult(null));
+                });
+    }
+
+    private void saveRecording(
+            String basename, String tmpFile, int counter, Handler<AsyncResult<String>> handler) {
+        // TODO byte-sized rename limit is arbitrary. Probably plenty since recordings
+        // are also differentiated by second-resolution timestamp
+        if (counter >= Byte.MAX_VALUE) {
+            handler.handle(
+                    makeFailedAsyncResult(
+                            new IOException(
+                                    "Recording could not be saved. File already exists and rename attempts were exhausted.")));
+            return;
+        }
+
+        String filename = counter > 1 ? basename + "." + counter + ".jfr" : basename + ".jfr";
+
+        vertx.fileSystem()
+                .exists(
+                        savedRecordingsPath.resolve(filename).toString(),
+                        (res) -> {
+                            if (res.failed()) {
+                                handler.handle(makeFailedAsyncResult(res.cause()));
+                                return;
+                            }
+
+                            if (res.result()) {
+                                saveRecording(basename, tmpFile, counter + 1, handler);
+                                return;
+                            }
+
+                            // verified no name clash at this time
+                            vertx.fileSystem()
+                                    .move(
+                                            tmpFile,
+                                            savedRecordingsPath.resolve(filename).toString(),
+                                            (res2) -> {
+                                                if (res2.failed()) {
+                                                    handler.handle(
+                                                            makeFailedAsyncResult(res2.cause()));
+                                                    return;
+                                                }
+
+                                                handler.handle(makeAsyncResult(filename));
+                                            });
+                        });
+    }
+
+    private <T> AsyncResult<T> makeAsyncResult(T result) {
+        return new AsyncResult<>() {
+            @Override
+            public T result() {
+                return result;
+            }
+
+            @Override
+            public Throwable cause() {
+                return null;
+            }
+
+            @Override
+            public boolean succeeded() {
+                return true;
+            }
+
+            @Override
+            public boolean failed() {
+                return false;
+            }
+        };
+    }
+
+    private <T> AsyncResult<T> makeFailedAsyncResult(Throwable cause) {
+        return new AsyncResult<>() {
+            @Override
+            public T result() {
+                return null;
+            }
+
+            @Override
+            public Throwable cause() {
+                return cause;
+            }
+
+            @Override
+            public boolean succeeded() {
+                return false;
+            }
+
+            @Override
+            public boolean failed() {
+                return true;
+            }
+        };
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandler.java
@@ -111,6 +111,16 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
+    public boolean isOrdered() {
+        return true;
+    }
+
+    @Override
     void handleAuthenticated(RoutingContext ctx) {
         if (!fs.isDirectory(savedRecordingsPath)) {
             throw new HttpStatusException(503, "Recording saving not available");

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ReportGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ReportGetHandler.java
@@ -1,0 +1,118 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.reports.ReportGenerator;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.web.WebServer.DownloadDescriptor;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+
+class ReportGetHandler extends TargetReportGetHandler {
+
+    private final Path savedRecordingsPath;
+
+    @Inject
+    ReportGetHandler(
+            AuthManager auth,
+            Environment env,
+            @Named("RECORDINGS_PATH") Path savedRecordingsPath,
+            ReportGenerator reportGenerator,
+            Logger logger) {
+        super(auth, env, null, reportGenerator, logger);
+        this.savedRecordingsPath = savedRecordingsPath;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/reports/:recordingName";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        String recordingName = ctx.pathParam("recordingName");
+        handleReportPageRequest(null, recordingName, ctx);
+    }
+
+    // TODO refactor, this is duplicated from RecordingGetRequestHandler
+    @Override
+    Optional<DownloadDescriptor> getRecordingDescriptor(String targetId, String recordingName) {
+        try {
+            // TODO refactor Files calls into FileSystem for testability
+            Optional<Path> savedRecording =
+                    Files.list(savedRecordingsPath)
+                            .filter(
+                                    saved ->
+                                            saved.getFileName()
+                                                    .toFile()
+                                                    .getName()
+                                                    .equals(recordingName))
+                            .findFirst();
+            if (savedRecording.isPresent()) {
+                return Optional.of(
+                        new DownloadDescriptor(
+                                Files.newInputStream(savedRecording.get(), StandardOpenOption.READ),
+                                Files.size(savedRecording.get()),
+                                null));
+            }
+        } catch (Exception e) {
+            logger.error(e);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ReportGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ReportGetHandler.java
@@ -84,6 +84,16 @@ class ReportGetHandler extends TargetReportGetHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
+    public boolean isOrdered() {
+        return true;
+    }
+
+    @Override
     void handleAuthenticated(RoutingContext ctx) {
         String recordingName = ctx.pathParam("recordingName");
         handleReportPageRequest(null, recordingName, ctx);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandler.java
@@ -49,6 +49,8 @@ public interface RequestHandler extends Handler<RoutingContext> {
     /** Lower number == higher priority handler */
     static final int DEFAULT_PRIORITY = 100;
 
+    static final String ALL_PATHS = "ALL_PATHS";
+
     default int getPriority() {
         return DEFAULT_PRIORITY;
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandler.java
@@ -62,10 +62,10 @@ public interface RequestHandler extends Handler<RoutingContext> {
     }
 
     default boolean isAsync() {
-        return false;
+        return true;
     }
 
     default boolean isOrdered() {
-        return false;
+        return true;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandler.java
@@ -49,7 +49,7 @@ public interface RequestHandler extends Handler<RoutingContext> {
     /** Lower number == higher priority handler */
     static final int DEFAULT_PRIORITY = 100;
 
-    static final String ALL_PATHS = "ALL_PATHS";
+    static final String ALL_PATHS = "*";
 
     default int getPriority() {
         return DEFAULT_PRIORITY;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandler.java
@@ -46,7 +46,6 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 
 public interface RequestHandler extends Handler<RoutingContext> {
-
     String path();
 
     HttpMethod httpMethod();

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandler.java
@@ -39,58 +39,27 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr.net.web;
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import java.nio.file.Path;
-import java.util.Set;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
+public interface RequestHandler extends Handler<RoutingContext> {
 
-import com.google.gson.Gson;
+    String path();
 
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
-import com.redhat.rhjmc.containerjfr.core.reports.ReportGenerator;
-import com.redhat.rhjmc.containerjfr.core.sys.Environment;
-import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
-import com.redhat.rhjmc.containerjfr.net.AuthManager;
-import com.redhat.rhjmc.containerjfr.net.HttpServer;
-import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
-import com.redhat.rhjmc.containerjfr.net.NetworkModule;
-import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
-import com.redhat.rhjmc.containerjfr.net.web.handlers.RequestHandler;
-import com.redhat.rhjmc.containerjfr.net.web.handlers.RequestHandlersModule;
+    HttpMethod httpMethod();
 
-import dagger.Module;
-import dagger.Provides;
+    default boolean isAvailable() {
+        return true;
+    }
 
-@Module(includes = {NetworkModule.class, RequestHandlersModule.class})
-public abstract class WebModule {
-    @Provides
-    @Singleton
-    static WebServer provideWebServer(
-            HttpServer httpServer,
-            NetworkConfiguration netConf,
-            Environment env,
-            @Named("RECORDINGS_PATH") Path recordingsPath,
-            FileSystem fs,
-            Set<RequestHandler> requestHandlers,
-            Gson gson,
-            AuthManager authManager,
-            TargetConnectionManager targetConnectionManager,
-            ReportGenerator reportGenerator,
-            Logger logger) {
-        return new WebServer(
-                httpServer,
-                netConf,
-                env,
-                recordingsPath,
-                fs,
-                requestHandlers,
-                gson,
-                authManager,
-                targetConnectionManager,
-                reportGenerator,
-                logger);
+    default boolean isAsync() {
+        return false;
+    }
+
+    default boolean isOrdered() {
+        return false;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -39,58 +39,9 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr.net.web;
-
-import java.nio.file.Path;
-import java.util.Set;
-
-import javax.inject.Named;
-import javax.inject.Singleton;
-
-import com.google.gson.Gson;
-
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
-import com.redhat.rhjmc.containerjfr.core.reports.ReportGenerator;
-import com.redhat.rhjmc.containerjfr.core.sys.Environment;
-import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
-import com.redhat.rhjmc.containerjfr.net.AuthManager;
-import com.redhat.rhjmc.containerjfr.net.HttpServer;
-import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
-import com.redhat.rhjmc.containerjfr.net.NetworkModule;
-import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
-import com.redhat.rhjmc.containerjfr.net.web.handlers.RequestHandler;
-import com.redhat.rhjmc.containerjfr.net.web.handlers.RequestHandlersModule;
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
 import dagger.Module;
-import dagger.Provides;
 
-@Module(includes = {NetworkModule.class, RequestHandlersModule.class})
-public abstract class WebModule {
-    @Provides
-    @Singleton
-    static WebServer provideWebServer(
-            HttpServer httpServer,
-            NetworkConfiguration netConf,
-            Environment env,
-            @Named("RECORDINGS_PATH") Path recordingsPath,
-            FileSystem fs,
-            Set<RequestHandler> requestHandlers,
-            Gson gson,
-            AuthManager authManager,
-            TargetConnectionManager targetConnectionManager,
-            ReportGenerator reportGenerator,
-            Logger logger) {
-        return new WebServer(
-                httpServer,
-                netConf,
-                env,
-                recordingsPath,
-                fs,
-                requestHandlers,
-                gson,
-                authManager,
-                targetConnectionManager,
-                reportGenerator,
-                logger);
-    }
-}
+@Module
+public abstract class RequestHandlersModule {}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -50,6 +50,10 @@ public abstract class RequestHandlersModule {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindAuthPostHandler(AuthPostHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindClientUrlGetHandler(ClientUrlGetHandler handler);
 
     @Binds

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -50,6 +50,14 @@ public abstract class RequestHandlersModule {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindCorsEnablingHandler(CorsEnablingHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindCorsOptionsHandler(CorsOptionsHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindAuthPostHandler(AuthPostHandler handler);
 
     @Binds

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -69,4 +69,12 @@ public abstract class RequestHandlersModule {
     @Binds
     @IntoSet
     abstract RequestHandler bindRecordingGetHandler(RecordingGetHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTargetReportGetHandler(TargetReportGetHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindReportGetHandler(ReportGetHandler handler);
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -81,4 +81,12 @@ public abstract class RequestHandlersModule {
     @Binds
     @IntoSet
     abstract RequestHandler bindReportGetHandler(ReportGetHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindRecordingsPostBodyHandler(RecordingsPostBodyHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindRecordingsPostHandler(RecordingsPostHandler handler);
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ResponseUtils.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ResponseUtils.java
@@ -41,14 +41,22 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import dagger.Binds;
-import dagger.Module;
-import dagger.multibindings.IntoSet;
+import javax.inject.Inject;
 
-@Module
-public abstract class RequestHandlersModule {
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpServerResponse;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindClientUrlGetHandler(ClientUrlGetHandler handler);
+class ResponseUtils {
+
+    static final String MIME_TYPE_JSON = "application/json";
+    private final Gson gson;
+
+    @Inject
+    ResponseUtils(Gson gson) {
+        this.gson = gson;
+    }
+
+    <T> void endWithJsonKeyValue(String key, T value, HttpServerResponse response) {
+        response.end(String.format("{\"%s\":%s}", key, gson.toJson(value)));
+    }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/StaticAssetsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/StaticAssetsGetHandler.java
@@ -41,60 +41,38 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import dagger.Binds;
-import dagger.Module;
-import dagger.multibindings.IntoSet;
+import javax.inject.Inject;
 
-@Module
-public abstract class RequestHandlersModule {
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.StaticHandler;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindAuthPostHandler(AuthPostHandler handler);
+class StaticAssetsGetHandler implements RequestHandler {
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindClientUrlGetHandler(ClientUrlGetHandler handler);
+    private final StaticHandler staticHandler;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindGrafanaDatasourceUrlGetHandler(
-            GrafanaDatasourceUrlGetHandler handler);
+    @Inject
+    StaticAssetsGetHandler() {
+        this.staticHandler = StaticHandler.create(WebClientAssetsGetHandler.WEB_CLIENT_ASSETS_BASE);
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindGrafanaDashboardUrlGetHandler(
-            GrafanaDashboardUrlGetHandler handler);
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetRecordingGetHandler(TargetRecordingGetHandler handler);
+    @Override
+    public String path() {
+        return "/*";
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindRecordingGetHandler(RecordingGetHandler handler);
+    @Override
+    public boolean isAsync() {
+        return true;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetReportGetHandler(TargetReportGetHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindReportGetHandler(ReportGetHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindRecordingsPostBodyHandler(RecordingsPostBodyHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindRecordingsPostHandler(RecordingsPostHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindWebClientAssetsGetHandler(WebClientAssetsGetHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindStaticAssetsGetHandler(StaticAssetsGetHandler handler);
+    @Override
+    public void handle(RoutingContext ctx) {
+        staticHandler.handle(ctx);
+    }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/StaticAssetsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/StaticAssetsGetHandler.java
@@ -67,11 +67,6 @@ class StaticAssetsGetHandler implements RequestHandler {
     }
 
     @Override
-    public boolean isAsync() {
-        return true;
-    }
-
-    @Override
     public void handle(RoutingContext ctx) {
         staticHandler.handle(ctx);
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandler.java
@@ -59,6 +59,7 @@ import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 import com.redhat.rhjmc.containerjfr.net.web.WebServer.DownloadDescriptor;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -70,7 +71,6 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 class TargetRecordingGetHandler extends AbstractAuthenticatedRequestHandler {
-    static final String MIME_TYPE_OCTET_STREAM = "application/octet-stream";
     static final String USE_LOW_MEM_PRESSURE_STREAMING_ENV = "USE_LOW_MEM_PRESSURE_STREAMING";
 
     protected static final int WRITE_BUFFER_SIZE = 64 * 1024; // 64 KB
@@ -132,7 +132,7 @@ class TargetRecordingGetHandler extends AbstractAuthenticatedRequestHandler {
             }
 
             ctx.response().setChunked(true);
-            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_OCTET_STREAM);
+            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.OCTET_STREAM.mime());
             descriptor
                     .get()
                     .bytes

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandler.java
@@ -107,6 +107,11 @@ class TargetRecordingGetHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     void handleAuthenticated(RoutingContext ctx) {
         String targetId = ctx.pathParam("targetId");
         String recordingName = ctx.pathParam("recordingName");

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandler.java
@@ -1,0 +1,252 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.inject.Inject;
+
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.web.WebServer.DownloadDescriptor;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class TargetRecordingGetHandler extends AbstractAuthenticatedRequestHandler {
+    static final String MIME_TYPE_OCTET_STREAM = "application/octet-stream";
+    static final String USE_LOW_MEM_PRESSURE_STREAMING_ENV = "USE_LOW_MEM_PRESSURE_STREAMING";
+
+    protected static final int WRITE_BUFFER_SIZE = 64 * 1024; // 64 KB
+
+    protected final Environment env;
+    protected final TargetConnectionManager targetConnectionManager;
+    protected final Logger logger;
+
+    @Inject
+    TargetRecordingGetHandler(
+            AuthManager auth,
+            Environment env,
+            TargetConnectionManager targetConnectionManager,
+            Logger logger) {
+        super(auth);
+        this.env = env;
+        this.targetConnectionManager = targetConnectionManager;
+        this.logger = logger;
+        if (env.hasEnv(USE_LOW_MEM_PRESSURE_STREAMING_ENV)) {
+            logger.info("low memory pressure streaming enabled for web server");
+        } else {
+            logger.info("low memory pressure streaming disabled for web server");
+        }
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/targets/:targetId/recordings/:recordingName";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        String targetId = ctx.pathParam("targetId");
+        String recordingName = ctx.pathParam("recordingName");
+        if (recordingName != null && recordingName.endsWith(".jfr")) {
+            recordingName = recordingName.substring(0, recordingName.length() - 4);
+        }
+        handleRecordingDownloadRequest(targetId, recordingName, ctx);
+    }
+
+    // try-with-resources generates a "redundant" nullcheck in bytecode
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
+    void handleRecordingDownloadRequest(String targetId, String recordingName, RoutingContext ctx) {
+        try {
+            Optional<DownloadDescriptor> descriptor =
+                    getRecordingDescriptor(targetId, recordingName);
+            if (descriptor.isEmpty()) {
+                throw new HttpStatusException(404, String.format("%s not found", recordingName));
+            }
+
+            ctx.response().setChunked(true);
+            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, MIME_TYPE_OCTET_STREAM);
+            descriptor
+                    .get()
+                    .bytes
+                    .ifPresent(
+                            b ->
+                                    ctx.response()
+                                            .putHeader(
+                                                    HttpHeaders.CONTENT_LENGTH, Long.toString(b)));
+            try (InputStream stream = descriptor.get().stream) {
+                if (env.hasEnv(USE_LOW_MEM_PRESSURE_STREAMING_ENV)) {
+                    writeInputStreamLowMemPressure(stream, ctx.response());
+                } else {
+                    writeInputStream(stream, ctx.response());
+                }
+                ctx.response().end();
+            } finally {
+                descriptor
+                        .get()
+                        .resource
+                        .ifPresent(
+                                resource -> {
+                                    try {
+                                        resource.close();
+                                    } catch (Exception e) {
+                                        logger.warn(e);
+                                    }
+                                });
+            }
+        } catch (HttpStatusException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new HttpStatusException(500, e);
+        }
+    }
+
+    Optional<DownloadDescriptor> getRecordingDescriptor(String targetId, String recordingName)
+            throws Exception {
+        JFRConnection connection = targetConnectionManager.connect(targetId);
+        Optional<IRecordingDescriptor> desc =
+                connection.getService().getAvailableRecordings().stream()
+                        .filter(r -> Objects.equals(recordingName, r.getName()))
+                        .findFirst();
+        if (desc.isPresent()) {
+            return Optional.of(
+                    new DownloadDescriptor(
+                            connection.getService().openStream(desc.get(), false),
+                            null,
+                            connection));
+        } else {
+            connection.close();
+            return Optional.empty();
+        }
+    }
+
+    HttpServerResponse writeInputStreamLowMemPressure(
+            InputStream inputStream, HttpServerResponse response) throws IOException {
+        // blocking function, must be called from a blocking handler
+        byte[] buff = new byte[WRITE_BUFFER_SIZE];
+        Buffer chunk = Buffer.buffer();
+
+        ExecutorService worker = Executors.newSingleThreadExecutor();
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        worker.submit(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        int n;
+                        try {
+                            n = inputStream.read(buff);
+                        } catch (IOException e) {
+                            future.completeExceptionally(e);
+                            return;
+                        }
+
+                        if (n == -1) {
+                            future.complete(null);
+                            return;
+                        }
+
+                        chunk.setBytes(0, buff, 0, n);
+                        response.write(
+                                chunk.slice(0, n),
+                                (res) -> {
+                                    if (res.failed()) {
+                                        future.completeExceptionally(res.cause());
+                                        return;
+                                    }
+                                    worker.submit(this); // recursive call on this runnable itself
+                                });
+                    }
+                });
+
+        try {
+            future.join();
+            worker.shutdownNow();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            } else {
+                throw e;
+            }
+        }
+
+        return response;
+    }
+
+    HttpServerResponse writeInputStream(InputStream inputStream, HttpServerResponse response)
+            throws IOException {
+        // blocking function, must be called from a blocking handler
+        byte[] buff = new byte[WRITE_BUFFER_SIZE]; // 64 KB
+        int n;
+        while (true) {
+            n = inputStream.read(buff);
+            if (n == -1) {
+                break;
+            }
+            response.write(Buffer.buffer().appendBytes(buff, 0, n));
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandler.java
@@ -55,7 +55,7 @@ import com.redhat.rhjmc.containerjfr.core.reports.ReportGenerator;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
-import com.redhat.rhjmc.containerjfr.net.web.WebServer;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 import com.redhat.rhjmc.containerjfr.net.web.WebServer.DownloadDescriptor;
 
 import io.vertx.core.http.HttpHeaders;
@@ -115,7 +115,7 @@ class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
                 throw new HttpStatusException(404, String.format("%s not found", recordingName));
             }
 
-            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, WebServer.MIME_TYPE_HTML);
+            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.HTML.mime());
             try (InputStream stream = descriptor.get().stream) {
                 // blocking function, must be called from a blocking handler
                 ctx.response().end(reportGenerator.generateReport(stream));

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandler.java
@@ -1,0 +1,156 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.reports.ReportGenerator;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.web.WebServer;
+import com.redhat.rhjmc.containerjfr.net.web.WebServer.DownloadDescriptor;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
+
+    protected final TargetConnectionManager targetConnectionManager;
+    protected final ReportGenerator reportGenerator;
+    protected final Logger logger;
+
+    @Inject
+    TargetReportGetHandler(
+            AuthManager auth,
+            Environment env,
+            TargetConnectionManager targetConnectionManager,
+            ReportGenerator reportGenerator,
+            Logger logger) {
+        super(auth);
+        this.targetConnectionManager = targetConnectionManager;
+        this.reportGenerator = reportGenerator;
+        this.logger = logger;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/targets/:targetId/reports/:recordingName";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        String targetId = ctx.pathParam("targetId");
+        String recordingName = ctx.pathParam("recordingName");
+        if (recordingName != null && recordingName.endsWith(".jfr")) {
+            recordingName = recordingName.substring(0, recordingName.length() - 4);
+        }
+        handleReportPageRequest(targetId, recordingName, ctx);
+    }
+
+    void handleReportPageRequest(String targetId, String recordingName, RoutingContext ctx) {
+        try {
+            Optional<DownloadDescriptor> descriptor =
+                    getRecordingDescriptor(targetId, recordingName);
+            if (descriptor.isEmpty()) {
+                throw new HttpStatusException(404, String.format("%s not found", recordingName));
+            }
+
+            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, WebServer.MIME_TYPE_HTML);
+            try (InputStream stream = descriptor.get().stream) {
+                // blocking function, must be called from a blocking handler
+                ctx.response().end(reportGenerator.generateReport(stream));
+            } finally {
+                descriptor
+                        .get()
+                        .resource
+                        .ifPresent(
+                                resource -> {
+                                    try {
+                                        resource.close();
+                                    } catch (Exception e) {
+                                        logger.warn(e);
+                                    }
+                                });
+            }
+        } catch (HttpStatusException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new HttpStatusException(500, e);
+        }
+    }
+
+    // TODO refactor, this is duplicated from TargetRecordingGetRequestHandler
+    Optional<DownloadDescriptor> getRecordingDescriptor(String targetId, String recordingName)
+            throws Exception {
+        JFRConnection connection = targetConnectionManager.connect(targetId);
+        Optional<IRecordingDescriptor> desc =
+                connection.getService().getAvailableRecordings().stream()
+                        .filter(r -> Objects.equals(recordingName, r.getName()))
+                        .findFirst();
+        if (desc.isPresent()) {
+            return Optional.of(
+                    new DownloadDescriptor(
+                            connection.getService().openStream(desc.get(), false),
+                            null,
+                            connection));
+        } else {
+            connection.close();
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandler.java
@@ -93,6 +93,11 @@ class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     void handleAuthenticated(RoutingContext ctx) {
         String targetId = ctx.pathParam("targetId");
         String recordingName = ctx.pathParam("recordingName");

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/WebClientAssetsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/WebClientAssetsGetHandler.java
@@ -73,11 +73,6 @@ class WebClientAssetsGetHandler implements RequestHandler {
     }
 
     @Override
-    public boolean isAsync() {
-        return true;
-    }
-
-    @Override
     public void handle(RoutingContext ctx) {
         ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, WebServer.MIME_TYPE_HTML);
         ctx.response().sendFile(WEB_CLIENT_ASSETS_BASE + "/index.html");

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/WebClientAssetsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/WebClientAssetsGetHandler.java
@@ -43,6 +43,7 @@ package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
 import javax.inject.Inject;
 
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 import com.redhat.rhjmc.containerjfr.net.web.WebServer;
 
 import io.vertx.core.http.HttpHeaders;
@@ -74,7 +75,7 @@ class WebClientAssetsGetHandler implements RequestHandler {
 
     @Override
     public void handle(RoutingContext ctx) {
-        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, WebServer.MIME_TYPE_HTML);
+        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.HTML.mime());
         ctx.response().sendFile(WEB_CLIENT_ASSETS_BASE + "/index.html");
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/WebClientAssetsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/WebClientAssetsGetHandler.java
@@ -41,60 +41,45 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import dagger.Binds;
-import dagger.Module;
-import dagger.multibindings.IntoSet;
+import javax.inject.Inject;
 
-@Module
-public abstract class RequestHandlersModule {
+import com.redhat.rhjmc.containerjfr.net.web.WebServer;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindAuthPostHandler(AuthPostHandler handler);
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindClientUrlGetHandler(ClientUrlGetHandler handler);
+class WebClientAssetsGetHandler implements RequestHandler {
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindGrafanaDatasourceUrlGetHandler(
-            GrafanaDatasourceUrlGetHandler handler);
+    static final String WEB_CLIENT_ASSETS_BASE =
+            WebServer.class.getPackageName().replaceAll("\\.", "/");
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindGrafanaDashboardUrlGetHandler(
-            GrafanaDashboardUrlGetHandler handler);
+    @Inject
+    WebClientAssetsGetHandler() {}
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetRecordingGetHandler(TargetRecordingGetHandler handler);
+    @Override
+    public int getPriority() {
+        return DEFAULT_PRIORITY + 10;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindRecordingGetHandler(RecordingGetHandler handler);
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetReportGetHandler(TargetReportGetHandler handler);
+    @Override
+    public String path() {
+        return "/*";
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindReportGetHandler(ReportGetHandler handler);
+    @Override
+    public boolean isAsync() {
+        return true;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindRecordingsPostBodyHandler(RecordingsPostBodyHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindRecordingsPostHandler(RecordingsPostHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindWebClientAssetsGetHandler(WebClientAssetsGetHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindStaticAssetsGetHandler(StaticAssetsGetHandler handler);
+    @Override
+    public void handle(RoutingContext ctx) {
+        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, WebServer.MIME_TYPE_HTML);
+        ctx.response().sendFile(WEB_CLIENT_ASSETS_BASE + "/index.html");
+    }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
@@ -42,11 +42,6 @@
 package com.redhat.rhjmc.containerjfr.net.web;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
@@ -56,10 +51,7 @@ import java.net.SocketException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
-import java.nio.file.Path;
-import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import javax.management.remote.JMXServiceURL;
 
@@ -86,16 +78,6 @@ import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.HttpServer;
 import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.file.FileSystem;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.ext.web.FileUpload;
-import io.vertx.ext.web.RoutingContext;
-
 @ExtendWith(MockitoExtension.class)
 class WebServerTest {
 
@@ -103,8 +85,6 @@ class WebServerTest {
     @Mock HttpServer httpServer;
     @Mock NetworkConfiguration netConf;
     @Mock Environment env;
-    @Mock Path recordingsPath;
-    @Mock com.redhat.rhjmc.containerjfr.core.sys.FileSystem fs;
     @Mock AuthManager authManager;
     Gson gson = MainModule.provideGson();
     @Mock Logger logger;
@@ -113,17 +93,7 @@ class WebServerTest {
 
     @BeforeEach
     void setup() {
-        exporter =
-                new WebServer(
-                        httpServer,
-                        netConf,
-                        env,
-                        recordingsPath,
-                        fs,
-                        Set.of(),
-                        gson,
-                        authManager,
-                        logger);
+        exporter = new WebServer(httpServer, netConf, env, Set.of(), gson, authManager, logger);
     }
 
     @Test
@@ -136,17 +106,7 @@ class WebServerTest {
     @Test
     void shouldSuccessfullyInstantiateWithDefaultServer() {
         assertDoesNotThrow(
-                () ->
-                        new WebServer(
-                                httpServer,
-                                netConf,
-                                env,
-                                recordingsPath,
-                                fs,
-                                Set.of(),
-                                gson,
-                                authManager,
-                                logger));
+                () -> new WebServer(httpServer, netConf, env, Set.of(), gson, authManager, logger));
     }
 
     @Test
@@ -283,138 +243,5 @@ class WebServerTest {
                 Matchers.equalTo(
                         "https://example.com:8181/api/v1/targets/service:jmx:rmi:%2F%2Flocalhost:9091%2Fjndi%2Frmi:%2F%2FfooHost:9091%2Fjmxrmi/reports/"
                                 + recordingName));
-    }
-
-    @Test
-    void shouldHandleRecordingUploadRequest() throws Exception {
-        String basename = "localhost_test_20191219T213834Z";
-        String filename = basename + ".jfr";
-        String savePath = "/some/path/";
-
-        RoutingContext ctx = mock(RoutingContext.class);
-
-        when(authManager.validateHttpHeader(any()))
-                .thenReturn(CompletableFuture.completedFuture(true));
-        HttpServerRequest req = mock(HttpServerRequest.class);
-        when(ctx.request()).thenReturn(req);
-
-        when(fs.isDirectory(recordingsPath)).thenReturn(true);
-
-        Set<FileUpload> uploads = new HashSet<>();
-        FileUpload upload = mock(FileUpload.class);
-        uploads.add(upload);
-        when(ctx.fileUploads()).thenReturn(uploads);
-        when(upload.name()).thenReturn("recording");
-        when(upload.fileName()).thenReturn(filename);
-        when(upload.uploadedFileName()).thenReturn("foo");
-
-        Path filePath = mock(Path.class);
-        when(filePath.toString()).thenReturn(savePath + filename);
-        when(recordingsPath.resolve(filename)).thenReturn(filePath);
-
-        Vertx vertx = mock(Vertx.class);
-        when(httpServer.getVertx()).thenReturn(vertx);
-
-        FileSystem fs = mock(FileSystem.class);
-        when(vertx.fileSystem()).thenReturn(fs);
-
-        doAnswer(
-                        invocation -> {
-                            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(1);
-                            handler.handle(
-                                    new AsyncResult<>() {
-                                        @Override
-                                        public Boolean result() {
-                                            return false;
-                                        }
-
-                                        @Override
-                                        public Throwable cause() {
-                                            return null;
-                                        }
-
-                                        @Override
-                                        public boolean succeeded() {
-                                            return true;
-                                        }
-
-                                        @Override
-                                        public boolean failed() {
-                                            return false;
-                                        }
-                                    });
-
-                            return null;
-                        })
-                .when(vertx)
-                .executeBlocking(any(Handler.class), any(Handler.class));
-
-        when(fs.exists(eq(savePath + filename), any(Handler.class)))
-                .thenAnswer(
-                        invocation -> {
-                            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(1);
-                            handler.handle(
-                                    new AsyncResult<>() {
-                                        @Override
-                                        public Boolean result() {
-                                            return false;
-                                        }
-
-                                        @Override
-                                        public Throwable cause() {
-                                            return null;
-                                        }
-
-                                        @Override
-                                        public boolean succeeded() {
-                                            return true;
-                                        }
-
-                                        @Override
-                                        public boolean failed() {
-                                            return false;
-                                        }
-                                    });
-
-                            return null;
-                        });
-
-        when(fs.move(eq("foo"), eq(savePath + filename), any(Handler.class)))
-                .thenAnswer(
-                        invocation -> {
-                            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(2);
-                            handler.handle(
-                                    new AsyncResult<>() {
-                                        @Override
-                                        public Boolean result() {
-                                            return true;
-                                        }
-
-                                        @Override
-                                        public Throwable cause() {
-                                            return null;
-                                        }
-
-                                        @Override
-                                        public boolean succeeded() {
-                                            return true;
-                                        }
-
-                                        @Override
-                                        public boolean failed() {
-                                            return false;
-                                        }
-                                    });
-
-                            return null;
-                        });
-
-        HttpServerResponse rep = mock(HttpServerResponse.class);
-        when(ctx.response()).thenReturn(rep);
-
-        exporter.handleRecordingUploadRequest(ctx);
-
-        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
-        verify(rep).end("{\"name\":\"" + filename + "\"}");
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
@@ -133,10 +133,11 @@ class WebServerTest {
                         env,
                         recordingsPath,
                         fs,
-                        authManager,
+                        Set.of(),
                         gson,
-                        reportGenerator,
+                        authManager,
                         targetConnectionManager,
+                        reportGenerator,
                         logger);
     }
 
@@ -157,10 +158,11 @@ class WebServerTest {
                                 env,
                                 recordingsPath,
                                 fs,
-                                authManager,
+                                Set.of(),
                                 gson,
-                                reportGenerator,
+                                authManager,
                                 targetConnectionManager,
+                                reportGenerator,
                                 logger));
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
@@ -43,7 +43,6 @@ package com.redhat.rhjmc.containerjfr.net.web;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -105,7 +104,6 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 @ExtendWith(MockitoExtension.class)
 class WebServerTest {
@@ -300,38 +298,6 @@ class WebServerTest {
                 Matchers.equalTo(
                         "https://example.com:8181/api/v1/targets/service:jmx:rmi:%2F%2Flocalhost:9091%2Fjndi%2Frmi:%2F%2FfooHost:9091%2Fjmxrmi/reports/"
                                 + recordingName));
-    }
-
-    @Test
-    void shouldHandleGrafanaDashboardUrlRequest() {
-        RoutingContext ctx = mock(RoutingContext.class);
-        HttpServerResponse rep = mock(HttpServerResponse.class);
-        when(ctx.response()).thenReturn(rep);
-
-        String url = "http://hostname:1/path?query=value";
-        when(env.hasEnv("GRAFANA_DASHBOARD_URL")).thenReturn(true);
-        when(env.getEnv("GRAFANA_DASHBOARD_URL", "")).thenReturn(url);
-
-        exporter.handleGrafanaDashboardUrlRequest(ctx);
-
-        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
-        verify(rep).end("{\"grafanaDashboardUrl\":\"" + url + "\"}");
-    }
-
-    @Test
-    void shouldHandleGrafanaDashboardUrlRequestWithoutEnvVar() {
-        RoutingContext ctx = mock(RoutingContext.class);
-
-        when(env.hasEnv("GRAFANA_DASHBOARD_URL")).thenReturn(false);
-
-        HttpStatusException e =
-                assertThrows(
-                        HttpStatusException.class,
-                        () -> exporter.handleGrafanaDashboardUrlRequest(ctx));
-        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo("Internal Server Error"));
-        MatcherAssert.assertThat(
-                e.getPayload(), Matchers.equalTo("Deployment has no Grafana " + "configuration"));
-        MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(500));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
@@ -303,38 +303,6 @@ class WebServerTest {
     }
 
     @Test
-    void shouldHandleGrafanaDatasourceUrlRequest() {
-        RoutingContext ctx = mock(RoutingContext.class);
-        HttpServerResponse rep = mock(HttpServerResponse.class);
-        when(ctx.response()).thenReturn(rep);
-
-        String url = "http://hostname:1/path?query=value";
-        when(env.hasEnv("GRAFANA_DATASOURCE_URL")).thenReturn(true);
-        when(env.getEnv("GRAFANA_DATASOURCE_URL", "")).thenReturn(url);
-
-        exporter.handleGrafanaDatasourceUrlRequest(ctx);
-
-        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
-        verify(rep).end("{\"grafanaDatasourceUrl\":\"" + url + "\"}");
-    }
-
-    @Test
-    void shouldHandleGrafanaDatasourceUrlRequestWithoutEnvVar() {
-        RoutingContext ctx = mock(RoutingContext.class);
-
-        when(env.hasEnv("GRAFANA_DATASOURCE_URL")).thenReturn(false);
-
-        HttpStatusException e =
-                assertThrows(
-                        HttpStatusException.class,
-                        () -> exporter.handleGrafanaDatasourceUrlRequest(ctx));
-        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo("Internal Server Error"));
-        MatcherAssert.assertThat(
-                e.getPayload(), Matchers.equalTo("Deployment has no Grafana " + "configuration"));
-        MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(500));
-    }
-
-    @Test
     void shouldHandleGrafanaDashboardUrlRequest() {
         RoutingContext ctx = mock(RoutingContext.class);
         HttpServerResponse rep = mock(HttpServerResponse.class);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
@@ -303,35 +303,6 @@ class WebServerTest {
     }
 
     @Test
-    void shouldHandleClientUrlRequest() throws SocketException, UnknownHostException {
-        RoutingContext ctx = mock(RoutingContext.class);
-        HttpServerResponse rep = mock(HttpServerResponse.class);
-        when(ctx.response()).thenReturn(rep);
-        when(netConf.getWebServerHost()).thenReturn("hostname");
-        when(netConf.getExternalWebServerPort()).thenReturn(1);
-
-        exporter.handleClientUrlRequest(ctx);
-
-        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
-        verify(rep).end("{\"clientUrl\":\"ws://hostname:1/api/v1/command\"}");
-    }
-
-    @Test
-    void shouldHandleClientUrlRequestWithWss() throws SocketException, UnknownHostException {
-        RoutingContext ctx = mock(RoutingContext.class);
-        HttpServerResponse rep = mock(HttpServerResponse.class);
-        when(ctx.response()).thenReturn(rep);
-        when(netConf.getWebServerHost()).thenReturn("hostname");
-        when(netConf.getExternalWebServerPort()).thenReturn(1);
-        when(httpServer.isSsl()).thenReturn(true);
-
-        exporter.handleClientUrlRequest(ctx);
-
-        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
-        verify(rep).end("{\"clientUrl\":\"wss://hostname:1/api/v1/command\"}");
-    }
-
-    @Test
     void shouldHandleGrafanaDatasourceUrlRequest() {
         RoutingContext ctx = mock(RoutingContext.class);
         HttpServerResponse rep = mock(HttpServerResponse.class);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/WebServerTest.java
@@ -73,7 +73,6 @@ import com.google.gson.Gson;
 import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
-import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.HttpServer;
 import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
@@ -84,7 +83,6 @@ class WebServerTest {
     WebServer exporter;
     @Mock HttpServer httpServer;
     @Mock NetworkConfiguration netConf;
-    @Mock Environment env;
     @Mock AuthManager authManager;
     Gson gson = MainModule.provideGson();
     @Mock Logger logger;
@@ -93,7 +91,7 @@ class WebServerTest {
 
     @BeforeEach
     void setup() {
-        exporter = new WebServer(httpServer, netConf, env, Set.of(), gson, authManager, logger);
+        exporter = new WebServer(httpServer, netConf, Set.of(), gson, authManager, logger);
     }
 
     @Test
@@ -106,7 +104,7 @@ class WebServerTest {
     @Test
     void shouldSuccessfullyInstantiateWithDefaultServer() {
         assertDoesNotThrow(
-                () -> new WebServer(httpServer, netConf, env, Set.of(), gson, authManager, logger));
+                () -> new WebServer(httpServer, netConf, Set.of(), gson, authManager, logger));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AuthPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AuthPostHandlerTest.java
@@ -1,0 +1,135 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class AuthPostHandlerTest {
+
+    AuthPostHandler handler;
+    @Mock AuthManager auth;
+
+    @BeforeEach
+    void setup() {
+        this.handler = new AuthPostHandler(auth);
+    }
+
+    @Test
+    void shouldHandlePostRequests() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+    }
+
+    @Test
+    void shouldHandleExpectedPath() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v1/auth"));
+    }
+
+    @Test
+    void shouldRespond200IfAuthPasses() {
+        when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+        HttpServerResponse rep = mock(HttpServerResponse.class);
+        when(ctx.response()).thenReturn(rep);
+
+        handler.handle(ctx);
+
+        InOrder inOrder = Mockito.inOrder(rep);
+        inOrder.verify(rep).setStatusCode(200);
+        inOrder.verify(rep).end();
+    }
+
+    @Test
+    void shouldThrow401IfAuthFails() {
+        when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(false));
+
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
+    }
+
+    @Test
+    void shouldThrow500IfAuthThrows() {
+        when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.failedFuture(new NullPointerException()));
+
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ClientUrlGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ClientUrlGetHandlerTest.java
@@ -58,10 +58,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import com.google.gson.Gson;
 
 import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.net.HttpServer;
 import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -76,13 +78,13 @@ class ClientUrlGetHandlerTest {
     class WithoutSsl {
 
         ClientUrlGetHandler handler;
-        ResponseUtils utils = new ResponseUtils(MainModule.provideGson());
+        Gson gson = MainModule.provideGson();
         @Mock HttpServer httpServer;
         @Mock NetworkConfiguration netConf;
 
         @BeforeEach
         void setup() {
-            this.handler = new ClientUrlGetHandler(utils, httpServer, netConf);
+            this.handler = new ClientUrlGetHandler(gson, httpServer, netConf);
         }
 
         @Test
@@ -111,7 +113,7 @@ class ClientUrlGetHandlerTest {
             handler.handle(ctx);
 
             InOrder inOrder = inOrder(rep);
-            inOrder.verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            inOrder.verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
             inOrder.verify(rep).end("{\"clientUrl\":\"ws://hostname:1/api/v1/command\"}");
         }
 
@@ -130,14 +132,14 @@ class ClientUrlGetHandlerTest {
     class WithSsl {
 
         ClientUrlGetHandler handler;
-        ResponseUtils utils = new ResponseUtils(MainModule.provideGson());
+        Gson gson = MainModule.provideGson();
         @Mock HttpServer httpServer;
         @Mock NetworkConfiguration netConf;
 
         @BeforeEach
         void setup() {
             when(httpServer.isSsl()).thenReturn(true);
-            this.handler = new ClientUrlGetHandler(utils, httpServer, netConf);
+            this.handler = new ClientUrlGetHandler(gson, httpServer, netConf);
         }
 
         @Test
@@ -151,7 +153,7 @@ class ClientUrlGetHandlerTest {
             handler.handle(ctx);
 
             InOrder inOrder = inOrder(rep);
-            inOrder.verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            inOrder.verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
             inOrder.verify(rep).end("{\"clientUrl\":\"wss://hostname:1/api/v1/command\"}");
         }
     }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ClientUrlGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ClientUrlGetHandlerTest.java
@@ -1,0 +1,158 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.SocketException;
+import java.net.UnknownHostException;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.net.HttpServer;
+import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class ClientUrlGetHandlerTest {
+
+    @Nested
+    class WithoutSsl {
+
+        ClientUrlGetHandler handler;
+        ResponseUtils utils = new ResponseUtils(MainModule.provideGson());
+        @Mock HttpServer httpServer;
+        @Mock NetworkConfiguration netConf;
+
+        @BeforeEach
+        void setup() {
+            this.handler = new ClientUrlGetHandler(utils, httpServer, netConf);
+        }
+
+        @Test
+        void shouldBeGETRequest() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+        }
+
+        @Test
+        void shouldHaveCorrectPath() {
+            MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v1/clienturl"));
+        }
+
+        @Test
+        void shouldBeAsync() {
+            Assertions.assertTrue(handler.isAsync());
+        }
+
+        @Test
+        void shouldHandleClientUrlRequest() throws SocketException, UnknownHostException {
+            RoutingContext ctx = mock(RoutingContext.class);
+            HttpServerResponse rep = mock(HttpServerResponse.class);
+            when(ctx.response()).thenReturn(rep);
+            when(netConf.getWebServerHost()).thenReturn("hostname");
+            when(netConf.getExternalWebServerPort()).thenReturn(1);
+
+            handler.handle(ctx);
+
+            InOrder inOrder = inOrder(rep);
+            inOrder.verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            inOrder.verify(rep).end("{\"clientUrl\":\"ws://hostname:1/api/v1/command\"}");
+        }
+
+        @Test
+        void shouldBubbleInternalServerErrorIfHandlerThrows()
+                throws SocketException, UnknownHostException {
+            RoutingContext ctx = mock(RoutingContext.class);
+            HttpServerResponse rep = mock(HttpServerResponse.class);
+            when(ctx.response()).thenReturn(rep);
+            when(netConf.getWebServerHost()).thenThrow(UnknownHostException.class);
+            Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        }
+    }
+
+    @Nested
+    class WithSsl {
+
+        ClientUrlGetHandler handler;
+        ResponseUtils utils = new ResponseUtils(MainModule.provideGson());
+        @Mock HttpServer httpServer;
+        @Mock NetworkConfiguration netConf;
+
+        @BeforeEach
+        void setup() {
+            when(httpServer.isSsl()).thenReturn(true);
+            this.handler = new ClientUrlGetHandler(utils, httpServer, netConf);
+        }
+
+        @Test
+        void shouldHandleClientUrlRequestWithWss() throws SocketException, UnknownHostException {
+            RoutingContext ctx = mock(RoutingContext.class);
+            HttpServerResponse rep = mock(HttpServerResponse.class);
+            when(ctx.response()).thenReturn(rep);
+            when(netConf.getWebServerHost()).thenReturn("hostname");
+            when(netConf.getExternalWebServerPort()).thenReturn(1);
+
+            handler.handle(ctx);
+
+            InOrder inOrder = inOrder(rep);
+            inOrder.verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            inOrder.verify(rep).end("{\"clientUrl\":\"wss://hostname:1/api/v1/command\"}");
+        }
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandlerTest.java
@@ -1,0 +1,185 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.web.WebServer;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+
+@ExtendWith(MockitoExtension.class)
+class CorsEnablingHandlerTest {
+
+    CorsEnablingHandler handler;
+    @Mock Environment env;
+
+    @BeforeEach
+    void setup() {
+        this.handler = new CorsEnablingHandler(env);
+    }
+
+    @Test
+    void shouldApplyToAllPaths() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo(RequestHandler.ALL_PATHS));
+    }
+
+    @Test
+    void shouldApplyToOtherMethod() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.OTHER));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void availabilityShouldDependOnEnvVar(boolean available) {
+        Mockito.when(env.hasEnv(CorsEnablingHandler.ENABLE_CORS_ENV)).thenReturn(available);
+        MatcherAssert.assertThat(handler.isAvailable(), Matchers.equalTo(available));
+    }
+
+    @Nested
+    class HandlingTest {
+
+        @Mock RoutingContext ctx;
+        @Mock HttpServerRequest req;
+        @Mock HttpServerResponse res;
+        @Mock MultiMap headers;
+
+        @BeforeEach
+        void setRequestAndResponse() {
+            Mockito.when(ctx.request()).thenReturn(req);
+            Mockito.when(ctx.response()).thenReturn(res);
+            Mockito.when(req.headers()).thenReturn(headers);
+        }
+
+        @Test
+        void shouldPassToNextHandlerOnNonCORS() {
+            handler.handle(ctx);
+
+            InOrder inOrder = Mockito.inOrder(ctx, req, res);
+            inOrder.verify(ctx).request();
+            inOrder.verify(ctx).response();
+            inOrder.verify(ctx).request();
+            inOrder.verify(req).headers();
+            inOrder.verify(ctx).next();
+            inOrder.verifyNoMoreInteractions();
+        }
+
+        @Test
+        void shouldAddHeadersToCORS() {
+            Mockito.when(headers.get(HttpHeaders.ORIGIN))
+                    .thenReturn(CorsEnablingHandler.DEV_ORIGIN);
+
+            handler.handle(ctx);
+
+            Mockito.verify(res).putHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+            Mockito.verify(res)
+                    .putHeader(
+                            HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                            CorsEnablingHandler.DEV_ORIGIN);
+            Mockito.verify(res)
+                    .putHeader(
+                            HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                            WebServer.AUTH_SCHEME_HEADER);
+            Mockito.verifyNoMoreInteractions(res);
+            Mockito.verify(ctx).next();
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+                value = HttpMethod.class,
+                names = {"GET", "POST", "OPTIONS", "HEAD"})
+        void shouldRespondOKToOPTIONSWithAcceptedMethod(HttpMethod method) {
+            Mockito.when(req.method()).thenReturn(HttpMethod.OPTIONS);
+            Mockito.when(headers.get(HttpHeaders.ORIGIN))
+                    .thenReturn(CorsEnablingHandler.DEV_ORIGIN);
+            Mockito.when(headers.get(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD))
+                    .thenReturn(method.name());
+            Mockito.when(res.setStatusCode(Mockito.anyInt())).thenReturn(res);
+
+            handler.handle(ctx);
+
+            Mockito.verify(res).putHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+            Mockito.verify(res)
+                    .putHeader(
+                            HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                            CorsEnablingHandler.DEV_ORIGIN);
+            Mockito.verify(res)
+                    .putHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET,POST,OPTIONS,HEAD");
+            Mockito.verify(res)
+                    .putHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "Authorization");
+            Mockito.verify(res).setStatusCode(200);
+            Mockito.verify(res).end();
+            Mockito.verifyNoMoreInteractions(res);
+        }
+
+        @Test
+        void shouldRespond403ForCORSRequestWithInvalidOrigin() {
+            Mockito.when(headers.get(HttpHeaders.ORIGIN)).thenReturn("http://example.com:1234/");
+            Mockito.when(req.response()).thenReturn(res);
+            Mockito.when(res.setStatusCode(Mockito.anyInt())).thenReturn(res);
+            Mockito.when(res.setStatusMessage(Mockito.anyString())).thenReturn(res);
+
+            handler.handle(ctx);
+
+            Mockito.verify(res).setStatusCode(403);
+            Mockito.verify(res).end();
+        }
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsOptionsHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsOptionsHandlerTest.java
@@ -39,36 +39,43 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr.net.web;
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import java.util.Set;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.inject.Singleton;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import io.vertx.core.http.HttpMethod;
 
-import com.google.gson.Gson;
+@ExtendWith(MockitoExtension.class)
+class CorsOptionsHandlerTest {
 
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
-import com.redhat.rhjmc.containerjfr.net.AuthManager;
-import com.redhat.rhjmc.containerjfr.net.HttpServer;
-import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
-import com.redhat.rhjmc.containerjfr.net.NetworkModule;
-import com.redhat.rhjmc.containerjfr.net.web.handlers.RequestHandler;
-import com.redhat.rhjmc.containerjfr.net.web.handlers.RequestHandlersModule;
+    CorsOptionsHandler handler;
+    @Mock Environment env;
 
-import dagger.Module;
-import dagger.Provides;
+    @BeforeEach
+    void setup() {
+        this.handler = new CorsOptionsHandler(env);
+    }
 
-@Module(includes = {NetworkModule.class, RequestHandlersModule.class})
-public abstract class WebModule {
-    @Provides
-    @Singleton
-    static WebServer provideWebServer(
-            HttpServer httpServer,
-            NetworkConfiguration netConf,
-            Set<RequestHandler> requestHandlers,
-            Gson gson,
-            AuthManager authManager,
-            Logger logger) {
-        return new WebServer(httpServer, netConf, requestHandlers, gson, authManager, logger);
+    @Test
+    void shouldApplyOPTIONSVerb() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.OPTIONS));
+    }
+
+    @Test
+    void shouldApplyToAllRequests() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/*"));
+    }
+
+    @Test
+    void shouldBeHighPriority() {
+        MatcherAssert.assertThat(
+                handler.getPriority(), Matchers.lessThan(RequestHandler.DEFAULT_PRIORITY));
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDashboardUrlGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDashboardUrlGetHandlerTest.java
@@ -52,10 +52,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import com.google.gson.Gson;
 
 import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -67,12 +70,12 @@ import io.vertx.ext.web.handler.impl.HttpStatusException;
 class GrafanaDashboardUrlGetHandlerTest {
 
     GrafanaDashboardUrlGetHandler handler;
-    ResponseUtils utils = new ResponseUtils(MainModule.provideGson());
+    Gson gson = MainModule.provideGson();
     @Mock Environment env;
 
     @BeforeEach
     void setup() {
-        this.handler = new GrafanaDashboardUrlGetHandler(env, utils);
+        this.handler = new GrafanaDashboardUrlGetHandler(env, gson);
     }
 
     @Test
@@ -95,6 +98,7 @@ class GrafanaDashboardUrlGetHandlerTest {
         RoutingContext ctx = mock(RoutingContext.class);
         HttpServerResponse rep = mock(HttpServerResponse.class);
         when(ctx.response()).thenReturn(rep);
+        when(rep.putHeader(Mockito.any(CharSequence.class), Mockito.anyString())).thenReturn(rep);
 
         String url = "http://hostname:1/path?query=value";
         when(env.hasEnv("GRAFANA_DASHBOARD_URL")).thenReturn(true);
@@ -102,7 +106,7 @@ class GrafanaDashboardUrlGetHandlerTest {
 
         handler.handle(ctx);
 
-        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
         verify(rep).end("{\"grafanaDashboardUrl\":\"" + url + "\"}");
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDashboardUrlGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDashboardUrlGetHandlerTest.java
@@ -1,0 +1,122 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class GrafanaDashboardUrlGetHandlerTest {
+
+    GrafanaDashboardUrlGetHandler handler;
+    ResponseUtils utils = new ResponseUtils(MainModule.provideGson());
+    @Mock Environment env;
+
+    @BeforeEach
+    void setup() {
+        this.handler = new GrafanaDashboardUrlGetHandler(env, utils);
+    }
+
+    @Test
+    void shouldHandleGETRequest() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v1/grafana_dashboard_url"));
+    }
+
+    @Test
+    void shouldBeAsync() {
+        Assertions.assertTrue(handler.isAsync());
+    }
+
+    @Test
+    void shouldHandleGrafanaDashboardUrlRequest() {
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerResponse rep = mock(HttpServerResponse.class);
+        when(ctx.response()).thenReturn(rep);
+
+        String url = "http://hostname:1/path?query=value";
+        when(env.hasEnv("GRAFANA_DASHBOARD_URL")).thenReturn(true);
+        when(env.getEnv("GRAFANA_DASHBOARD_URL")).thenReturn(url);
+
+        handler.handle(ctx);
+
+        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        verify(rep).end("{\"grafanaDashboardUrl\":\"" + url + "\"}");
+    }
+
+    @Test
+    void shouldHandleGrafanaDashboardUrlRequestWithoutEnvVar() {
+        RoutingContext ctx = mock(RoutingContext.class);
+
+        when(env.hasEnv("GRAFANA_DASHBOARD_URL")).thenReturn(false);
+
+        HttpStatusException e =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo("Internal Server Error"));
+        MatcherAssert.assertThat(
+                e.getPayload(), Matchers.equalTo("Deployment has no Grafana configuration"));
+        MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(500));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDatasourceUrlGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDatasourceUrlGetHandlerTest.java
@@ -52,10 +52,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import com.google.gson.Gson;
 
 import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -67,12 +70,12 @@ import io.vertx.ext.web.handler.impl.HttpStatusException;
 class GrafanaDatasourceUrlGetHandlerTest {
 
     GrafanaDatasourceUrlGetHandler handler;
-    ResponseUtils utils = new ResponseUtils(MainModule.provideGson());
+    Gson gson = MainModule.provideGson();
     @Mock Environment env;
 
     @BeforeEach
     void setup() {
-        this.handler = new GrafanaDatasourceUrlGetHandler(env, utils);
+        this.handler = new GrafanaDatasourceUrlGetHandler(env, gson);
     }
 
     @Test
@@ -96,6 +99,7 @@ class GrafanaDatasourceUrlGetHandlerTest {
         RoutingContext ctx = mock(RoutingContext.class);
         HttpServerResponse rep = mock(HttpServerResponse.class);
         when(ctx.response()).thenReturn(rep);
+        when(rep.putHeader(Mockito.any(CharSequence.class), Mockito.anyString())).thenReturn(rep);
 
         String url = "http://hostname:1/path?query=value";
         when(env.hasEnv("GRAFANA_DATASOURCE_URL")).thenReturn(true);
@@ -103,7 +107,7 @@ class GrafanaDatasourceUrlGetHandlerTest {
 
         handler.handle(ctx);
 
-        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
         verify(rep).end("{\"grafanaDatasourceUrl\":\"" + url + "\"}");
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDatasourceUrlGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/GrafanaDatasourceUrlGetHandlerTest.java
@@ -1,0 +1,123 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class GrafanaDatasourceUrlGetHandlerTest {
+
+    GrafanaDatasourceUrlGetHandler handler;
+    ResponseUtils utils = new ResponseUtils(MainModule.provideGson());
+    @Mock Environment env;
+
+    @BeforeEach
+    void setup() {
+        this.handler = new GrafanaDatasourceUrlGetHandler(env, utils);
+    }
+
+    @Test
+    void shouldHandleGETRequest() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(), Matchers.equalTo("/api/v1/grafana_datasource_url"));
+    }
+
+    @Test
+    void shouldBeAsync() {
+        Assertions.assertTrue(handler.isAsync());
+    }
+
+    @Test
+    void shouldHandleGrafanaDatasourceUrlRequest() {
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerResponse rep = mock(HttpServerResponse.class);
+        when(ctx.response()).thenReturn(rep);
+
+        String url = "http://hostname:1/path?query=value";
+        when(env.hasEnv("GRAFANA_DATASOURCE_URL")).thenReturn(true);
+        when(env.getEnv("GRAFANA_DATASOURCE_URL")).thenReturn(url);
+
+        handler.handle(ctx);
+
+        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        verify(rep).end("{\"grafanaDatasourceUrl\":\"" + url + "\"}");
+    }
+
+    @Test
+    void shouldHandleGrafanaDatasourceUrlRequestWithoutEnvVar() {
+        RoutingContext ctx = mock(RoutingContext.class);
+
+        when(env.hasEnv("GRAFANA_DATASOURCE_URL")).thenReturn(false);
+
+        HttpStatusException e =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo("Internal Server Error"));
+        MatcherAssert.assertThat(
+                e.getPayload(), Matchers.equalTo("Deployment has no Grafana configuration"));
+        MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(500));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingGetHandlerTest.java
@@ -41,32 +41,49 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import dagger.Binds;
-import dagger.Module;
-import dagger.multibindings.IntoSet;
+import java.nio.file.Path;
 
-@Module
-public abstract class RequestHandlersModule {
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindClientUrlGetHandler(ClientUrlGetHandler handler);
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import io.vertx.core.http.HttpMethod;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindGrafanaDatasourceUrlGetHandler(
-            GrafanaDatasourceUrlGetHandler handler);
+@ExtendWith(MockitoExtension.class)
+class RecordingGetHandlerTest {
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindGrafanaDashboardUrlGetHandler(
-            GrafanaDashboardUrlGetHandler handler);
+    TargetRecordingGetHandler handler;
+    @Mock AuthManager authManager;
+    @Mock Environment env;
+    @Mock Path savedRecordingsPath;
+    @Mock Logger logger;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetRecordingGetHandler(TargetRecordingGetHandler handler);
+    @BeforeEach
+    void setup() {
+        this.handler = new RecordingGetHandler(authManager, env, savedRecordingsPath, logger);
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindRecordingGetHandler(RecordingGetHandler handler);
+    @Test
+    void shouldHandleGETRequest() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(), Matchers.equalTo("/api/v1/recordings/:recordingName"));
+    }
+
+    @Test
+    void shouldNotBeAsync() {
+        Assertions.assertFalse(handler.isAsync());
+    }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandlerTest.java
@@ -1,0 +1,239 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.HttpServer;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RoutingContext;
+
+@ExtendWith(MockitoExtension.class)
+class RecordingsPostHandlerTest {
+
+    RecordingsPostHandler handler;
+    @Mock AuthManager authManager;
+    @Mock HttpServer httpServer;
+    @Mock Vertx vertx;
+    @Mock FileSystem cjfrFs;
+    @Mock Path recordingsPath;
+    @Mock Logger logger;
+
+    @BeforeEach
+    void setup() {
+        when(httpServer.getVertx()).thenReturn(vertx);
+        this.handler =
+                new RecordingsPostHandler(
+                        authManager,
+                        httpServer,
+                        cjfrFs,
+                        recordingsPath,
+                        new ResponseUtils(MainModule.provideGson()),
+                        logger);
+    }
+
+    @Test
+    void shouldBeLowerPriority() {
+        MatcherAssert.assertThat(
+                handler.getPriority(), Matchers.greaterThan(RequestHandler.DEFAULT_PRIORITY));
+    }
+
+    @Test
+    void shouldHandleRecordingUploadRequest() throws Exception {
+        String basename = "localhost_test_20191219T213834Z";
+        String filename = basename + ".jfr";
+        String savePath = "/some/path/";
+
+        RoutingContext ctx = mock(RoutingContext.class);
+
+        when(authManager.validateHttpHeader(any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
+        when(cjfrFs.isDirectory(recordingsPath)).thenReturn(true);
+
+        Set<FileUpload> uploads = new HashSet<>();
+        FileUpload upload = mock(FileUpload.class);
+        uploads.add(upload);
+        when(ctx.fileUploads()).thenReturn(uploads);
+        when(upload.name()).thenReturn("recording");
+        when(upload.fileName()).thenReturn(filename);
+        when(upload.uploadedFileName()).thenReturn("foo");
+
+        Path filePath = mock(Path.class);
+        when(filePath.toString()).thenReturn(savePath + filename);
+        when(recordingsPath.resolve(filename)).thenReturn(filePath);
+
+        io.vertx.core.file.FileSystem vertxFs = mock(io.vertx.core.file.FileSystem.class);
+        when(vertx.fileSystem()).thenReturn(vertxFs);
+
+        doAnswer(
+                        invocation -> {
+                            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(1);
+                            handler.handle(
+                                    new AsyncResult<>() {
+                                        @Override
+                                        public Boolean result() {
+                                            return false;
+                                        }
+
+                                        @Override
+                                        public Throwable cause() {
+                                            return null;
+                                        }
+
+                                        @Override
+                                        public boolean succeeded() {
+                                            return true;
+                                        }
+
+                                        @Override
+                                        public boolean failed() {
+                                            return false;
+                                        }
+                                    });
+
+                            return null;
+                        })
+                .when(vertx)
+                .executeBlocking(any(Handler.class), any(Handler.class));
+
+        when(vertxFs.exists(Mockito.eq(savePath + filename), any(Handler.class)))
+                .thenAnswer(
+                        invocation -> {
+                            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(1);
+                            handler.handle(
+                                    new AsyncResult<>() {
+                                        @Override
+                                        public Boolean result() {
+                                            return false;
+                                        }
+
+                                        @Override
+                                        public Throwable cause() {
+                                            return null;
+                                        }
+
+                                        @Override
+                                        public boolean succeeded() {
+                                            return true;
+                                        }
+
+                                        @Override
+                                        public boolean failed() {
+                                            return false;
+                                        }
+                                    });
+
+                            return null;
+                        });
+
+        when(vertxFs.move(Mockito.eq("foo"), Mockito.eq(savePath + filename), any(Handler.class)))
+                .thenAnswer(
+                        invocation -> {
+                            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(2);
+                            handler.handle(
+                                    new AsyncResult<>() {
+                                        @Override
+                                        public Boolean result() {
+                                            return true;
+                                        }
+
+                                        @Override
+                                        public Throwable cause() {
+                                            return null;
+                                        }
+
+                                        @Override
+                                        public boolean succeeded() {
+                                            return true;
+                                        }
+
+                                        @Override
+                                        public boolean failed() {
+                                            return false;
+                                        }
+                                    });
+
+                            return null;
+                        });
+
+        HttpServerResponse rep = mock(HttpServerResponse.class);
+        when(ctx.response()).thenReturn(rep);
+
+        handler.handle(ctx);
+
+        InOrder inOrder = Mockito.inOrder(rep);
+        inOrder.verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        inOrder.verify(rep).end("{\"name\":\"" + filename + "\"}");
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandlerTest.java
@@ -66,6 +66,7 @@ import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.HttpServer;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -96,7 +97,7 @@ class RecordingsPostHandlerTest {
                         httpServer,
                         cjfrFs,
                         recordingsPath,
-                        new ResponseUtils(MainModule.provideGson()),
+                        MainModule.provideGson(),
                         logger);
     }
 
@@ -229,11 +230,12 @@ class RecordingsPostHandlerTest {
 
         HttpServerResponse rep = mock(HttpServerResponse.class);
         when(ctx.response()).thenReturn(rep);
+        when(rep.putHeader(Mockito.any(CharSequence.class), Mockito.anyString())).thenReturn(rep);
 
         handler.handle(ctx);
 
         InOrder inOrder = Mockito.inOrder(rep);
-        inOrder.verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        inOrder.verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
         inOrder.verify(rep).end("{\"name\":\"" + filename + "\"}");
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ReportGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ReportGetHandlerTest.java
@@ -1,0 +1,124 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.reports.ReportGenerator;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class ReportGetHandlerTest {
+
+    ReportGetHandler handler;
+    @Mock AuthManager authManager;
+    @Mock Environment env;
+    @Mock Path savedRecordingsPath;
+    @Mock ReportGenerator reportGenerator;
+    @Mock Logger logger;
+    @Mock JFRConnection connection;
+    @Mock IFlightRecorderService service;
+
+    @BeforeEach
+    void setup() {
+        this.handler =
+                new ReportGetHandler(
+                        authManager, env, savedRecordingsPath, reportGenerator, logger);
+    }
+
+    @Test
+    void shouldHandleGETRequest() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(), Matchers.equalTo("/api/v1/reports/:recordingName"));
+    }
+
+    @Test
+    void shouldNotBeAsync() {
+        Assertions.assertFalse(handler.isAsync());
+    }
+
+    @Test
+    void shouldRespond404IfRecordingNameNotFound() throws Exception {
+        when(authManager.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
+        when(ctx.pathParam("recordingName")).thenReturn("someRecording");
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        ex.printStackTrace();
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandlerTest.java
@@ -1,0 +1,246 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TargetRecordingGetHandlerTest {
+
+    TargetRecordingGetHandler handler;
+    @Mock AuthManager authManager;
+    @Mock Environment env;
+    @Mock TargetConnectionManager targetConnectionManager;
+    @Mock Logger logger;
+    @Mock JFRConnection connection;
+    @Mock IFlightRecorderService service;
+
+    @BeforeEach
+    void setup() {
+        this.handler =
+                new TargetRecordingGetHandler(authManager, env, targetConnectionManager, logger);
+    }
+
+    @Test
+    void shouldHandleGETRequest() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(),
+                Matchers.equalTo("/api/v1/targets/:targetId/recordings/:recordingName"));
+    }
+
+    @Test
+    void shouldNotBeAsync() {
+        Assertions.assertFalse(handler.isAsync());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false}) // FIXME low memory pressure streaming test hangs
+    void shouldHandleRecordingDownloadRequest(boolean lowMemPressure) throws Exception {
+        when(env.hasEnv(TargetRecordingGetHandler.USE_LOW_MEM_PRESSURE_STREAMING_ENV))
+                .thenReturn(lowMemPressure);
+
+        when(authManager.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        when(connection.getService()).thenReturn(service);
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerResponse resp = mock(HttpServerResponse.class);
+        when(ctx.response()).thenReturn(resp);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
+        byte[] src = new byte[1024 * 1024];
+        new Random(123456).nextBytes(src);
+        IRecordingDescriptor descriptor = mock(IRecordingDescriptor.class);
+        String recordingName = "foo";
+        when(descriptor.getName()).thenReturn(recordingName);
+        when(service.openStream(descriptor, false)).thenReturn(new ByteArrayInputStream(src));
+        when(service.getAvailableRecordings()).thenReturn(List.of(descriptor));
+
+        Buffer dst = Buffer.buffer(1024 * 1024);
+        when(resp.write(Mockito.any(Buffer.class)))
+                .thenAnswer(
+                        invocation -> {
+                            Buffer chunk = invocation.getArgument(0);
+                            dst.appendBuffer(chunk);
+                            return null;
+                        });
+        when(ctx.pathParam("targetId")).thenReturn("fooHost:0");
+        when(ctx.pathParam("recordingName")).thenReturn(recordingName);
+
+        when(targetConnectionManager.connect(Mockito.anyString())).thenReturn(connection);
+
+        handler.handle(ctx);
+
+        verify(resp).putHeader(HttpHeaders.CONTENT_TYPE, "application/octet-stream");
+        Assertions.assertArrayEquals(src, dst.getBytes());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false}) // FIXME low memory pressure streaming test hangs
+    void shouldHandleRecordingDownloadRequestWithJfrSuffix(boolean lowMemPressure)
+            throws Exception {
+        when(env.hasEnv(TargetRecordingGetHandler.USE_LOW_MEM_PRESSURE_STREAMING_ENV))
+                .thenReturn(lowMemPressure);
+
+        when(authManager.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        when(connection.getService()).thenReturn(service);
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerResponse resp = mock(HttpServerResponse.class);
+        when(ctx.response()).thenReturn(resp);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
+        byte[] src = new byte[1024 * 1024];
+        new Random(123456).nextBytes(src);
+        IRecordingDescriptor descriptor = mock(IRecordingDescriptor.class);
+        String recordingName = "foo";
+        when(descriptor.getName()).thenReturn(recordingName);
+        when(service.openStream(descriptor, false)).thenReturn(new ByteArrayInputStream(src));
+        when(service.getAvailableRecordings()).thenReturn(List.of(descriptor));
+
+        Buffer dst = Buffer.buffer(1024 * 1024);
+        when(resp.write(Mockito.any(Buffer.class)))
+                .thenAnswer(
+                        invocation -> {
+                            Buffer chunk = invocation.getArgument(0);
+                            dst.appendBuffer(chunk);
+                            return null;
+                        });
+        when(ctx.pathParam("targetId")).thenReturn("fooHost:0");
+        when(ctx.pathParam("recordingName")).thenReturn(recordingName + ".jfr");
+
+        when(targetConnectionManager.connect(Mockito.anyString())).thenReturn(connection);
+
+        handler.handle(ctx);
+
+        verify(resp).putHeader(HttpHeaders.CONTENT_TYPE, "application/octet-stream");
+        Assertions.assertArrayEquals(src, dst.getBytes());
+    }
+
+    @Test
+    void shouldRespond404IfRecordingNameNotFound() throws Exception {
+        when(authManager.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
+        when(targetConnectionManager.connect(Mockito.anyString())).thenReturn(connection);
+        when(connection.getService()).thenReturn(service);
+        when(service.getAvailableRecordings()).thenReturn(List.of());
+
+        when(ctx.pathParam("targetId")).thenReturn("fooHost:0");
+        when(ctx.pathParam("recordingName")).thenReturn("someRecording");
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        ex.printStackTrace();
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+    }
+
+    @Test
+    void shouldResponse500IfUnexpectedExceptionThrown() throws Exception {
+        when(authManager.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
+        when(targetConnectionManager.connect(Mockito.anyString())).thenReturn(connection);
+        when(connection.getService()).thenReturn(service);
+        when(service.getAvailableRecordings()).thenThrow(NullPointerException.class);
+
+        when(ctx.pathParam("targetId")).thenReturn("fooHost:0");
+        when(ctx.pathParam("recordingName")).thenReturn("someRecording");
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        ex.printStackTrace();
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandlerTest.java
@@ -70,6 +70,7 @@ import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
@@ -152,7 +153,7 @@ class TargetRecordingGetHandlerTest {
 
         handler.handle(ctx);
 
-        verify(resp).putHeader(HttpHeaders.CONTENT_TYPE, "application/octet-stream");
+        verify(resp).putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.OCTET_STREAM.mime());
         Assertions.assertArrayEquals(src, dst.getBytes());
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandlerTest.java
@@ -1,0 +1,222 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.reports.ReportGenerator;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TargetReportGetHandlerTest {
+
+    TargetReportGetHandler handler;
+    @Mock AuthManager authManager;
+    @Mock Environment env;
+    @Mock TargetConnectionManager targetConnectionManager;
+    @Mock ReportGenerator reportGenerator;
+    @Mock Logger logger;
+    @Mock JFRConnection connection;
+    @Mock IFlightRecorderService service;
+
+    @BeforeEach
+    void setup() {
+        this.handler =
+                new TargetReportGetHandler(
+                        authManager, env, targetConnectionManager, reportGenerator, logger);
+    }
+
+    @Test
+    void shouldHandleGETRequest() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(),
+                Matchers.equalTo("/api/v1/targets/:targetId/reports/:recordingName"));
+    }
+
+    @Test
+    void shouldNotBeAsync() {
+        Assertions.assertFalse(handler.isAsync());
+    }
+
+    @Test
+    void shouldHandleRecordingDownloadRequest() throws Exception {
+        when(authManager.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        when(connection.getService()).thenReturn(service);
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerResponse rep = mock(HttpServerResponse.class);
+        when(ctx.response()).thenReturn(rep);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
+        InputStream ins = mock(InputStream.class);
+        IRecordingDescriptor descriptor = mock(IRecordingDescriptor.class);
+        String recordingName = "foo";
+        String content = "foobar";
+        when(descriptor.getName()).thenReturn(recordingName);
+        when(service.openStream(descriptor, false)).thenReturn(ins);
+        when(service.getAvailableRecordings()).thenReturn(List.of(descriptor));
+        when(reportGenerator.generateReport(ins)).thenReturn(content);
+
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("fooHost:0");
+        Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
+
+        when(targetConnectionManager.connect(Mockito.anyString())).thenReturn(connection);
+
+        handler.handle(ctx);
+
+        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "text/html");
+        verify(rep).end(content);
+    }
+
+    @Test
+    void shouldHandleRecordingDownloadRequestWithJfrSuffix() throws Exception {
+        when(authManager.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        when(connection.getService()).thenReturn(service);
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerResponse rep = mock(HttpServerResponse.class);
+        when(ctx.response()).thenReturn(rep);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
+        InputStream ins = mock(InputStream.class);
+        IRecordingDescriptor descriptor = mock(IRecordingDescriptor.class);
+        String recordingName = "foo";
+        String content = "foobar";
+        when(descriptor.getName()).thenReturn(recordingName);
+        when(service.openStream(descriptor, false)).thenReturn(ins);
+        when(service.getAvailableRecordings()).thenReturn(List.of(descriptor));
+        when(reportGenerator.generateReport(ins)).thenReturn(content);
+
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("fooHost:0");
+        Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName + ".jfr");
+
+        when(targetConnectionManager.connect(Mockito.anyString())).thenReturn(connection);
+
+        handler.handle(ctx);
+
+        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "text/html");
+        verify(rep).end(content);
+    }
+
+    @Test
+    void shouldRespond404IfRecordingNameNotFound() throws Exception {
+        when(authManager.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
+        when(targetConnectionManager.connect(Mockito.anyString())).thenReturn(connection);
+        when(connection.getService()).thenReturn(service);
+        when(service.getAvailableRecordings()).thenReturn(List.of());
+
+        when(ctx.pathParam("targetId")).thenReturn("fooHost:0");
+        when(ctx.pathParam("recordingName")).thenReturn("someRecording");
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        ex.printStackTrace();
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+    }
+
+    @Test
+    void shouldResponse500IfUnexpectedExceptionThrown() throws Exception {
+        when(authManager.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+
+        when(targetConnectionManager.connect(Mockito.anyString())).thenReturn(connection);
+        when(connection.getService()).thenReturn(service);
+        when(service.getAvailableRecordings()).thenThrow(NullPointerException.class);
+
+        when(ctx.pathParam("targetId")).thenReturn("fooHost:0");
+        when(ctx.pathParam("recordingName")).thenReturn("someRecording");
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        ex.printStackTrace();
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandlerTest.java
@@ -68,6 +68,7 @@ import com.redhat.rhjmc.containerjfr.core.reports.ReportGenerator;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -140,7 +141,7 @@ class TargetReportGetHandlerTest {
 
         handler.handle(ctx);
 
-        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "text/html");
+        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.HTML.mime());
         verify(rep).end(content);
     }
 
@@ -172,7 +173,7 @@ class TargetReportGetHandlerTest {
 
         handler.handle(ctx);
 
-        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, "text/html");
+        verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.HTML.mime());
         verify(rep).end(content);
     }
 


### PR DESCRIPTION
This introduces a RequestHandler interface, where implementations are injected into a set of handlers and processed into a sorted list by the WebServer, and then applied to its router as before. Each of these new handlers extracts existing logic and behaviour from the WebServer, as well as moving any relevant tests. No functional changes are made, which has been verified by running the integration tests in #164 against these changes as well as with manual testing. This makes the WebServer significantly smaller and simpler, so that the individual RequestHandlers can be unit tested much more easily and the WebServer itself does not have as many direct responsibilities.

~~Still in progress: handle CORS using these new handlers.~~

There are some TODOs left behind or newly added, which are intended to be addressed in a later cleanup. Some of them also require supporting changes in -core. There is also opportunity for more tests to be added, before and particularly after these cleanups are done.