### PR TITLE
Fix intermittent print URL bug

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
@@ -156,7 +156,7 @@ class ListCommand extends AbstractConnectedCommand implements SerializableComman
         for (Method m : methods) {
             if (m.getParameterTypes().length == 0
                     && (m.getName().startsWith("get") || m.getName().startsWith("is"))) {
-                if (m.getName().contains("Url")) {
+                if (m.getName().toLowerCase().contains("url")) {
                     urls.add(String.format("\t%s\t\t%s%n", m.getName(), m.invoke(descriptor)));
                 } else {
                     sb.append(String.format("\t%s\t\t%s%n", m.getName(), m.invoke(descriptor)));

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
@@ -44,6 +44,7 @@ package com.redhat.rhjmc.containerjfr.commands.internal;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -150,17 +151,22 @@ class ListCommand extends AbstractConnectedCommand implements SerializableComman
                 ArrayUtils.addAll(
                         descriptor.getClass().getSuperclass().getDeclaredMethods(),
                         descriptor.getClass().getDeclaredMethods());
+
+        List<String> urls = new ArrayList<String>();
         for (Method m : methods) {
             if (m.getParameterTypes().length == 0
                     && (m.getName().startsWith("get") || m.getName().startsWith("is"))) {
-                sb.append("\t");
-                sb.append(m.getName());
-
-                sb.append("\t\t");
-                sb.append(m.invoke(descriptor));
-
-                sb.append("\n");
+                if (m.getName().contains("Url")) {
+                    urls.add(String.format("\t%s\t\t%s%n", m.getName(), m.invoke(descriptor)));
+                } else {
+                    sb.append(String.format("\t%s\t\t%s%n", m.getName(), m.invoke(descriptor)));
+                }
             }
+        }
+
+        Collections.sort(urls);
+        for (String s : urls) {
+            sb.append(s);
         }
 
         return sb.toString();

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommand.java
@@ -143,7 +143,7 @@ class ListSavedRecordingsCommand implements SerializableCommand {
         for (Method m : methods) {
             if (m.getParameterTypes().length == 0
                     && (m.getName().startsWith("get") || m.getName().startsWith("is"))) {
-                if (m.getName().contains("Url")) {
+                if (m.getName().toLowerCase().contains("url")) {
                     urls.add(String.format("\t%s\t\t%s%n", m.getName(), m.invoke(descriptor)));
                 } else {
                     sb.append(String.format("\t%s\t\t%s%n", m.getName(), m.invoke(descriptor)));

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommand.java
@@ -46,6 +46,7 @@ import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -137,17 +138,22 @@ class ListSavedRecordingsCommand implements SerializableCommand {
     private static String toString(SavedRecordingDescriptor descriptor) throws Exception {
         StringBuilder sb = new StringBuilder();
         Method[] methods = ArrayUtils.addAll(descriptor.getClass().getDeclaredMethods());
+
+        List<String> urls = new ArrayList<String>();
         for (Method m : methods) {
             if (m.getParameterTypes().length == 0
                     && (m.getName().startsWith("get") || m.getName().startsWith("is"))) {
-                sb.append("\t");
-                sb.append(m.getName());
-
-                sb.append("\t\t");
-                sb.append(m.invoke(descriptor));
-
-                sb.append("\n");
+                if (m.getName().contains("Url")) {
+                    urls.add(String.format("\t%s\t\t%s%n", m.getName(), m.invoke(descriptor)));
+                } else {
+                    sb.append(String.format("\t%s\t\t%s%n", m.getName(), m.invoke(descriptor)));
+                }
             }
+        }
+
+        Collections.sort(urls);
+        for (String s : urls) {
+            sb.append(s);
         }
 
         return sb.toString();

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommandTest.java
@@ -151,7 +151,7 @@ class ListCommandTest implements ValidatesTargetId {
     }
 
     @Test
-    void shouldPrintDownloadAndReportURL() throws Exception {
+    void shouldPrintDownloadURL() throws Exception {
         when(targetConnectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any()))
                 .thenAnswer(
                         arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(connection));
@@ -173,6 +173,31 @@ class ListCommandTest implements ValidatesTargetId {
                                         invocation.getArguments()[1]);
                             }
                         });
+
+        command.execute(new String[] {"foo:9091"});
+        InOrder inOrder = inOrder(cw);
+        inOrder.verify(cw).println("Available recordings:");
+        inOrder.verify(cw)
+                .println(
+                        Mockito.contains(
+                                "\tgetDownloadUrl\t\thttp://example.com:1234/api/v1/targets/fooHost:1/recordings/foo"));
+        inOrder.verify(cw)
+                .println(
+                        Mockito.contains(
+                                "\tgetDownloadUrl\t\thttp://example.com:1234/api/v1/targets/fooHost:1/recordings/bar"));
+    }
+
+    @Test
+    void shouldPrintReportURL() throws Exception {
+        when(targetConnectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any()))
+                .thenAnswer(
+                        arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(connection));
+        when(connection.getService()).thenReturn(service);
+        when(connection.getHost()).thenReturn("fooHost");
+        when(connection.getPort()).thenReturn(1);
+        List<IRecordingDescriptor> descriptors =
+                Arrays.asList(createDescriptor("foo"), createDescriptor("bar"));
+        when(service.getAvailableRecordings()).thenReturn(descriptors);
         when(exporter.getReportURL(Mockito.any(JFRConnection.class), Mockito.anyString()))
                 .thenAnswer(
                         new Answer<String>() {
@@ -191,13 +216,11 @@ class ListCommandTest implements ValidatesTargetId {
         inOrder.verify(cw)
                 .println(
                         Mockito.contains(
-                                "\tgetDownloadUrl\t\thttp://example.com:1234/api/v1/targets/fooHost:1/recordings/foo\n"
-                                        + "\tgetReportUrl\t\thttp://example.com:1234/api/v1/targets/fooHost:1/reports/foo"));
+                                "\tgetReportUrl\t\thttp://example.com:1234/api/v1/targets/fooHost:1/reports/foo"));
         inOrder.verify(cw)
                 .println(
                         Mockito.contains(
-                                "\tgetDownloadUrl\t\thttp://example.com:1234/api/v1/targets/fooHost:1/recordings/bar\n"
-                                        + "\tgetReportUrl\t\thttp://example.com:1234/api/v1/targets/fooHost:1/reports/bar"));
+                                "\tgetReportUrl\t\thttp://example.com:1234/api/v1/targets/fooHost:1/reports/bar"));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommandTest.java
@@ -142,7 +142,7 @@ class ListSavedRecordingsCommandTest {
     }
 
     @Test
-    void shouldPrintURLs() throws Exception {
+    void shouldPrintDownloadURL() throws Exception {
         when(fs.listDirectoryChildren(recordingsPath)).thenReturn(Arrays.asList("foo", "bar"));
         when(exporter.getArchivedDownloadURL(Mockito.anyString()))
                 .thenAnswer(
@@ -154,6 +154,24 @@ class ListSavedRecordingsCommandTest {
                                         invocation.getArguments()[0]);
                             }
                         });
+
+        command.execute(new String[0]);
+
+        InOrder inOrder = inOrder(cw);
+        inOrder.verify(cw).println("Saved recordings:");
+        inOrder.verify(cw)
+                .println(
+                        Mockito.contains(
+                                "\tgetDownloadUrl\t\thttp://example.com:1234/api/v1/recordings/foo"));
+        inOrder.verify(cw)
+                .println(
+                        Mockito.contains(
+                                "\tgetDownloadUrl\t\thttp://example.com:1234/api/v1/recordings/bar"));
+    }
+
+    @Test
+    void shouldPrintReportURL() throws Exception {
+        when(fs.listDirectoryChildren(recordingsPath)).thenReturn(Arrays.asList("foo", "bar"));
         when(exporter.getArchivedReportURL(Mockito.anyString()))
                 .thenAnswer(
                         new Answer<String>() {
@@ -172,13 +190,11 @@ class ListSavedRecordingsCommandTest {
         inOrder.verify(cw)
                 .println(
                         Mockito.contains(
-                                "\tgetDownloadUrl\t\thttp://example.com:1234/api/v1/recordings/foo\n"
-                                        + "\tgetReportUrl\t\thttp://example.com:1234/api/v1/reports/foo"));
+                                "\tgetReportUrl\t\thttp://example.com:1234/api/v1/reports/foo"));
         inOrder.verify(cw)
                 .println(
                         Mockito.contains(
-                                "\tgetDownloadUrl\t\thttp://example.com:1234/api/v1/recordings/bar\n"
-                                        + "\tgetReportUrl\t\thttp://example.com:1234/api/v1/reports/bar"));
+                                "\tgetReportUrl\t\thttp://example.com:1234/api/v1/reports/bar"));
     }
 
     @Test


### PR DESCRIPTION
By strictly enforcing the order in which they print it seems to not fail the tests anymore.