### PR TITLE
Archive path should be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,12 @@ taking the contents of a recording at a point in time and saving these contents
 to a file local to the `container-jfr` process (as opposed to "active"
 recordings, which exist within the memory of the JVM target and continue to grow
 over time). The default directory used is `/flightrecordings`, but the environment
-variable `ARCHIVE_PATH` can be used to specify a different path. To enable 
-`container-jfr` archive support ensure that the directory specified by `ARCHIVE_PATH`
-(or `/flightrecordings` if not set) exists and has appropriate permissions. 
-`container-jfr` will detect the path and enable related functionality. `run.sh` has 
-an example of a `tmpfs` volume being mounted with the default path and enabling the 
-archive functionality.
+variable `CONTAINER_JFR_ARCHIVE_PATH` can be used to specify a different path. To 
+enable `container-jfr` archive support ensure that the directory specified by 
+`CONTAINER_JFR_ARCHIVE_PATH` (or `/flightrecordings` if not set) exists and has 
+appropriate permissions. `container-jfr` will detect the path and enable related 
+functionality. `run.sh` has an example of a `tmpfs` volume being mounted with the 
+default path and enabling the archive functionality.
 
 ## SECURING COMMUNICATION CHANNELS
 `container-jfr` can be optionally configured to secure HTTP and WebSocket

--- a/README.md
+++ b/README.md
@@ -181,11 +181,13 @@ deployments, port 9091 is expected for automatic port-scanning target discovery.
 taking the contents of a recording at a point in time and saving these contents
 to a file local to the `container-jfr` process (as opposed to "active"
 recordings, which exist within the memory of the JVM target and continue to grow
-over time). To enable `container-jfr` archive support ensure that the directory
-`/flightrecordings` exists and has appropriate permissions. `container-jfr` will
-automatically detect this path and enable related functionality. `run.sh` has an
-example of a `tmpfs` volume being mounted to this path and enabling the archive
-functionality.
+over time). The default directory used is `/flightrecordings`, but the environment
+variable `ARCHIVE_PATH` can be used to specify a different path. To enable 
+`container-jfr` archive support ensure that the directory specified by `ARCHIVE_PATH`
+(or `/flightrecordings` if not set) exists and has appropriate permissions. 
+`container-jfr` will detect the path and enable related functionality. `run.sh` has 
+an example of a `tmpfs` volume being mounted with the default path and enabling the 
+archive functionality.
 
 ## SECURING COMMUNICATION CHANNELS
 `container-jfr` can be optionally configured to secure HTTP and WebSocket

--- a/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
@@ -90,6 +90,8 @@ public abstract class MainModule {
     @Provides
     @Named(RECORDINGS_PATH)
     static Path provideSavedRecordingsPath(Logger logger, Environment env) {
-        return Paths.get(env.getEnv("CONTAINER_JFR_ARCHIVE_PATH", "/flightrecordings"));
+        String ARCHIVE_PATH = env.getEnv("CONTAINER_JFR_ARCHIVE_PATH", "/flightrecordings");
+        logger.info(String.format("Local save path for flight recordings set as %s", ARCHIVE_PATH));
+        return Paths.get(ARCHIVE_PATH);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
@@ -52,6 +52,7 @@ import com.google.gson.GsonBuilder;
 
 import com.redhat.rhjmc.containerjfr.commands.CommandsModule;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.net.web.WebModule;
 import com.redhat.rhjmc.containerjfr.platform.PlatformModule;
 import com.redhat.rhjmc.containerjfr.sys.SystemModule;
@@ -88,18 +89,7 @@ public abstract class MainModule {
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     @Provides
     @Named(RECORDINGS_PATH)
-    static Path provideSavedRecordingsPath() {
-        String ARCHIVE_PATH = null;
-        final Logger logger = provideLogger();
-        try {
-            ARCHIVE_PATH = System.getenv("ARCHIVE_PATH");
-        } catch (Exception SecurityException) {
-            logger.warn("Denied access to ARCHIVE_PATH env variable");
-        } finally {
-            if (ARCHIVE_PATH == null) {
-                ARCHIVE_PATH = "/flightrecordings";
-            }
-        }
-        return Paths.get(ARCHIVE_PATH);
+    static Path provideSavedRecordingsPath(Logger logger, Environment env) {
+        return Paths.get(env.getEnv("CONTAINER_JFR_ARCHIVE_PATH", "/flightrecordings"));
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
@@ -90,17 +90,16 @@ public abstract class MainModule {
     @Named(RECORDINGS_PATH)
     static Path provideSavedRecordingsPath() {
         String ARCHIVE_PATH = null;
-        final Logger logger = Logger.INSTANCE;
+        final Logger logger = provideLogger();
         try {
             ARCHIVE_PATH = System.getenv("ARCHIVE_PATH");
         } catch (Exception SecurityException) {
             logger.warn("Denied access to ARCHIVE_PATH env variable");
+        } finally {
+            if (ARCHIVE_PATH == null) {
+                ARCHIVE_PATH = "/flightrecordings";
+            }
         }
-
-        if (ARCHIVE_PATH == null) {
-            ARCHIVE_PATH = "/flightrecordings-test";
-        }
-
         return Paths.get(ARCHIVE_PATH);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
@@ -89,6 +89,18 @@ public abstract class MainModule {
     @Provides
     @Named(RECORDINGS_PATH)
     static Path provideSavedRecordingsPath() {
-        return Paths.get("/", "flightrecordings");
+        String ARCHIVE_PATH = null;
+        final Logger logger = Logger.INSTANCE;
+        try {
+            ARCHIVE_PATH = System.getenv("ARCHIVE_PATH");
+        } catch (Exception SecurityException) {
+            logger.warn("Denied access to ARCHIVE_PATH env variable");
+        }
+
+        if (ARCHIVE_PATH == null) {
+            ARCHIVE_PATH = "/flightrecordings-test";
+        }
+
+        return Paths.get(ARCHIVE_PATH);
     }
 }


### PR DESCRIPTION
Adds environment variable `ARCHIVE_PATH` which specifies path when saving flight recordings locally. If not set, the default path remains `/flightrecordings`. 