### PR TITLE
Add download URL and report URL to `list` command in interactive mode

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
@@ -88,7 +88,13 @@ class ListCommand extends AbstractConnectedCommand implements SerializableComman
                         cw.println("\tNone");
                     }
                     for (IRecordingDescriptor recording : recordings) {
-                        cw.println(toString(recording));
+                        String downloadURL =
+                                "\tgetDownloadURL\t\t"
+                                + exporter.getDownloadURL(connection, recording.getName());
+                        String reportURL =
+                                "\tgetReportURL\t\t"
+                                + exporter.getReportURL(connection, recording.getName());
+                        cw.println(toString(recording) + downloadURL + "\n" + reportURL);
                     }
                     return null;
                 });

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
@@ -49,6 +49,8 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import com.redhat.rhjmc.containerjfr.commands.SerializableCommand;
@@ -88,13 +90,12 @@ class ListCommand extends AbstractConnectedCommand implements SerializableComman
                         cw.println("\tNone");
                     }
                     for (IRecordingDescriptor recording : recordings) {
-                        String downloadURL =
-                                "\tgetDownloadURL\t\t"
-                                + exporter.getDownloadURL(connection, recording.getName());
-                        String reportURL =
-                                "\tgetReportURL\t\t"
-                                + exporter.getReportURL(connection, recording.getName());
-                        cw.println(toString(recording) + downloadURL + "\n" + reportURL);
+                        HyperlinkedSerializableRecordingDescriptor descriptor =
+                                new HyperlinkedSerializableRecordingDescriptor(
+                                        recording,
+                                        exporter.getDownloadURL(connection, recording.getName()),
+                                        exporter.getReportURL(connection, recording.getName()));
+                        cw.println(toString(descriptor));
                     }
                     return null;
                 });
@@ -142,10 +143,13 @@ class ListCommand extends AbstractConnectedCommand implements SerializableComman
         return true;
     }
 
-    private static String toString(IRecordingDescriptor descriptor) throws Exception {
+    private static String toString(HyperlinkedSerializableRecordingDescriptor descriptor)
+            throws Exception {
         StringBuilder sb = new StringBuilder();
-
-        for (Method m : descriptor.getClass().getDeclaredMethods()) {
+        Method[] methods = ArrayUtils.addAll(
+                descriptor.getClass().getSuperclass().getDeclaredMethods(),
+                descriptor.getClass().getDeclaredMethods());
+        for (Method m : methods) {
             if (m.getParameterTypes().length == 0
                     && (m.getName().startsWith("get") || m.getName().startsWith("is"))) {
                 sb.append("\t");

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommandTest.java
@@ -189,11 +189,11 @@ class ListCommandTest implements ValidatesTargetId {
         InOrder inOrder = inOrder(cw);
         inOrder.verify(cw).println("Available recordings:");
         inOrder.verify(cw).println(Mockito.contains(
-                "\tgetDownloadURL\t\thttp://example.com:1234/api/v1/targets/fooHost:1/recordings/foo\n"
-                + "\tgetReportURL\t\thttp://example.com:1234/api/v1/targets/fooHost:1/reports/foo"));
+                "\tgetDownloadUrl\t\thttp://example.com:1234/api/v1/targets/fooHost:1/recordings/foo\n"
+                + "\tgetReportUrl\t\thttp://example.com:1234/api/v1/targets/fooHost:1/reports/foo"));
         inOrder.verify(cw).println(Mockito.contains(
-                "\tgetDownloadURL\t\thttp://example.com:1234/api/v1/targets/fooHost:1/recordings/bar\n"
-                + "\tgetReportURL\t\thttp://example.com:1234/api/v1/targets/fooHost:1/reports/bar"));
+                "\tgetDownloadUrl\t\thttp://example.com:1234/api/v1/targets/fooHost:1/recordings/bar\n"
+                + "\tgetReportUrl\t\thttp://example.com:1234/api/v1/targets/fooHost:1/reports/bar"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #160 

The code for the test has a lot duplicated with the test for the serializable list command, `shouldReturnListOutput()`, but I'm not sure if there's a good way to put it all into a method or if this would even be worth it, since it's just two tests.