### PR TITLE
Add HTTP API handlers for various "lists"

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommand.java
@@ -53,9 +53,10 @@ import com.redhat.rhjmc.containerjfr.core.templates.Template;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 
-abstract class AbstractRecordingCommand extends AbstractConnectedCommand {
+public abstract class AbstractRecordingCommand extends AbstractConnectedCommand {
 
-    static final Template ALL_EVENTS_TEMPLATE =
+    // TODO extract this somewhere more appropriate
+    public static final Template ALL_EVENTS_TEMPLATE =
             new Template(
                     "ALL",
                     "Enable all available events in the target JVM, with default option values. This will be very expensive and is intended primarily for testing ContainerJFR's own capabilities.",

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
@@ -59,6 +59,8 @@ import com.redhat.rhjmc.containerjfr.jmc.serialization.HyperlinkedSerializableRe
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.web.WebServer;
 
+/** @deprecated Use HTTP GET /api/v1/targets/:targetId/recordings */
+@Deprecated
 @Singleton
 class ListCommand extends AbstractConnectedCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommand.java
@@ -55,6 +55,8 @@ import com.redhat.rhjmc.containerjfr.core.templates.Template;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 
+/** @deprecated Use HTTP GET /api/v1/targets/:targetId/templates */
+@Deprecated
 @Singleton
 class ListEventTemplatesCommand extends AbstractConnectedCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTypesCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTypesCommand.java
@@ -55,6 +55,8 @@ import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.jmc.serialization.SerializableEventTypeInfo;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 
+/** @deprecated Use HTTP GET /api/v1/targets/:targetId/events */
+@Deprecated
 @Singleton
 class ListEventTypesCommand extends AbstractConnectedCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommand.java
@@ -58,6 +58,8 @@ import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.jmc.serialization.SavedRecordingDescriptor;
 import com.redhat.rhjmc.containerjfr.net.web.WebServer;
 
+/** @deprecated Use HTTP GET /api/v1/recordings */
+@Deprecated
 @Singleton
 class ListSavedRecordingsCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ScanTargetsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ScanTargetsCommand.java
@@ -48,6 +48,8 @@ import com.redhat.rhjmc.containerjfr.commands.SerializableCommand;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.platform.PlatformClient;
 
+/** @deprecated Use HTTP GET /api/v1/targets */
+@Deprecated
 @Singleton
 class ScanTargetsCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -203,8 +203,7 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
         private final Optional<InputStream> stream;
         private final Optional<JFRConnection> connection;
 
-        RecordingConnection(
-                Optional<InputStream> stream, Optional<JFRConnection> connection) {
+        RecordingConnection(Optional<InputStream> stream, Optional<JFRConnection> connection) {
             this.stream = stream;
             this.connection = connection;
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsGetHandler.java
@@ -1,0 +1,114 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.google.gson.Gson;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class RecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
+
+    private final Path savedRecordingsPath;
+    private final FileSystem fs;
+    private final Gson gson;
+
+    @Inject
+    RecordingsGetHandler(
+            AuthManager auth,
+            @Named(MainModule.RECORDINGS_PATH) Path savedRecordingsPath,
+            FileSystem fs,
+            Gson gson) {
+        super(auth);
+        this.savedRecordingsPath = savedRecordingsPath;
+        this.fs = fs;
+        this.gson = gson;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/recordings";
+    }
+
+    @Override
+    public void handleAuthenticated(RoutingContext ctx) {
+        if (!fs.exists(savedRecordingsPath)) {
+            throw new HttpStatusException(
+                    403,
+                    String.format(
+                            "Archive path %s does not exist", savedRecordingsPath.toString()));
+        }
+        if (!fs.isReadable(savedRecordingsPath)) {
+            throw new HttpStatusException(
+                    403,
+                    String.format(
+                            "Archive path %s is not readable", savedRecordingsPath.toString()));
+        }
+        if (!fs.isDirectory(savedRecordingsPath)) {
+            throw new HttpStatusException(
+                    403,
+                    String.format(
+                            "Archive path %s is not a directory", savedRecordingsPath.toString()));
+        }
+        try {
+            ctx.response().end(gson.toJson(this.fs.listDirectoryChildren(savedRecordingsPath)));
+        } catch (IOException ioe) {
+            throw new HttpStatusException(500, ioe);
+        }
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -96,6 +96,10 @@ public abstract class RequestHandlersModule {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindRecordingsGetHandler(RecordingsGetHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindRecordingsPostBodyHandler(RecordingsPostBodyHandler handler);
 
     @Binds

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -121,4 +121,8 @@ public abstract class RequestHandlersModule {
     @Binds
     @IntoSet
     abstract RequestHandler bindTargetTemplatesGetHandler(TargetTemplatesGetHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTargetEventsGetHandler(TargetEventsGetHandler handler);
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -113,4 +113,8 @@ public abstract class RequestHandlersModule {
     @Binds
     @IntoSet
     abstract RequestHandler bindTargetsGetHandler(TargetsGetHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTargetRecordingsGetHandler(TargetRecordingsGetHandler handler);
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -117,4 +117,8 @@ public abstract class RequestHandlersModule {
     @Binds
     @IntoSet
     abstract RequestHandler bindTargetRecordingsGetHandler(TargetRecordingsGetHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTargetTemplatesGetHandler(TargetTemplatesGetHandler handler);
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetEventsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetEventsGetHandler.java
@@ -1,0 +1,106 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
+
+import com.google.gson.Gson;
+
+import com.redhat.rhjmc.containerjfr.jmc.serialization.SerializableEventTypeInfo;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class TargetEventsGetHandler extends AbstractAuthenticatedRequestHandler {
+
+    private final TargetConnectionManager connectionManager;
+    private final Gson gson;
+
+    @Inject
+    TargetEventsGetHandler(AuthManager auth, TargetConnectionManager connectionManager, Gson gson) {
+        super(auth);
+        this.connectionManager = connectionManager;
+        this.gson = gson;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/targets/:targetId/events";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        try {
+            String targetId = ctx.pathParam("targetId");
+            List<SerializableEventTypeInfo> templates =
+                    connectionManager.executeConnectedTask(
+                            targetId,
+                            connection -> {
+                                Collection<? extends IEventTypeInfo> origInfos =
+                                        connection.getService().getAvailableEventTypes();
+                                List<SerializableEventTypeInfo> infos =
+                                        new ArrayList<>(origInfos.size());
+                                for (IEventTypeInfo info : origInfos) {
+                                    infos.add(new SerializableEventTypeInfo(info));
+                                }
+                                return infos;
+                            });
+            ctx.response().end(gson.toJson(templates));
+        } catch (Exception e) {
+            throw new HttpStatusException(500, e);
+        }
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsGetHandler.java
@@ -1,0 +1,120 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.google.gson.Gson;
+
+import com.redhat.rhjmc.containerjfr.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.web.WebServer;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class TargetRecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
+
+    private final TargetConnectionManager connectionManager;
+    private final Provider<WebServer> webServerProvider;
+    private final Gson gson;
+
+    @Inject
+    TargetRecordingsGetHandler(
+            AuthManager auth,
+            TargetConnectionManager connectionManager,
+            Provider<WebServer> webServerProvider,
+            Gson gson) {
+        super(auth);
+        this.connectionManager = connectionManager;
+        this.webServerProvider = webServerProvider;
+        this.gson = gson;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/targets/:targetId/recordings";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        try {
+            String targetId = ctx.pathParam("targetId");
+            WebServer webServer = webServerProvider.get();
+            List<HyperlinkedSerializableRecordingDescriptor> descriptors =
+                    connectionManager.executeConnectedTask(
+                            targetId,
+                            connection -> {
+                                List<IRecordingDescriptor> origDescriptors =
+                                        connection.getService().getAvailableRecordings();
+                                List<HyperlinkedSerializableRecordingDescriptor> list =
+                                        new ArrayList<>(origDescriptors.size());
+                                for (IRecordingDescriptor desc : origDescriptors) {
+                                    list.add(
+                                            new HyperlinkedSerializableRecordingDescriptor(
+                                                    desc,
+                                                    webServer.getDownloadURL(
+                                                            connection, desc.getName()),
+                                                    webServer.getReportURL(
+                                                            connection, desc.getName())));
+                                }
+                                return list;
+                            });
+            ctx.response().end(gson.toJson(descriptors));
+        } catch (Exception e) {
+            throw new HttpStatusException(500, e);
+        }
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplatesGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplatesGetHandler.java
@@ -1,0 +1,102 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import com.google.gson.Gson;
+
+import com.redhat.rhjmc.containerjfr.commands.internal.AbstractRecordingCommand;
+import com.redhat.rhjmc.containerjfr.core.templates.Template;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class TargetTemplatesGetHandler extends AbstractAuthenticatedRequestHandler {
+
+    private final TargetConnectionManager connectionManager;
+    private final Gson gson;
+
+    @Inject
+    TargetTemplatesGetHandler(
+            AuthManager auth, TargetConnectionManager connectionManager, Gson gson) {
+        super(auth);
+        this.connectionManager = connectionManager;
+        this.gson = gson;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/targets/:targetId/templates";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        try {
+            String targetId = ctx.pathParam("targetId");
+            List<Template> templates =
+                    connectionManager.executeConnectedTask(
+                            targetId,
+                            connection -> {
+                                List<Template> list =
+                                        new ArrayList<>(
+                                                connection.getTemplateService().getTemplates());
+                                list.add(AbstractRecordingCommand.ALL_EVENTS_TEMPLATE);
+                                return list;
+                            });
+            ctx.response().end(gson.toJson(templates));
+        } catch (Exception e) {
+            throw new HttpStatusException(500, e);
+        }
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetsGetHandler.java
@@ -41,76 +41,40 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import dagger.Binds;
-import dagger.Module;
-import dagger.multibindings.IntoSet;
+import javax.inject.Inject;
 
-@Module
-public abstract class RequestHandlersModule {
+import com.google.gson.Gson;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindCorsEnablingHandler(CorsEnablingHandler handler);
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.platform.PlatformClient;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindCorsOptionsHandler(CorsOptionsHandler handler);
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindAuthPostHandler(AuthPostHandler handler);
+class TargetsGetHandler extends AbstractAuthenticatedRequestHandler {
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindHealthGetHandler(HealthGetHandler handler);
+    private final PlatformClient platformClient;
+    private final Gson gson;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindClientUrlGetHandler(ClientUrlGetHandler handler);
+    @Inject
+    TargetsGetHandler(AuthManager auth, PlatformClient platformClient, Gson gson) {
+        super(auth);
+        this.platformClient = platformClient;
+        this.gson = gson;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindGrafanaDatasourceUrlGetHandler(
-            GrafanaDatasourceUrlGetHandler handler);
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindGrafanaDashboardUrlGetHandler(
-            GrafanaDashboardUrlGetHandler handler);
+    @Override
+    public String path() {
+        return "/api/v1/targets";
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetRecordingGetHandler(TargetRecordingGetHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindRecordingGetHandler(RecordingGetHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetReportGetHandler(TargetReportGetHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindReportGetHandler(ReportGetHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindRecordingsPostBodyHandler(RecordingsPostBodyHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindRecordingsPostHandler(RecordingsPostHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindWebClientAssetsGetHandler(WebClientAssetsGetHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindStaticAssetsGetHandler(StaticAssetsGetHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetsGetHandler(TargetsGetHandler handler);
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        ctx.response().end(gson.toJson(this.platformClient.listDiscoverableServices()));
+    }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsGetHandlerTest.java
@@ -1,0 +1,168 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.google.gson.Gson;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class RecordingsGetHandlerTest {
+
+    RecordingsGetHandler handler;
+    @Mock AuthManager auth;
+    @Mock Path savedRecordingsPath;
+    @Mock FileSystem fs;
+    Gson gson = MainModule.provideGson();
+
+    @BeforeEach
+    void setup() {
+        this.handler = new RecordingsGetHandler(auth, savedRecordingsPath, fs, gson);
+    }
+
+    @Test
+    void shouldHandleGETRequest() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v1/recordings"));
+    }
+
+    @Test
+    void shouldRespondWith403IfDirectoryDoesNotExist() throws IOException {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+
+        Mockito.when(fs.exists(Mockito.any())).thenReturn(false);
+
+        HttpStatusException httpEx =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(httpEx.getStatusCode(), Matchers.equalTo(403));
+    }
+
+    @Test
+    void shouldResponseWith403IfDirectoryNotReadable() throws IOException {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+
+        Mockito.when(fs.exists(Mockito.any())).thenReturn(true);
+        Mockito.when(fs.isReadable(Mockito.any())).thenReturn(false);
+
+        HttpStatusException httpEx =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(httpEx.getStatusCode(), Matchers.equalTo(403));
+    }
+
+    @Test
+    void shouldRespondWith403IfPathNotDirectory() throws IOException {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+
+        Mockito.when(fs.exists(Mockito.any())).thenReturn(true);
+        Mockito.when(fs.isReadable(Mockito.any())).thenReturn(true);
+        Mockito.when(fs.isDirectory(Mockito.any())).thenReturn(false);
+
+        HttpStatusException httpEx =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(httpEx.getStatusCode(), Matchers.equalTo(403));
+    }
+
+    @Test
+    void shouldRespondWithInternalErrorIfExceptionThrown() throws IOException {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.response()).thenReturn(resp);
+
+        Mockito.when(fs.exists(Mockito.any())).thenReturn(true);
+        Mockito.when(fs.isReadable(Mockito.any())).thenReturn(true);
+        Mockito.when(fs.isDirectory(Mockito.any())).thenReturn(true);
+        Mockito.when(fs.listDirectoryChildren(Mockito.any())).thenThrow(IOException.class);
+
+        HttpStatusException httpEx =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(httpEx.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Test
+    void shouldRespondWithListOfFileNames() throws IOException {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.response()).thenReturn(resp);
+
+        Mockito.when(fs.exists(Mockito.any())).thenReturn(true);
+        Mockito.when(fs.isReadable(Mockito.any())).thenReturn(true);
+        Mockito.when(fs.isDirectory(Mockito.any())).thenReturn(true);
+        List<String> names = List.of("recordingA", "123recording");
+        Mockito.when(fs.listDirectoryChildren(Mockito.any())).thenReturn(names);
+
+        handler.handleAuthenticated(ctx);
+
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(resp).end(responseCaptor.capture());
+        MatcherAssert.assertThat(
+                gson.fromJson(responseCaptor.getValue(), List.class), Matchers.equalTo(names));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetEventsGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetEventsGetHandlerTest.java
@@ -1,0 +1,169 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.openjdk.jmc.flightrecorder.configuration.events.IEventTypeID;
+import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.jmc.serialization.SerializableEventTypeInfo;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TargetEventsGetHandlerTest {
+
+    TargetEventsGetHandler handler;
+    @Mock AuthManager auth;
+    @Mock TargetConnectionManager connectionManager;
+    Gson gson = MainModule.provideGson();
+
+    @BeforeEach
+    void setup() {
+        this.handler = new TargetEventsGetHandler(auth, connectionManager, gson);
+    }
+
+    @Test
+    void shouldHandleGETRequest() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(), Matchers.equalTo("/api/v1/targets/:targetId/events"));
+    }
+
+    @Test
+    void shouldRespondWithErrorIfExceptionThrown() throws Exception {
+        Mockito.when(connectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any()))
+                .thenThrow(new Exception("dummy exception"));
+
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
+
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Test
+    void shouldRespondWithEventsList() throws Exception {
+        JFRConnection connection = Mockito.mock(JFRConnection.class);
+        IFlightRecorderService service = Mockito.mock(IFlightRecorderService.class);
+
+        IEventTypeInfo event1 = Mockito.mock(IEventTypeInfo.class);
+        IEventTypeID eventTypeId1 = Mockito.mock(IEventTypeID.class);
+        Mockito.when(eventTypeId1.getFullKey()).thenReturn("com.example.foo");
+        Mockito.when(event1.getName()).thenReturn("foo");
+        Mockito.when(event1.getEventTypeID()).thenReturn(eventTypeId1);
+        Mockito.when(event1.getDescription()).thenReturn("Foo description");
+        Mockito.when(event1.getHierarchicalCategory()).thenReturn(new String[] {"com", "example"});
+        Mockito.when(event1.getOptionDescriptors()).thenReturn(Collections.emptyMap());
+
+        IEventTypeInfo event2 = Mockito.mock(IEventTypeInfo.class);
+        IEventTypeID eventTypeId2 = Mockito.mock(IEventTypeID.class);
+        Mockito.when(eventTypeId2.getFullKey()).thenReturn("com.example.bar");
+        Mockito.when(event2.getName()).thenReturn("bar");
+        Mockito.when(event2.getEventTypeID()).thenReturn(eventTypeId2);
+        Mockito.when(event2.getDescription()).thenReturn("Bar description");
+        Mockito.when(event2.getHierarchicalCategory()).thenReturn(new String[] {"com", "example"});
+        Mockito.when(event2.getOptionDescriptors()).thenReturn(Collections.emptyMap());
+
+        Collection events = Arrays.asList(event1, event2);
+
+        Mockito.when(connectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any()))
+                .thenAnswer(
+                        arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(connection));
+        Mockito.when(connection.getService()).thenReturn(service);
+        Mockito.when(service.getAvailableEventTypes()).thenReturn(events);
+
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.response()).thenReturn(resp);
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
+
+        handler.handleAuthenticated(ctx);
+
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(resp).end(responseCaptor.capture());
+        List<SerializableEventTypeInfo> result =
+                gson.fromJson(
+                        responseCaptor.getValue(),
+                        new TypeToken<List<SerializableEventTypeInfo>>() {}.getType());
+
+        MatcherAssert.assertThat(
+                result,
+                Matchers.equalTo(
+                        Arrays.asList(
+                                new SerializableEventTypeInfo(event1),
+                                new SerializableEventTypeInfo(event2))));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsGetHandlerTest.java
@@ -1,0 +1,206 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.QuantityConversionException;
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
+import com.redhat.rhjmc.containerjfr.net.web.WebServer;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TargetRecordingsGetHandlerTest {
+
+    TargetRecordingsGetHandler handler;
+    @Mock AuthManager auth;
+    @Mock TargetConnectionManager connectionManager;
+    @Mock WebServer webServer;
+    Gson gson = MainModule.provideGson();
+
+    @BeforeEach
+    void setup() {
+        this.handler =
+                new TargetRecordingsGetHandler(auth, connectionManager, () -> webServer, gson);
+    }
+
+    @Test
+    void shouldHandleGETRequest() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(), Matchers.equalTo("/api/v1/targets/:targetId/recordings"));
+    }
+
+    @Test
+    void shouldRespondWithErrorIfExceptionThrown() throws Exception {
+        Mockito.when(connectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any()))
+                .thenThrow(new Exception("dummy exception"));
+
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
+
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Test
+    void shouldRespondWithRecordingsList() throws Exception {
+        JFRConnection connection = Mockito.mock(JFRConnection.class);
+        IFlightRecorderService service = Mockito.mock(IFlightRecorderService.class);
+
+        Mockito.when(connectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any()))
+                .thenAnswer(
+                        arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(connection));
+        Mockito.when(connection.getService()).thenReturn(service);
+        Mockito.when(connection.getHost()).thenReturn("fooHost");
+        Mockito.when(connection.getPort()).thenReturn(1);
+        List<IRecordingDescriptor> descriptors =
+                Arrays.asList(createDescriptor("foo"), createDescriptor("bar"));
+        Mockito.when(service.getAvailableRecordings()).thenReturn(descriptors);
+        Mockito.when(
+                        webServer.getDownloadURL(
+                                Mockito.any(JFRConnection.class), Mockito.anyString()))
+                .thenAnswer(
+                        new Answer<String>() {
+                            @Override
+                            public String answer(InvocationOnMock invocation) throws Throwable {
+                                return String.format(
+                                        "http://example.com:1234/api/v1/targets/%s:%d/recordings/%s",
+                                        ((JFRConnection) invocation.getArguments()[0]).getHost(),
+                                        ((JFRConnection) invocation.getArguments()[0]).getPort(),
+                                        invocation.getArguments()[1]);
+                            }
+                        });
+        Mockito.when(webServer.getReportURL(Mockito.any(JFRConnection.class), Mockito.anyString()))
+                .thenAnswer(
+                        new Answer<String>() {
+                            @Override
+                            public String answer(InvocationOnMock invocation) throws Throwable {
+                                return String.format(
+                                        "http://example.com:1234/api/v1/targets/%s:%d/reports/%s",
+                                        ((JFRConnection) invocation.getArguments()[0]).getHost(),
+                                        ((JFRConnection) invocation.getArguments()[0]).getPort(),
+                                        invocation.getArguments()[1]);
+                            }
+                        });
+
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.response()).thenReturn(resp);
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
+
+        handler.handleAuthenticated(ctx);
+
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(resp).end(responseCaptor.capture());
+        List<HyperlinkedSerializableRecordingDescriptor> result =
+                gson.fromJson(
+                        responseCaptor.getValue(),
+                        new TypeToken<
+                                List<HyperlinkedSerializableRecordingDescriptor>>() {}.getType());
+
+        MatcherAssert.assertThat(
+                result,
+                Matchers.equalTo(
+                        Arrays.asList(
+                                new HyperlinkedSerializableRecordingDescriptor(
+                                        createDescriptor("foo"),
+                                        "http://example.com:1234/api/v1/targets/fooHost:1/recordings/foo",
+                                        "http://example.com:1234/api/v1/targets/fooHost:1/reports/foo"),
+                                new HyperlinkedSerializableRecordingDescriptor(
+                                        createDescriptor("bar"),
+                                        "http://example.com:1234/api/v1/targets/fooHost:1/recordings/bar",
+                                        "http://example.com:1234/api/v1/targets/fooHost:1/reports/bar"))));
+    }
+
+    private static IRecordingDescriptor createDescriptor(String name)
+            throws QuantityConversionException {
+        IQuantity zeroQuantity = Mockito.mock(IQuantity.class);
+        IRecordingDescriptor descriptor = Mockito.mock(IRecordingDescriptor.class);
+        Mockito.when(descriptor.getId()).thenReturn(1L);
+        Mockito.when(descriptor.getName()).thenReturn(name);
+        Mockito.when(descriptor.getState()).thenReturn(IRecordingDescriptor.RecordingState.STOPPED);
+        Mockito.when(descriptor.getStartTime()).thenReturn(zeroQuantity);
+        Mockito.when(descriptor.getDuration()).thenReturn(zeroQuantity);
+        Mockito.when(descriptor.isContinuous()).thenReturn(false);
+        Mockito.when(descriptor.getToDisk()).thenReturn(false);
+        Mockito.when(descriptor.getMaxSize()).thenReturn(zeroQuantity);
+        Mockito.when(descriptor.getMaxAge()).thenReturn(zeroQuantity);
+        return descriptor;
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplatesGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplatesGetHandlerTest.java
@@ -1,0 +1,148 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.commands.internal.AbstractRecordingCommand;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.templates.Template;
+import com.redhat.rhjmc.containerjfr.core.templates.TemplateService;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TargetTemplatesGetHandlerTest {
+
+    TargetTemplatesGetHandler handler;
+    @Mock AuthManager auth;
+    @Mock TargetConnectionManager connectionManager;
+    Gson gson = MainModule.provideGson();
+
+    @BeforeEach
+    void setup() {
+        this.handler = new TargetTemplatesGetHandler(auth, connectionManager, gson);
+    }
+
+    @Test
+    void shouldHandleGETRequest() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(), Matchers.equalTo("/api/v1/targets/:targetId/templates"));
+    }
+
+    @Test
+    void shouldRespondWithErrorIfExceptionThrown() throws Exception {
+        Mockito.when(connectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any()))
+                .thenThrow(new Exception("dummy exception"));
+
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
+
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Test
+    void shouldRespondWithTemplatesList() throws Exception {
+        JFRConnection connection = Mockito.mock(JFRConnection.class);
+        TemplateService templateService = Mockito.mock(TemplateService.class);
+
+        Template template1 = new Template("FooTemplate", "Template for foo-ing", "Test 1");
+        Template template2 = new Template("BarTemplate", "Template for bar-ing", "Test 2");
+
+        Mockito.when(connectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any()))
+                .thenAnswer(
+                        arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(connection));
+        Mockito.when(connection.getTemplateService()).thenReturn(templateService);
+        Mockito.when(templateService.getTemplates())
+                .thenReturn(Arrays.asList(template1, template2));
+
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.response()).thenReturn(resp);
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
+
+        handler.handleAuthenticated(ctx);
+
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(resp).end(responseCaptor.capture());
+        List<Template> result =
+                gson.fromJson(
+                        responseCaptor.getValue(), new TypeToken<List<Template>>() {}.getType());
+
+        MatcherAssert.assertThat(
+                result,
+                Matchers.equalTo(
+                        Arrays.asList(
+                                template1,
+                                template2,
+                                AbstractRecordingCommand.ALL_EVENTS_TEMPLATE)));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetsGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetsGetHandlerTest.java
@@ -1,0 +1,114 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.platform.PlatformClient;
+import com.redhat.rhjmc.containerjfr.platform.ServiceRef;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+
+@ExtendWith(MockitoExtension.class)
+class TargetsGetHandlerTest {
+
+    TargetsGetHandler handler;
+    @Mock AuthManager auth;
+    @Mock PlatformClient platformClient;
+    Gson gson = MainModule.provideGson();
+
+    @BeforeEach
+    void setup() {
+        this.handler = new TargetsGetHandler(auth, platformClient, gson);
+    }
+
+    @Test
+    void shouldHandleGETRequest() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v1/targets"));
+    }
+
+    @Test
+    void shouldReturnListOfTargets() {
+        ServiceRef target = new ServiceRef("foo", 1);
+        List<ServiceRef> targets = Collections.singletonList(target);
+        Mockito.when(platformClient.listDiscoverableServices()).thenReturn(targets);
+
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.response()).thenReturn(resp);
+
+        handler.handleAuthenticated(ctx);
+
+        Mockito.verify(ctx).response();
+        Mockito.verifyNoMoreInteractions(ctx);
+
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(resp).end(responseCaptor.capture());
+        Mockito.verifyNoMoreInteractions(resp);
+        List<ServiceRef> result =
+                gson.fromJson(
+                        responseCaptor.getValue(), new TypeToken<List<ServiceRef>>() {}.getType());
+        MatcherAssert.assertThat(result, Matchers.equalTo(targets));
+    }
+}


### PR DESCRIPTION
This adds HTTP API handlers for various paths with a GET verb, mirroring current WebSocket APIs (`scan-targets`, `list`, `list-saved`, `list-templates`, `list-event-types`). Those WebSocket APIs should be deprecated, although there is currently no defined way to mark them as such in the API responses. This helps bring the API closer to a typical HTTP REST design, moving further away from the original interactive execution mode that was initially implemented and is currently mirrored in the WebSocket command channel API.