### PR TITLE
Replace Apache HttpClient with Vertx WebClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,11 +100,6 @@
     <version>${org.apache.httpcomponents.version}</version>
   </dependency>
   <dependency>
-    <groupId>org.apache.httpcomponents</groupId>
-    <artifactId>httpmime</artifactId>
-    <version>${org.apache.httpcomponents.version}</version>
-  </dependency>
-  <dependency>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-web</artifactId>
     <version>${io.vertx.web.version}</version>

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/HttpServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/HttpServer.java
@@ -68,11 +68,11 @@ public class HttpServer {
     private final io.vertx.core.http.HttpServer server;
     private volatile boolean isAlive;
 
-    HttpServer(NetworkConfiguration netConf, SslConfiguration sslConf, Logger logger) {
+    HttpServer(Vertx vertx, NetworkConfiguration netConf, SslConfiguration sslConf, Logger logger) {
+        this.vertx = vertx;
         this.netConf = netConf;
         this.sslConf = sslConf;
         this.logger = logger;
-        this.vertx = Vertx.vertx();
         this.server =
                 vertx.createHttpServer(
                         sslConf.applyToHttpServerOptions(

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/NetworkModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/NetworkModule.java
@@ -58,7 +58,6 @@ import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.IntoSet;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClientOptions;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
@@ -68,8 +67,8 @@ public abstract class NetworkModule {
     @Provides
     @Singleton
     static HttpServer provideHttpServer(
-            NetworkConfiguration netConf, SslConfiguration sslConf, Logger logger) {
-        return new HttpServer(netConf, sslConf, logger);
+            Vertx vertx, NetworkConfiguration netConf, SslConfiguration sslConf, Logger logger) {
+        return new HttpServer(vertx, netConf, sslConf, logger);
     }
 
     @Provides

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/NetworkModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/NetworkModule.java
@@ -41,22 +41,10 @@
  */
 package com.redhat.rhjmc.containerjfr.net;
 
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
+import java.net.SocketException;
+import java.net.UnknownHostException;
 
 import javax.inject.Singleton;
-
-import org.apache.http.config.Registry;
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.conn.socket.ConnectionSocketFactory;
-import org.apache.http.conn.socket.PlainConnectionSocketFactory;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustAllStrategy;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
-import org.apache.http.ssl.SSLContextBuilder;
 
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnectionToolkit;
@@ -69,6 +57,10 @@ import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.IntoSet;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
 
 @Module(includes = {ReportsModule.class})
 public abstract class NetworkModule {
@@ -100,30 +92,25 @@ public abstract class NetworkModule {
     }
 
     @Provides
-    static CloseableHttpClient provideHttpClient(NetworkConfiguration netConf) {
-        if (!netConf.isUntrustedSslAllowed()) {
-            return HttpClients.createMinimal(new BasicHttpClientConnectionManager());
-        }
+    @Singleton
+    static Vertx provideVertx() {
+        return Vertx.vertx();
+    }
 
+    @Provides
+    @Singleton
+    static WebClient provideWebClient(Vertx vertx, NetworkConfiguration netConf) {
         try {
-            SSLConnectionSocketFactory sslSocketFactory =
-                    new SSLConnectionSocketFactory(
-                            new SSLContextBuilder()
-                                    .loadTrustMaterial(null, new TrustAllStrategy())
-                                    .build(),
-                            SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
-
-            Registry<ConnectionSocketFactory> registry =
-                    RegistryBuilder.<ConnectionSocketFactory>create()
-                            .register("http", new PlainConnectionSocketFactory())
-                            .register("https", sslSocketFactory)
-                            .build();
-
-            return HttpClients.custom()
-                    .setSSLSocketFactory(sslSocketFactory)
-                    .setConnectionManager(new BasicHttpClientConnectionManager(registry))
-                    .build();
-        } catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
+            WebClientOptions opts =
+                    new WebClientOptions()
+                            .setSsl(true)
+                            .setDefaultHost(netConf.getWebServerHost())
+                            .setDefaultPort(netConf.getExternalWebServerPort());
+            if (!netConf.isUntrustedSslAllowed()) {
+                opts = opts.setTrustAll(true).setVerifyHost(false);
+            }
+            return WebClient.create(vertx, opts);
+        } catch (SocketException | UnknownHostException e) {
             throw new RuntimeException(e); // @Provides methods may only throw unchecked exceptions
         }
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -212,6 +212,8 @@ public class WebServer {
     }
 
     URI getHostUri() throws SocketException, UnknownHostException, URISyntaxException {
+        // FIXME replace URIBuilder with another implementation. This is the only remaining use
+        // of the Apache HttpComponents dependency
         return new URIBuilder()
                 .setScheme(server.isSsl() ? "https" : "http")
                 .setHost(netConf.getWebServerHost())

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
@@ -41,23 +41,18 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,7 +61,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
@@ -82,8 +79,14 @@ import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+
 @ExtendWith(MockitoExtension.class)
-@Disabled("TODO")
 class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordingName {
 
     static final String HOST_ID = "fooHost:9091";
@@ -94,7 +97,7 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock FileSystem fs;
     @Mock Path path;
-    @Mock CloseableHttpClient httpClient;
+    @Mock WebClient webClient;
     @Mock JFRConnection conn;
 
     @Override
@@ -109,9 +112,8 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
 
     @BeforeEach
     void setup() {
-        // this.command =
-        //         new UploadRecordingCommand(cw, targetConnectionManager, fs, path, () ->
-        // httpClient);
+        this.command =
+                new UploadRecordingCommand(cw, targetConnectionManager, fs, path, () -> webClient);
     }
 
     @Test
@@ -164,18 +166,20 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
             Mockito.when(conn.getService()).thenReturn(svc);
             Mockito.when(svc.getAvailableRecordings()).thenReturn(List.of(rec));
             Mockito.when(rec.getName()).thenReturn("foo");
-            Mockito.when(command.targetConnectionManager.connect(Mockito.anyString()))
-                    .thenReturn(conn);
             Mockito.when(svc.openStream(Mockito.any(), Mockito.anyBoolean())).thenReturn(stream);
 
-            // FIXME
-            // UploadRecordingCommand.RecordingConnection res =
-            //         command.getBestRecordingForName(HOST_ID, rec.getName());
+            Optional<Pair<Path, Boolean>> res =
+                    command.getBestRecordingForName(HOST_ID, rec.getName());
 
-            // Assertions.assertTrue(res.getStream().isPresent());
-            // Assertions.assertTrue(res.getConnection().isPresent());
-            // MatcherAssert.assertThat(res.getStream().get(), Matchers.sameInstance(stream));
-            // Mockito.verify(svc).openStream(rec, false);
+            Assertions.assertTrue(res.isPresent());
+            Assertions.assertNotNull(res.get().getLeft());
+            Assertions.assertTrue(res.get().getRight());
+            Mockito.verify(fs)
+                    .copy(
+                            Mockito.same(stream),
+                            Mockito.any(Path.class),
+                            Mockito.eq(StandardCopyOption.REPLACE_EXISTING));
+            Mockito.verify(svc).openStream(rec, false);
         }
 
         @Test
@@ -194,16 +198,13 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
             Mockito.when(path.resolve(Mockito.anyString())).thenReturn(rec);
             Mockito.when(fs.isRegularFile(rec)).thenReturn(true);
             Mockito.when(fs.isReadable(rec)).thenReturn(true);
-            Mockito.when(fs.newInputStream(rec)).thenReturn(stream);
 
-            // FIXME
-            // UploadRecordingCommand.RecordingConnection res =
-            //         command.getBestRecordingForName(HOST_ID, "foo");
+            Optional<Pair<Path, Boolean>> res = command.getBestRecordingForName(HOST_ID, "foo");
 
-            // Assertions.assertTrue(res.getStream().isPresent());
-            // Assertions.assertFalse(res.getConnection().isPresent());
-            // MatcherAssert.assertThat(
-            //         res.getStream().get(), Matchers.instanceOf(BufferedInputStream.class));
+            Assertions.assertTrue(res.isPresent());
+            Assertions.assertNotNull(res.get().getLeft());
+            Assertions.assertFalse(res.get().getRight());
+            MatcherAssert.assertThat(res.get().getLeft(), Matchers.sameInstance(rec));
         }
 
         @Test
@@ -221,12 +222,9 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
             Mockito.when(path.resolve(Mockito.anyString())).thenReturn(rec);
             Mockito.when(fs.isRegularFile(rec)).thenReturn(false);
 
-            // FIXME
-            // UploadRecordingCommand.RecordingConnection res =
-            //         command.getBestRecordingForName(HOST_ID, "foo");
+            Optional<Pair<Path, Boolean>> res = command.getBestRecordingForName(HOST_ID, "foo");
 
-            // Assertions.assertFalse(res.getStream().isPresent());
-            // Assertions.assertFalse(res.getConnection().isPresent());
+            Assertions.assertFalse(res.isPresent());
         }
 
         @Test
@@ -245,12 +243,9 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
             Mockito.when(fs.isRegularFile(rec)).thenReturn(true);
             Mockito.when(fs.isReadable(rec)).thenReturn(false);
 
-            // FIXME
-            // UploadRecordingCommand.RecordingConnection res =
-            //         command.getBestRecordingForName(HOST_ID, "foo");
+            Optional<Pair<Path, Boolean>> res = command.getBestRecordingForName(HOST_ID, "foo");
 
-            // Assertions.assertFalse(res.getStream().isPresent());
-            // Assertions.assertFalse(res.getConnection().isPresent());
+            Assertions.assertFalse(res.isPresent());
         }
     }
 
@@ -288,29 +283,36 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
             Mockito.when(conn.getService()).thenReturn(svc);
             Mockito.when(svc.getAvailableRecordings()).thenReturn(List.of(rec));
             Mockito.when(rec.getName()).thenReturn("foo");
-            Mockito.when(command.targetConnectionManager.connect(Mockito.anyString()))
-                    .thenReturn(conn);
             Mockito.when(svc.openStream(Mockito.any(), Mockito.anyBoolean())).thenReturn(stream);
 
-            CloseableHttpResponse httpResp = Mockito.mock(CloseableHttpResponse.class);
-            HttpEntity entity = Mockito.mock(HttpEntity.class);
-            StatusLine status = Mockito.mock(StatusLine.class);
-            Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResp);
-            Mockito.when(httpResp.getEntity()).thenReturn(entity);
-            Mockito.when(httpResp.getStatusLine()).thenReturn(status);
-            Mockito.when(status.toString()).thenReturn("status_line");
-            Mockito.when(entity.getContent())
-                    .thenReturn(new ByteArrayInputStream("entity_response".getBytes()));
+            HttpRequest<Buffer> req = Mockito.mock(HttpRequest.class);
+            HttpResponse<Buffer> resp = Mockito.mock(HttpResponse.class);
+            Mockito.when(webClient.postAbs(Mockito.anyString())).thenReturn(req);
+            Mockito.doAnswer(
+                            new Answer<Void>() {
+                                @Override
+                                public Void answer(InvocationOnMock args) throws Throwable {
+                                    AsyncResult<HttpResponse<Buffer>> asyncResult =
+                                            Mockito.mock(AsyncResult.class);
+                                    Mockito.when(asyncResult.result()).thenReturn(resp);
+                                    Mockito.when(resp.statusCode()).thenReturn(200);
+                                    Mockito.when(resp.statusMessage()).thenReturn("OK");
+                                    Mockito.when(resp.bodyAsString()).thenReturn("HELLO");
+                                    ((Handler<AsyncResult<HttpResponse<Buffer>>>)
+                                                    args.getArgument(1))
+                                            .handle(asyncResult);
+                                    return null;
+                                }
+                            })
+                    .when(req)
+                    .sendMultipartForm(Mockito.any(), Mockito.any());
 
             command.execute(new String[] {HOST_ID, "foo", UPLOAD_URL});
 
-            ArgumentCaptor<HttpUriRequest> captor = ArgumentCaptor.forClass(HttpUriRequest.class);
-            Mockito.verify(httpClient).execute(captor.capture());
-            MatcherAssert.assertThat(captor.getValue(), Matchers.instanceOf(HttpPost.class));
-            HttpPost post = (HttpPost) captor.getValue();
-            MatcherAssert.assertThat(post.getURI().toString(), Matchers.equalTo(UPLOAD_URL));
-            MatcherAssert.assertThat(post.getEntity(), Matchers.notNullValue());
-            Mockito.verify(cw).println("[status_line] entity_response");
+            ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+            Mockito.verify(webClient).postAbs(urlCaptor.capture());
+            MatcherAssert.assertThat(urlCaptor.getValue(), Matchers.equalTo(UPLOAD_URL));
+            Mockito.verify(cw).println("[200 OK] HELLO");
         }
     }
 
@@ -348,19 +350,29 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
             Mockito.when(conn.getService()).thenReturn(svc);
             Mockito.when(svc.getAvailableRecordings()).thenReturn(List.of(rec));
             Mockito.when(rec.getName()).thenReturn("foo");
-            Mockito.when(command.targetConnectionManager.connect(Mockito.anyString()))
-                    .thenReturn(conn);
             Mockito.when(svc.openStream(Mockito.any(), Mockito.anyBoolean())).thenReturn(stream);
 
-            CloseableHttpResponse httpResp = Mockito.mock(CloseableHttpResponse.class);
-            HttpEntity entity = Mockito.mock(HttpEntity.class);
-            StatusLine status = Mockito.mock(StatusLine.class);
-            Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResp);
-            Mockito.when(httpResp.getEntity()).thenReturn(entity);
-            Mockito.when(httpResp.getStatusLine()).thenReturn(status);
-            Mockito.when(status.toString()).thenReturn("status_line");
-            Mockito.when(entity.getContent())
-                    .thenReturn(new ByteArrayInputStream("entity_response".getBytes()));
+            HttpRequest<Buffer> req = Mockito.mock(HttpRequest.class);
+            HttpResponse<Buffer> resp = Mockito.mock(HttpResponse.class);
+            Mockito.when(webClient.postAbs(Mockito.anyString())).thenReturn(req);
+            Mockito.doAnswer(
+                            new Answer<Void>() {
+                                @Override
+                                public Void answer(InvocationOnMock args) throws Throwable {
+                                    AsyncResult<HttpResponse<Buffer>> asyncResult =
+                                            Mockito.mock(AsyncResult.class);
+                                    Mockito.when(asyncResult.result()).thenReturn(resp);
+                                    Mockito.when(resp.statusCode()).thenReturn(200);
+                                    Mockito.when(resp.statusMessage()).thenReturn("OK");
+                                    Mockito.when(resp.bodyAsString()).thenReturn("HELLO");
+                                    ((Handler<AsyncResult<HttpResponse<Buffer>>>)
+                                                    args.getArgument(1))
+                                            .handle(asyncResult);
+                                    return null;
+                                }
+                            })
+                    .when(req)
+                    .sendMultipartForm(Mockito.any(), Mockito.any());
 
             Output<?> out = command.serializableExecute(new String[] {HOST_ID, "foo", UPLOAD_URL});
 
@@ -370,16 +382,12 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
                     Matchers.allOf(
                             Matchers.startsWith("{"),
                             Matchers.endsWith("}"),
-                            Matchers.containsString("body=entity_response"),
-                            Matchers.containsString("status=status_line"),
-                            Matchers.containsString(", ")));
+                            Matchers.containsString("body=HELLO"),
+                            Matchers.containsString("status=200 OK")));
 
-            ArgumentCaptor<HttpUriRequest> captor = ArgumentCaptor.forClass(HttpUriRequest.class);
-            Mockito.verify(httpClient).execute(captor.capture());
-            MatcherAssert.assertThat(captor.getValue(), Matchers.instanceOf(HttpPost.class));
-            HttpPost post = (HttpPost) captor.getValue();
-            MatcherAssert.assertThat(post.getURI().toString(), Matchers.equalTo(UPLOAD_URL));
-            MatcherAssert.assertThat(post.getEntity(), Matchers.notNullValue());
+            ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+            Mockito.verify(webClient).postAbs(urlCaptor.capture());
+            MatcherAssert.assertThat(urlCaptor.getValue(), Matchers.equalTo(UPLOAD_URL));
         }
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
@@ -41,7 +41,6 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -58,6 +57,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -83,6 +83,7 @@ import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 
 @ExtendWith(MockitoExtension.class)
+@Disabled("TODO")
 class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordingName {
 
     static final String HOST_ID = "fooHost:9091";
@@ -108,8 +109,9 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
 
     @BeforeEach
     void setup() {
-        this.command =
-                new UploadRecordingCommand(cw, targetConnectionManager, fs, path, () -> httpClient);
+        // this.command =
+        //         new UploadRecordingCommand(cw, targetConnectionManager, fs, path, () ->
+        // httpClient);
     }
 
     @Test
@@ -166,13 +168,14 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
                     .thenReturn(conn);
             Mockito.when(svc.openStream(Mockito.any(), Mockito.anyBoolean())).thenReturn(stream);
 
-            UploadRecordingCommand.RecordingConnection res =
-                    command.getBestRecordingForName(HOST_ID, rec.getName());
+            // FIXME
+            // UploadRecordingCommand.RecordingConnection res =
+            //         command.getBestRecordingForName(HOST_ID, rec.getName());
 
-            Assertions.assertTrue(res.getStream().isPresent());
-            Assertions.assertTrue(res.getConnection().isPresent());
-            MatcherAssert.assertThat(res.getStream().get(), Matchers.sameInstance(stream));
-            Mockito.verify(svc).openStream(rec, false);
+            // Assertions.assertTrue(res.getStream().isPresent());
+            // Assertions.assertTrue(res.getConnection().isPresent());
+            // MatcherAssert.assertThat(res.getStream().get(), Matchers.sameInstance(stream));
+            // Mockito.verify(svc).openStream(rec, false);
         }
 
         @Test
@@ -193,13 +196,14 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
             Mockito.when(fs.isReadable(rec)).thenReturn(true);
             Mockito.when(fs.newInputStream(rec)).thenReturn(stream);
 
-            UploadRecordingCommand.RecordingConnection res =
-                    command.getBestRecordingForName(HOST_ID, "foo");
+            // FIXME
+            // UploadRecordingCommand.RecordingConnection res =
+            //         command.getBestRecordingForName(HOST_ID, "foo");
 
-            Assertions.assertTrue(res.getStream().isPresent());
-            Assertions.assertFalse(res.getConnection().isPresent());
-            MatcherAssert.assertThat(
-                    res.getStream().get(), Matchers.instanceOf(BufferedInputStream.class));
+            // Assertions.assertTrue(res.getStream().isPresent());
+            // Assertions.assertFalse(res.getConnection().isPresent());
+            // MatcherAssert.assertThat(
+            //         res.getStream().get(), Matchers.instanceOf(BufferedInputStream.class));
         }
 
         @Test
@@ -217,11 +221,12 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
             Mockito.when(path.resolve(Mockito.anyString())).thenReturn(rec);
             Mockito.when(fs.isRegularFile(rec)).thenReturn(false);
 
-            UploadRecordingCommand.RecordingConnection res =
-                    command.getBestRecordingForName(HOST_ID, "foo");
+            // FIXME
+            // UploadRecordingCommand.RecordingConnection res =
+            //         command.getBestRecordingForName(HOST_ID, "foo");
 
-            Assertions.assertFalse(res.getStream().isPresent());
-            Assertions.assertFalse(res.getConnection().isPresent());
+            // Assertions.assertFalse(res.getStream().isPresent());
+            // Assertions.assertFalse(res.getConnection().isPresent());
         }
 
         @Test
@@ -240,11 +245,12 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
             Mockito.when(fs.isRegularFile(rec)).thenReturn(true);
             Mockito.when(fs.isReadable(rec)).thenReturn(false);
 
-            UploadRecordingCommand.RecordingConnection res =
-                    command.getBestRecordingForName(HOST_ID, "foo");
+            // FIXME
+            // UploadRecordingCommand.RecordingConnection res =
+            //         command.getBestRecordingForName(HOST_ID, "foo");
 
-            Assertions.assertFalse(res.getStream().isPresent());
-            Assertions.assertFalse(res.getConnection().isPresent());
+            // Assertions.assertFalse(res.getStream().isPresent());
+            // Assertions.assertFalse(res.getConnection().isPresent());
         }
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/HealthGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/HealthGetHandlerTest.java
@@ -41,32 +41,24 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.Map;
 
-import javax.inject.Provider;
-
-import org.apache.http.StatusLine;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
@@ -75,24 +67,29 @@ import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
 
 @ExtendWith(MockitoExtension.class)
-@Disabled("TODO")
 class HealthGetHandlerTest {
 
     HealthGetHandler handler;
     Gson gson = MainModule.provideGson();
-    @Mock Provider<CloseableHttpClient> httpClientProvider;
+    @Mock WebClient webClient;
     @Mock Environment env;
     @Mock Logger logger;
 
     @BeforeEach
     void setup() {
-        //     this.handler = new HealthGetHandler(httpClientProvider, env, gson, logger);
+        this.handler = new HealthGetHandler(() -> webClient, env, gson, logger);
     }
 
     @Test
@@ -132,7 +129,7 @@ class HealthGetHandlerTest {
     }
 
     @Test
-    void shouldHandleHealthRequestWithDatasourceUrl() throws ClientProtocolException, IOException {
+    void shouldHandleHealthRequestWithDatasourceUrl() {
         RoutingContext ctx = mock(RoutingContext.class);
         HttpServerResponse rep = mock(HttpServerResponse.class);
         when(ctx.response()).thenReturn(rep);
@@ -143,14 +140,25 @@ class HealthGetHandlerTest {
         when(env.getEnv("GRAFANA_DATASOURCE_URL")).thenReturn(url);
         when(env.hasEnv("GRAFANA_DASHBOARD_URL")).thenReturn(false);
 
-        CloseableHttpResponse datasourceRep = mock(CloseableHttpResponse.class);
-        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
-        StatusLine mockLine = mock(StatusLine.class);
-
-        when(httpClientProvider.get()).thenReturn(httpClient);
-        when(httpClient.execute(any(HttpGet.class))).thenReturn(datasourceRep);
-        when(datasourceRep.getStatusLine()).thenReturn(mockLine);
-        when(mockLine.getStatusCode()).thenReturn(200);
+        HttpRequest<Buffer> req = Mockito.mock(HttpRequest.class);
+        HttpResponse<Buffer> resp = Mockito.mock(HttpResponse.class);
+        Mockito.when(webClient.getAbs(Mockito.anyString())).thenReturn(req);
+        Mockito.when(req.timeout(Mockito.anyLong())).thenReturn(req);
+        Mockito.doAnswer(
+                        new Answer<Void>() {
+                            @Override
+                            public Void answer(InvocationOnMock args) throws Throwable {
+                                AsyncResult<HttpResponse<Buffer>> asyncResult =
+                                        Mockito.mock(AsyncResult.class);
+                                Mockito.when(asyncResult.result()).thenReturn(resp);
+                                Mockito.when(resp.statusCode()).thenReturn(200);
+                                ((Handler<AsyncResult<HttpResponse<Buffer>>>) args.getArgument(0))
+                                        .handle(asyncResult);
+                                return null;
+                            }
+                        })
+                .when(req)
+                .send(Mockito.any());
 
         handler.handle(ctx);
 
@@ -167,7 +175,7 @@ class HealthGetHandlerTest {
     }
 
     @Test
-    void shouldHandleHealthRequestWithDashboardUrl() throws ClientProtocolException, IOException {
+    void shouldHandleHealthRequestWithDashboardUrl() {
         RoutingContext ctx = mock(RoutingContext.class);
         HttpServerResponse rep = mock(HttpServerResponse.class);
         when(ctx.response()).thenReturn(rep);
@@ -178,14 +186,25 @@ class HealthGetHandlerTest {
         when(env.getEnv("GRAFANA_DASHBOARD_URL")).thenReturn(url);
         when(env.hasEnv("GRAFANA_DATASOURCE_URL")).thenReturn(false);
 
-        CloseableHttpResponse grafanaRep = mock(CloseableHttpResponse.class);
-        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
-        StatusLine mockLine = mock(StatusLine.class);
-
-        when(httpClientProvider.get()).thenReturn(httpClient);
-        when(httpClient.execute(any(HttpGet.class))).thenReturn(grafanaRep);
-        when(grafanaRep.getStatusLine()).thenReturn(mockLine);
-        when(mockLine.getStatusCode()).thenReturn(200);
+        HttpRequest<Buffer> req = Mockito.mock(HttpRequest.class);
+        HttpResponse<Buffer> resp = Mockito.mock(HttpResponse.class);
+        Mockito.when(webClient.getAbs(Mockito.anyString())).thenReturn(req);
+        Mockito.when(req.timeout(Mockito.anyLong())).thenReturn(req);
+        Mockito.doAnswer(
+                        new Answer<Void>() {
+                            @Override
+                            public Void answer(InvocationOnMock args) throws Throwable {
+                                AsyncResult<HttpResponse<Buffer>> asyncResult =
+                                        Mockito.mock(AsyncResult.class);
+                                Mockito.when(asyncResult.result()).thenReturn(resp);
+                                Mockito.when(resp.statusCode()).thenReturn(200);
+                                ((Handler<AsyncResult<HttpResponse<Buffer>>>) args.getArgument(0))
+                                        .handle(asyncResult);
+                                return null;
+                            }
+                        })
+                .when(req)
+                .send(Mockito.any());
 
         handler.handle(ctx);
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/HealthGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/HealthGetHandlerTest.java
@@ -60,6 +60,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -80,6 +81,7 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 
 @ExtendWith(MockitoExtension.class)
+@Disabled("TODO")
 class HealthGetHandlerTest {
 
     HealthGetHandler handler;
@@ -90,7 +92,7 @@ class HealthGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new HealthGetHandler(httpClientProvider, env, gson, logger);
+        //     this.handler = new HealthGetHandler(httpClientProvider, env, gson, logger);
     }
 
     @Test


### PR DESCRIPTION
This PR is based on top of #164 , since that already previously introduced the Vertx WebClient dependency. Only the most recent five commits are specific to this PR.

The goal here is to remove the usage of the Apache HttpComponents HttpClient since it overlaps with the Vertx WebClient (or Vertx HttpClient). There is no need for both to be used in the project, and since we have a stronger dependency on Vertx for our webserver it makes sense to standardize on that.

There is one remaining use of an Apache URIBuilder class which comes from the HttpComponents dependency, but this has been deferred from this PR as it isn't as simple to fix as it sounds. A suitable replacement which properly escapes path parameters is needed, which may be a custom implementation or supplied by another dependency to be determined later.