### PR TITLE
Set expected archived recordings filepath to absolute path

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
@@ -59,6 +59,7 @@ import com.redhat.rhjmc.containerjfr.tui.TuiModule;
 
 import dagger.Module;
 import dagger.Provides;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @Module(
         includes = {
@@ -69,6 +70,8 @@ import dagger.Provides;
             TuiModule.class
         })
 public abstract class MainModule {
+    public static final String RECORDINGS_PATH = "RECORDINGS_PATH";
+
     @Provides
     @Singleton
     static Logger provideLogger() {
@@ -82,9 +85,10 @@ public abstract class MainModule {
         return new GsonBuilder().serializeNulls().disableHtmlEscaping().create();
     }
 
+    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     @Provides
-    @Named("RECORDINGS_PATH")
+    @Named(RECORDINGS_PATH)
     static Path provideSavedRecordingsPath() {
-        return Paths.get("flightrecordings");
+        return Paths.get("/", "flightrecordings");
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteSavedRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteSavedRecordingCommand.java
@@ -47,6 +47,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.commands.SerializableCommand;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
@@ -60,7 +61,9 @@ class DeleteSavedRecordingCommand implements SerializableCommand {
 
     @Inject
     DeleteSavedRecordingCommand(
-            ClientWriter cw, FileSystem fs, @Named("RECORDINGS_PATH") Path recordingsPath) {
+            ClientWriter cw,
+            FileSystem fs,
+            @Named(MainModule.RECORDINGS_PATH) Path recordingsPath) {
         this.cw = cw;
         this.fs = fs;
         this.recordingsPath = recordingsPath;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommand.java
@@ -51,6 +51,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.commands.SerializableCommand;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
@@ -69,7 +70,7 @@ class ListSavedRecordingsCommand implements SerializableCommand {
     ListSavedRecordingsCommand(
             ClientWriter cw,
             FileSystem fs,
-            @Named("RECORDINGS_PATH") Path recordingsPath,
+            @Named(MainModule.RECORDINGS_PATH) Path recordingsPath,
             WebServer exporter) {
         this.cw = cw;
         this.fs = fs;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
@@ -54,6 +54,7 @@ import javax.inject.Singleton;
 import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.commands.SerializableCommand;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.sys.Clock;
@@ -75,7 +76,7 @@ class SaveRecordingCommand extends AbstractConnectedCommand implements Serializa
             TargetConnectionManager targetConnectionManager,
             Clock clock,
             FileSystem fs,
-            @Named("RECORDINGS_PATH") Path recordingsPath) {
+            @Named(MainModule.RECORDINGS_PATH) Path recordingsPath) {
         super(targetConnectionManager);
         this.cw = cw;
         this.clock = clock;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -62,6 +62,7 @@ import org.apache.http.util.EntityUtils;
 
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.commands.SerializableCommand;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
@@ -81,7 +82,7 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
             ClientWriter cw,
             TargetConnectionManager targetConnectionManager,
             FileSystem fs,
-            @Named("RECORDINGS_PATH") Path recordingsPath,
+            @Named(MainModule.RECORDINGS_PATH) Path recordingsPath,
             Provider<CloseableHttpClient> httpClientProvider) {
         super(targetConnectionManager);
         this.cw = cw;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingGetHandler.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
@@ -63,7 +64,7 @@ class RecordingGetHandler extends TargetRecordingGetHandler {
     RecordingGetHandler(
             AuthManager auth,
             Environment env,
-            @Named("RECORDINGS_PATH") Path savedRecordingsPath,
+            @Named(MainModule.RECORDINGS_PATH) Path savedRecordingsPath,
             Logger logger) {
         super(auth, env, null, logger);
         this.savedRecordingsPath = savedRecordingsPath;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandler.java
@@ -56,6 +56,7 @@ import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
 
 import com.google.gson.Gson;
 
+import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
@@ -87,7 +88,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
             AuthManager auth,
             HttpServer httpServer,
             FileSystem fs,
-            @Named("RECORDINGS_PATH") Path savedRecordingsPath,
+            @Named(MainModule.RECORDINGS_PATH) Path savedRecordingsPath,
             Gson gson,
             Logger logger) {
         super(auth);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ReportGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ReportGetHandler.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.reports.ReportGenerator;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
@@ -66,7 +67,7 @@ class ReportGetHandler extends TargetReportGetHandler {
     ReportGetHandler(
             AuthManager auth,
             Environment env,
-            @Named("RECORDINGS_PATH") Path savedRecordingsPath,
+            @Named(MainModule.RECORDINGS_PATH) Path savedRecordingsPath,
             ReportGenerator reportGenerator,
             Logger logger) {
         super(auth, env, null, reportGenerator, logger);


### PR DESCRIPTION
Using previous gcr.io base image, a relative path to the archived
recordings directory happened to work. Since switching base images to
UBI8 this assumption no longer holds, so the path is explicitly made
absolute.

No new tests are included, but it's worth noting that the integration tests in #164 do actually catch this regression. However, that PR is still outstanding and was not tested against the base image change.

Fixes #171