### PR TITLE
Custom Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,13 @@ deployments, port 9091 is expected for automatic port-scanning target discovery.
 
 ## EVENT TEMPLATES
 
-JDK Flight Recorder has a concept of "event templates", which are a sort of
-preset definition of a set of events, and for each a set of options and option
-values. A given JVM is likely to have some built-in templates ready for use
-out-of-the-box, but ContainerJFR also hosts its own small catalog of templates
-within its own local storage. This catalog is stored at the path specified by
-the environment variable `CONTAINER_JFR_TEMPLATE_PATH`. Templates can be
-uploaded to ContainerJFR and then used to create recordings.
+JDK Flight Recorder has event templates, which are preset definition of a set of
+events, and for each a set of options and option values. A given JVM is likely
+to have some built-in templates ready for use out-of-the-box, but ContainerJFR
+also hosts its own small catalog of templates within its own local storage. This
+catalog is stored at the path specified by the environment variable
+`CONTAINER_JFR_TEMPLATE_PATH`. Templates can be uploaded to ContainerJFR and
+then used to create recordings.
 
 ## ARCHIVING RECORDINGS
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ number and the deployment network configuration allows connections on the
 configured port. As noted above, the final caveat is that in non-Kube
 deployments, port 9091 is expected for automatic port-scanning target discovery.
 
+## EVENT TEMPLATES
+
+JDK Flight Recorder has a concept of "event templates", which are a sort of
+preset definition of a set of events, and for each a set of options and option
+values. A given JVM is likely to have some built-in templates ready for use
+out-of-the-box, but ContainerJFR also hosts its own small catalog of templates
+within its own local storage. This catalog is stored at the path specified by
+the environment variable `CONTAINER_JFR_TEMPLATE_PATH`. Templates can be
+uploaded to ContainerJFR and then used to create recordings.
+
 ## ARCHIVING RECORDINGS
 
 `container-jfr` supports a concept of "archiving" recordings. This simply means
@@ -182,11 +192,11 @@ taking the contents of a recording at a point in time and saving these contents
 to a file local to the `container-jfr` process (as opposed to "active"
 recordings, which exist within the memory of the JVM target and continue to grow
 over time). The default directory used is `/flightrecordings`, but the environment
-variable `CONTAINER_JFR_ARCHIVE_PATH` can be used to specify a different path. To 
-enable `container-jfr` archive support ensure that the directory specified by 
-`CONTAINER_JFR_ARCHIVE_PATH` (or `/flightrecordings` if not set) exists and has 
-appropriate permissions. `container-jfr` will detect the path and enable related 
-functionality. `run.sh` has an example of a `tmpfs` volume being mounted with the 
+variable `CONTAINER_JFR_ARCHIVE_PATH` can be used to specify a different path. To
+enable `container-jfr` archive support ensure that the directory specified by
+`CONTAINER_JFR_ARCHIVE_PATH` (or `/flightrecordings` if not set) exists and has
+appropriate permissions. `container-jfr` will detect the path and enable related
+functionality. `run.sh` has an example of a `tmpfs` volume being mounted with the
 default path and enabling the archive functionality.
 
 ## SECURING COMMUNICATION CHANNELS

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@
       <artifactId>caffeine</artifactId>
       <version>${com.github.ben-manes.caffeine.version}</version>
   </dependency>
+  <dependency>
+    <groupId>org.jsoup</groupId>
+    <artifactId>jsoup</artifactId>
+    <version>${org.jsoup.version}</version>
+  </dependency>
 
   <!-- test deps -->
   <dependency>
@@ -160,12 +165,6 @@
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs-annotations</artifactId>
     <version>${com.github.spotbugs.version}</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jsoup</groupId>
-    <artifactId>jsoup</artifactId>
-    <version>${org.jsoup.version}</version>
-    <scope>test</scope>
   </dependency>
 </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
   <com.google.dagger.version>2.26</com.google.dagger.version>
 
-  <com.redhat.rhjmc.containerjfr.core.version>0.12.3</com.redhat.rhjmc.containerjfr.core.version>
+  <com.redhat.rhjmc.containerjfr.core.version>0.13.0</com.redhat.rhjmc.containerjfr.core.version>
 
   <org.apache.commons.lang3.version>3.9</org.apache.commons.lang3.version>
   <org.apache.commons.codec.version>1.13</org.apache.commons.codec.version>

--- a/run.sh
+++ b/run.sh
@@ -41,7 +41,6 @@ if [ -z "$CONTAINER_JFR_AUTH_MANAGER" ]; then
     CONTAINER_JFR_AUTH_MANAGER="com.redhat.rhjmc.containerjfr.net.NoopAuthManager"
 fi
 
-
 podman run \
     --hostname container-jfr \
     --name container-jfr \

--- a/run.sh
+++ b/run.sh
@@ -41,10 +41,12 @@ if [ -z "$CONTAINER_JFR_AUTH_MANAGER" ]; then
     CONTAINER_JFR_AUTH_MANAGER="com.redhat.rhjmc.containerjfr.net.NoopAuthManager"
 fi
 
+
 podman run \
     --hostname container-jfr \
     --name container-jfr \
     --mount type=tmpfs,target=/flightrecordings \
+    --mount type=tmpfs,target=/templates \
     -p 9091:9091 \
     -p $CONTAINER_JFR_EXT_LISTEN_PORT:$CONTAINER_JFR_LISTEN_PORT \
     -p $CONTAINER_JFR_EXT_WEB_PORT:$CONTAINER_JFR_WEB_PORT \
@@ -57,6 +59,8 @@ podman run \
     -e CONTAINER_JFR_LISTEN_PORT=$CONTAINER_JFR_LISTEN_PORT \
     -e CONTAINER_JFR_EXT_LISTEN_PORT=$CONTAINER_JFR_EXT_LISTEN_PORT \
     -e CONTAINER_JFR_AUTH_MANAGER=$CONTAINER_JFR_AUTH_MANAGER \
+    -e CONTAINER_JFR_ARCHIVE_PATH="/flightrecordings" \
+    -e CONTAINER_JFR_TEMPLATE_PATH="/templates" \
     -e GRAFANA_DATASOURCE_URL=$GRAFANA_DATASOURCE_URL \
     -e GRAFANA_DASHBOARD_URL=$GRAFANA_DASHBOARD_URL \
     -e USE_LOW_MEM_PRESSURE_STREAMING=$USE_LOW_MEM_PRESSURE_STREAMING \

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommand.java
@@ -90,7 +90,10 @@ public abstract class AbstractRecordingCommand extends AbstractConnectedCommand 
             if (ALL_EVENTS_TEMPLATE.getName().equals(templateName)) {
                 return enableAllEvents(connection);
             }
-            return connection.getTemplateService().getEventsByTemplateName(templateName);
+            return connection
+                    .getTemplateService()
+                    .getEventsByTemplateName(templateName)
+                    .orElseThrow(() -> new IllegalArgumentException(templateName));
         }
 
         return enableSelectedEvents(connection, events);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommand.java
@@ -50,6 +50,7 @@ import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
 
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.templates.Template;
+import com.redhat.rhjmc.containerjfr.core.templates.TemplateType;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 
@@ -60,7 +61,8 @@ public abstract class AbstractRecordingCommand extends AbstractConnectedCommand 
             new Template(
                     "ALL",
                     "Enable all available events in the target JVM, with default option values. This will be very expensive and is intended primarily for testing ContainerJFR's own capabilities.",
-                    "ContainerJFR");
+                    "ContainerJFR",
+                    TemplateType.TARGET);
 
     private static final Pattern TEMPLATE_PATTERN = Pattern.compile("^template=([\\w]+)$");
     private static final Pattern EVENTS_PATTERN =

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommand.java
@@ -79,6 +79,8 @@ class ListEventTemplatesCommand extends AbstractConnectedCommand implements Seri
                 args[0],
                 connection -> {
                     cw.println("Available recording templates:");
+                    // TODO format printed output to include template types as "headers" or row
+                    // labels
                     getTemplates(connection)
                             .forEach(
                                     template ->

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/NetworkModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/NetworkModule.java
@@ -86,8 +86,9 @@ public abstract class NetworkModule {
 
     @Provides
     @Singleton
-    static TargetConnectionManager provideTargetConnectionManager(Logger logger, ClientWriter cw) {
-        return new TargetConnectionManager(logger, new JFRConnectionToolkit(cw));
+    static TargetConnectionManager provideTargetConnectionManager(
+            Logger logger, ClientWriter cw, FileSystem fs, Environment env) {
+        return new TargetConnectionManager(logger, new JFRConnectionToolkit(cw, fs, env));
     }
 
     @Provides

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/HttpMimeType.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/HttpMimeType.java
@@ -45,7 +45,8 @@ public enum HttpMimeType {
     PLAINTEXT("text/plain"),
     HTML("text/html"),
     JSON("application/json"),
-    OCTET_STREAM("application/octet-stream");
+    OCTET_STREAM("application/octet-stream"),
+    JFC("application/jfc+xml");
 
     private final String mime;
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -138,7 +138,7 @@ public class WebServer {
 
                     ctx.response()
                             .setStatusCode(exception.getStatusCode())
-                            .setStatusMessage(exception.getMessage());
+                            .setStatusMessage(payload);
 
                     String accept = ctx.request().getHeader(HttpHeaders.ACCEPT);
                     if (accept.contains(HttpMimeType.JSON.mime())

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandler.java
@@ -65,6 +65,7 @@ class CorsEnablingHandler implements RequestHandler {
                         .allowedMethod(HttpMethod.POST)
                         .allowedMethod(HttpMethod.OPTIONS)
                         .allowedMethod(HttpMethod.HEAD)
+                        .allowedMethod(HttpMethod.DELETE)
                         .allowCredentials(true)
                         .exposedHeader(WebServer.AUTH_SCHEME_HEADER);
         this.env = env;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -128,6 +128,10 @@ public abstract class RequestHandlersModule {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindTargetTemplateGetHandler(TargetTemplateGetHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindTemplatesBodyHandler(TemplatesBodyHandler handler);
 
     @Binds
@@ -136,7 +140,7 @@ public abstract class RequestHandlersModule {
 
     @Binds
     @IntoSet
-    abstract RequestHandler bindTargetTemplateGetHandler(TargetTemplateGetHandler handler);
+    abstract RequestHandler bindTemplateDeleteHandler(TemplateDeleteHandler handler);
 
     @Binds
     @IntoSet

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -128,5 +128,17 @@ public abstract class RequestHandlersModule {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindTemplatesBodyHandler(TemplatesBodyHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTemplatesPostHandler(TemplatesPostHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTargetTemplateGetHandler(TargetTemplateGetHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindTargetEventsGetHandler(TargetEventsGetHandler handler);
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandler.java
@@ -1,0 +1,104 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import javax.inject.Inject;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class TargetTemplateGetHandler extends AbstractAuthenticatedRequestHandler {
+
+    private final TargetConnectionManager targetConnectionManager;
+    private final Logger logger;
+
+    @Inject
+    TargetTemplateGetHandler(
+            AuthManager auth, TargetConnectionManager targetConnectionManager, Logger logger) {
+        super(auth);
+        this.targetConnectionManager = targetConnectionManager;
+        this.logger = logger;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/targets/:targetId/templates/:templateName";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        String targetId = ctx.pathParam("targetId");
+        String templateName = ctx.pathParam("templateName");
+        try {
+            targetConnectionManager
+                    .executeConnectedTask(
+                            targetId, conn -> conn.getTemplateService().getXml(templateName))
+                    .ifPresentOrElse(
+                            doc -> {
+                                ctx.response()
+                                        .putHeader(
+                                                HttpHeaders.CONTENT_TYPE, HttpMimeType.JFC.mime());
+                                ctx.response().end(doc.toString());
+                            },
+                            () -> {
+                                throw new HttpStatusException(404);
+                            });
+        } catch (HttpStatusException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.warn(e);
+            throw new HttpStatusException(500, e);
+        }
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandler.java
@@ -44,6 +44,7 @@ package com.redhat.rhjmc.containerjfr.net.web.handlers;
 import javax.inject.Inject;
 
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.templates.TemplateType;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
@@ -73,17 +74,19 @@ class TargetTemplateGetHandler extends AbstractAuthenticatedRequestHandler {
 
     @Override
     public String path() {
-        return "/api/v1/targets/:targetId/templates/:templateName";
+        return "/api/v1/targets/:targetId/templates/:templateName/type/:templateType";
     }
 
     @Override
     void handleAuthenticated(RoutingContext ctx) {
         String targetId = ctx.pathParam("targetId");
         String templateName = ctx.pathParam("templateName");
+        TemplateType templateType = TemplateType.valueOf(ctx.pathParam("templateType"));
         try {
             targetConnectionManager
                     .executeConnectedTask(
-                            targetId, conn -> conn.getTemplateService().getXml(templateName))
+                            targetId,
+                            conn -> conn.getTemplateService().getXml(templateName, templateType))
                     .ifPresentOrElse(
                             doc -> {
                                 ctx.response()

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplateDeleteHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplateDeleteHandler.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import javax.inject.Inject;
 
 import com.redhat.rhjmc.containerjfr.core.templates.LocalStorageTemplateService;
+import com.redhat.rhjmc.containerjfr.core.templates.MutableTemplateService.InvalidEventTemplateException;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 
 import io.vertx.core.http.HttpMethod;
@@ -79,7 +80,9 @@ class TemplateDeleteHandler extends AbstractAuthenticatedRequestHandler {
             this.templateService.deleteTemplate(templateName);
             ctx.response().end();
         } catch (IOException ioe) {
-            throw new HttpStatusException(500, ioe);
+            throw new HttpStatusException(500, ioe.getMessage(), ioe);
+        } catch (InvalidEventTemplateException iete) {
+            throw new HttpStatusException(400, iete.getMessage(), iete);
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplateDeleteHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplateDeleteHandler.java
@@ -1,0 +1,85 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+import com.redhat.rhjmc.containerjfr.core.templates.LocalStorageTemplateService;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class TemplateDeleteHandler extends AbstractAuthenticatedRequestHandler {
+
+    private final LocalStorageTemplateService templateService;
+
+    @Inject
+    TemplateDeleteHandler(AuthManager auth, LocalStorageTemplateService templateService) {
+        super(auth);
+        this.templateService = templateService;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.DELETE;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/templates/:templateName";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        String templateName = ctx.pathParam("templateName");
+        try {
+            this.templateService.deleteTemplate(templateName);
+            ctx.response().end();
+        } catch (IOException ioe) {
+            throw new HttpStatusException(500, ioe);
+        }
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesBodyHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesBodyHandler.java
@@ -39,62 +39,42 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr;
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import javax.inject.Inject;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
 
-import com.redhat.rhjmc.containerjfr.commands.CommandsModule;
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
-import com.redhat.rhjmc.containerjfr.core.sys.Environment;
-import com.redhat.rhjmc.containerjfr.net.web.WebModule;
-import com.redhat.rhjmc.containerjfr.platform.PlatformModule;
-import com.redhat.rhjmc.containerjfr.sys.SystemModule;
-import com.redhat.rhjmc.containerjfr.templates.TemplatesModule;
-import com.redhat.rhjmc.containerjfr.tui.TuiModule;
+class TemplatesBodyHandler extends AbstractAuthenticatedRequestHandler {
 
-import dagger.Module;
-import dagger.Provides;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+    static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
 
-@Module(
-        includes = {
-            PlatformModule.class,
-            WebModule.class,
-            SystemModule.class,
-            CommandsModule.class,
-            TuiModule.class,
-            TemplatesModule.class,
-        })
-public abstract class MainModule {
-    public static final String RECORDINGS_PATH = "RECORDINGS_PATH";
-
-    @Provides
-    @Singleton
-    static Logger provideLogger() {
-        return Logger.INSTANCE;
+    @Inject
+    TemplatesBodyHandler(AuthManager auth) {
+        super(auth);
     }
 
-    // public since this is useful to use directly in tests
-    @Provides
-    @Singleton
-    public static Gson provideGson() {
-        return new GsonBuilder().serializeNulls().disableHtmlEscaping().create();
+    @Override
+    public int getPriority() {
+        return DEFAULT_PRIORITY - 1;
     }
 
-    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
-    @Provides
-    @Singleton
-    @Named(RECORDINGS_PATH)
-    static Path provideSavedRecordingsPath(Logger logger, Environment env) {
-        String ARCHIVE_PATH = env.getEnv("CONTAINER_JFR_ARCHIVE_PATH", "/flightrecordings");
-        logger.info(String.format("Local save path for flight recordings set as %s", ARCHIVE_PATH));
-        return Paths.get(ARCHIVE_PATH);
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/templates";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        BODY_HANDLER.handle(ctx);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandler.java
@@ -105,9 +105,9 @@ class TemplatesPostHandler extends AbstractAuthenticatedRequestHandler {
                 }
             }
         } catch (IOException ioe) {
-            throw new HttpStatusException(500, ioe);
+            throw new HttpStatusException(500, ioe.getMessage(), ioe);
         } catch (InvalidXmlException | InvalidEventTemplateException e) {
-            throw new HttpStatusException(400, e);
+            throw new HttpStatusException(400, e.getMessage(), e);
         }
         ctx.response().end();
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandler.java
@@ -1,0 +1,114 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+import javax.inject.Inject;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.core.templates.LocalStorageTemplateService;
+import com.redhat.rhjmc.containerjfr.core.templates.MutableTemplateService.InvalidEventTemplateException;
+import com.redhat.rhjmc.containerjfr.core.templates.MutableTemplateService.InvalidXmlException;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class TemplatesPostHandler extends AbstractAuthenticatedRequestHandler {
+
+    private final LocalStorageTemplateService templateService;
+    private final FileSystem fs;
+    private final Logger logger;
+
+    @Inject
+    TemplatesPostHandler(
+            AuthManager auth,
+            LocalStorageTemplateService templateService,
+            FileSystem fs,
+            Logger logger) {
+        super(auth);
+        this.templateService = templateService;
+        this.fs = fs;
+        this.logger = logger;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/templates";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        try {
+            for (FileUpload u : ctx.fileUploads()) {
+                Path path = fs.pathOf(u.uploadedFileName());
+                try (InputStream is = fs.newInputStream(path)) {
+                    if (!"template".equals(u.name())) {
+                        logger.info(
+                                String.format(
+                                        "Received unexpected file upload named %s", u.name()));
+                        continue;
+                    }
+                    templateService.addTemplate(is);
+                } finally {
+                    fs.deleteIfExists(path);
+                }
+            }
+        } catch (IOException ioe) {
+            throw new HttpStatusException(500, ioe);
+        } catch (InvalidXmlException | InvalidEventTemplateException e) {
+            throw new HttpStatusException(400, e);
+        }
+        ctx.response().end();
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/templates/TemplatesModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/templates/TemplatesModule.java
@@ -39,62 +39,24 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr;
+package com.redhat.rhjmc.containerjfr.templates;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import javax.inject.Named;
 import javax.inject.Singleton;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
-import com.redhat.rhjmc.containerjfr.commands.CommandsModule;
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
-import com.redhat.rhjmc.containerjfr.net.web.WebModule;
-import com.redhat.rhjmc.containerjfr.platform.PlatformModule;
-import com.redhat.rhjmc.containerjfr.sys.SystemModule;
-import com.redhat.rhjmc.containerjfr.templates.TemplatesModule;
-import com.redhat.rhjmc.containerjfr.tui.TuiModule;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.core.templates.LocalStorageTemplateService;
 
 import dagger.Module;
 import dagger.Provides;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-@Module(
-        includes = {
-            PlatformModule.class,
-            WebModule.class,
-            SystemModule.class,
-            CommandsModule.class,
-            TuiModule.class,
-            TemplatesModule.class,
-        })
-public abstract class MainModule {
-    public static final String RECORDINGS_PATH = "RECORDINGS_PATH";
+@Module
+public abstract class TemplatesModule {
 
     @Provides
     @Singleton
-    static Logger provideLogger() {
-        return Logger.INSTANCE;
-    }
-
-    // public since this is useful to use directly in tests
-    @Provides
-    @Singleton
-    public static Gson provideGson() {
-        return new GsonBuilder().serializeNulls().disableHtmlEscaping().create();
-    }
-
-    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
-    @Provides
-    @Singleton
-    @Named(RECORDINGS_PATH)
-    static Path provideSavedRecordingsPath(Logger logger, Environment env) {
-        String ARCHIVE_PATH = env.getEnv("CONTAINER_JFR_ARCHIVE_PATH", "/flightrecordings");
-        logger.info(String.format("Local save path for flight recordings set as %s", ARCHIVE_PATH));
-        return Paths.get(ARCHIVE_PATH);
+    static LocalStorageTemplateService provideLocalStorageTemplateService(
+            FileSystem fs, Environment env) {
+        return new LocalStorageTemplateService(fs, env);
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommandTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -73,10 +74,8 @@ import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
 import com.redhat.rhjmc.containerjfr.TestBase;
-import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.templates.TemplateService;
-import com.redhat.rhjmc.containerjfr.core.templates.TemplateService.UnknownEventTemplateException;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 
@@ -151,7 +150,8 @@ class AbstractRecordingCommandTest extends TestBase {
         when(connection.getTemplateService()).thenReturn(templateSvc);
 
         IConstrainedMap<EventOptionID> templateMap = mock(IConstrainedMap.class);
-        when(templateSvc.getEventsByTemplateName(Mockito.anyString())).thenReturn(templateMap);
+        when(templateSvc.getEventsByTemplateName(Mockito.anyString()))
+                .thenReturn(Optional.of(templateMap));
 
         IConstrainedMap<EventOptionID> result = command.enableEvents(connection, "template=Foo");
         assertThat(result, Matchers.sameInstance(templateMap));
@@ -162,11 +162,10 @@ class AbstractRecordingCommandTest extends TestBase {
         TemplateService templateSvc = mock(TemplateService.class);
         when(connection.getTemplateService()).thenReturn(templateSvc);
 
-        when(templateSvc.getEventsByTemplateName(Mockito.anyString()))
-                .thenThrow(new FlightRecorderException(new UnknownEventTemplateException("Foo")));
+        when(templateSvc.getEventsByTemplateName(Mockito.anyString())).thenReturn(Optional.empty());
 
         Assertions.assertThrows(
-                FlightRecorderException.class,
+                IllegalArgumentException.class,
                 () -> command.enableEvents(connection, "template=Foo"));
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommandTest.java
@@ -117,7 +117,10 @@ class AbstractRecordingCommandTest extends TestBase {
                 "foo.Event:prop=val",
                 "foo.Event:prop=val,bar.Event:thing=1",
                 "foo.class$Inner:prop=val",
-                "template=ALL"
+                "template=ALL",
+                "template=Foo",
+                "template=Continuous,type=TARGET",
+                "template=Foo,type=CUSTOM",
             })
     void shouldValidateValidEventString(String events) {
         assertTrue(command.validateEvents(events));

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommandTest.java
@@ -150,7 +150,7 @@ class AbstractRecordingCommandTest extends TestBase {
         when(connection.getTemplateService()).thenReturn(templateSvc);
 
         IConstrainedMap<EventOptionID> templateMap = mock(IConstrainedMap.class);
-        when(templateSvc.getEventsByTemplateName(Mockito.anyString()))
+        when(templateSvc.getEvents(Mockito.anyString(), Mockito.any()))
                 .thenReturn(Optional.of(templateMap));
 
         IConstrainedMap<EventOptionID> result = command.enableEvents(connection, "template=Foo");
@@ -162,7 +162,8 @@ class AbstractRecordingCommandTest extends TestBase {
         TemplateService templateSvc = mock(TemplateService.class);
         when(connection.getTemplateService()).thenReturn(templateSvc);
 
-        when(templateSvc.getEventsByTemplateName(Mockito.anyString())).thenReturn(Optional.empty());
+        when(templateSvc.getEvents(Mockito.anyString(), Mockito.any()))
+                .thenReturn(Optional.empty());
 
         Assertions.assertThrows(
                 IllegalArgumentException.class,

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommandTest.java
@@ -64,6 +64,7 @@ import com.redhat.rhjmc.containerjfr.commands.SerializableCommand.Output;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.templates.Template;
 import com.redhat.rhjmc.containerjfr.core.templates.TemplateService;
+import com.redhat.rhjmc.containerjfr.core.templates.TemplateType;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
@@ -111,9 +112,9 @@ class ListEventTemplatesCommandTest implements ValidatesTargetId {
                 .thenAnswer(
                         arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(connection));
         Mockito.when(connection.getTemplateService()).thenReturn(templateSvc);
-        Template foo = new Template("Foo", "a foo-ing template", "Foo Inc.");
-        Template bar = new Template("Bar", "a bar-ing template", "Bar Inc.");
-        Template baz = new Template("Baz", "a baz-ing template", "Baz Inc.");
+        Template foo = new Template("Foo", "a foo-ing template", "Foo Inc.", TemplateType.TARGET);
+        Template bar = new Template("Bar", "a bar-ing template", "Bar Inc.", TemplateType.TARGET);
+        Template baz = new Template("Baz", "a baz-ing template", "Baz Inc.", TemplateType.CUSTOM);
         Mockito.when(templateSvc.getTemplates()).thenReturn(List.of(foo, bar, baz));
 
         cmd.execute(new String[] {"fooHost:9091"});
@@ -136,9 +137,9 @@ class ListEventTemplatesCommandTest implements ValidatesTargetId {
                 .thenAnswer(
                         arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(connection));
         Mockito.when(connection.getTemplateService()).thenReturn(templateSvc);
-        Template foo = new Template("Foo", "a foo-ing template", "Foo Inc.");
-        Template bar = new Template("Bar", "a bar-ing template", "Bar Inc.");
-        Template baz = new Template("Baz", "a baz-ing template", "Baz Inc.");
+        Template foo = new Template("Foo", "a foo-ing template", "Foo Inc.", TemplateType.TARGET);
+        Template bar = new Template("Bar", "a bar-ing template", "Bar Inc.", TemplateType.TARGET);
+        Template baz = new Template("Baz", "a baz-ing template", "Baz Inc.", TemplateType.CUSTOM);
         List<Template> remoteList = List.of(foo, bar, baz);
         Mockito.when(templateSvc.getTemplates()).thenReturn(remoteList);
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandlerTest.java
@@ -144,7 +144,7 @@ class CorsEnablingHandlerTest {
         @ParameterizedTest
         @EnumSource(
                 value = HttpMethod.class,
-                names = {"GET", "POST", "OPTIONS", "HEAD"})
+                names = {"GET", "POST", "OPTIONS", "HEAD", "DELETE"})
         void shouldRespondOKToOPTIONSWithAcceptedMethod(HttpMethod method) {
             Mockito.when(req.method()).thenReturn(HttpMethod.OPTIONS);
             Mockito.when(headers.get(HttpHeaders.ORIGIN))
@@ -161,7 +161,9 @@ class CorsEnablingHandlerTest {
                             HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
                             CorsEnablingHandler.DEV_ORIGIN);
             Mockito.verify(res)
-                    .putHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET,POST,OPTIONS,HEAD");
+                    .putHeader(
+                            HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+                            "GET,POST,OPTIONS,HEAD,DELETE");
             Mockito.verify(res)
                     .putHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "Authorization");
             Mockito.verify(res).setStatusCode(200);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandlerTest.java
@@ -1,0 +1,164 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.Optional;
+
+import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.templates.TemplateService;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TargetTemplateGetHandlerTest {
+
+    TargetTemplateGetHandler handler;
+    @Mock AuthManager auth;
+    @Mock TargetConnectionManager targetConnectionManager;
+    @Mock Logger logger;
+    @Mock JFRConnection conn;
+    @Mock TemplateService templateService;
+
+    @BeforeEach
+    void setup() {
+        this.handler = new TargetTemplateGetHandler(auth, targetConnectionManager, logger);
+    }
+
+    @Test
+    void shouldHandleGET() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v1/targets/:targetId/templates/:templateName"));
+    }
+
+    @Test
+    void shouldThrowIfTargetConnectionManagerThrows() throws Exception {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("localhost");
+        Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
+
+        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any())).thenThrow(FlightRecorderException.class);
+
+        HttpStatusException ex = Assertions.assertThrows(HttpStatusException.class, () ->
+                handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Test
+    void shouldThrowIfNoMatchingTemplateFound() throws Exception {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("localhost");
+        Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
+
+        Mockito.when(conn.getTemplateService()).thenReturn(templateService);
+        Mockito.when(templateService.getXml("FooTemplate")).thenReturn(Optional.empty());
+
+        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any())).thenAnswer(new Answer<>() {
+            @Override
+            public Optional<Document> answer(InvocationOnMock args) throws Throwable {
+                ConnectedTask ct = (ConnectedTask) args.getArguments()[1];
+                return (Optional<Document>) ct.execute(conn);
+            }
+        });
+
+        HttpStatusException ex = Assertions.assertThrows(HttpStatusException.class, () ->
+                handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+    }
+
+    @Test
+    void shouldRespondWithXmlDocument() throws Exception {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("localhost");
+        Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
+
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.response()).thenReturn(resp);
+
+        Mockito.when(conn.getTemplateService()).thenReturn(templateService);
+
+        Document doc = Mockito.mock(Document.class);
+        Mockito.when(templateService.getXml("FooTemplate")).thenReturn(Optional.of(doc));
+        Mockito.when(doc.toString()).thenReturn("Mock Document XML");
+
+        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any())).thenAnswer(new Answer<>() {
+            @Override
+            public Optional<Document> answer(InvocationOnMock args) throws Throwable {
+                ConnectedTask ct = (ConnectedTask) args.getArguments()[1];
+                return (Optional<Document>) ct.execute(conn);
+            }
+        });
+
+        handler.handleAuthenticated(ctx);
+
+        Mockito.verify(ctx, Mockito.atLeastOnce()).response();
+        Mockito.verify(resp).putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JFC.mime());
+        Mockito.verify(resp).end("Mock Document XML");
+    }
+
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandlerTest.java
@@ -43,15 +43,6 @@ package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
 import java.util.Optional;
 
-import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
-import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
-import com.redhat.rhjmc.containerjfr.core.templates.TemplateService;
-import com.redhat.rhjmc.containerjfr.net.AuthManager;
-import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
-import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
-import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jsoup.nodes.Document;
@@ -64,6 +55,15 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
+
+import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.templates.TemplateService;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -93,7 +93,9 @@ class TargetTemplateGetHandlerTest {
 
     @Test
     void shouldHandleCorrectPath() {
-        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v1/targets/:targetId/templates/:templateName"));
+        MatcherAssert.assertThat(
+                handler.path(),
+                Matchers.equalTo("/api/v1/targets/:targetId/templates/:templateName"));
     }
 
     @Test
@@ -102,10 +104,14 @@ class TargetTemplateGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("localhost");
         Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
 
-        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any())).thenThrow(FlightRecorderException.class);
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any()))
+                .thenThrow(FlightRecorderException.class);
 
-        HttpStatusException ex = Assertions.assertThrows(HttpStatusException.class, () ->
-                handler.handleAuthenticated(ctx));
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 
@@ -118,16 +124,22 @@ class TargetTemplateGetHandlerTest {
         Mockito.when(conn.getTemplateService()).thenReturn(templateService);
         Mockito.when(templateService.getXml("FooTemplate")).thenReturn(Optional.empty());
 
-        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any())).thenAnswer(new Answer<>() {
-            @Override
-            public Optional<Document> answer(InvocationOnMock args) throws Throwable {
-                ConnectedTask ct = (ConnectedTask) args.getArguments()[1];
-                return (Optional<Document>) ct.execute(conn);
-            }
-        });
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any()))
+                .thenAnswer(
+                        new Answer<>() {
+                            @Override
+                            public Optional<Document> answer(InvocationOnMock args)
+                                    throws Throwable {
+                                ConnectedTask ct = (ConnectedTask) args.getArguments()[1];
+                                return (Optional<Document>) ct.execute(conn);
+                            }
+                        });
 
-        HttpStatusException ex = Assertions.assertThrows(HttpStatusException.class, () ->
-                handler.handleAuthenticated(ctx));
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 
@@ -146,13 +158,18 @@ class TargetTemplateGetHandlerTest {
         Mockito.when(templateService.getXml("FooTemplate")).thenReturn(Optional.of(doc));
         Mockito.when(doc.toString()).thenReturn("Mock Document XML");
 
-        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any())).thenAnswer(new Answer<>() {
-            @Override
-            public Optional<Document> answer(InvocationOnMock args) throws Throwable {
-                ConnectedTask ct = (ConnectedTask) args.getArguments()[1];
-                return (Optional<Document>) ct.execute(conn);
-            }
-        });
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any()))
+                .thenAnswer(
+                        new Answer<>() {
+                            @Override
+                            public Optional<Document> answer(InvocationOnMock args)
+                                    throws Throwable {
+                                ConnectedTask ct = (ConnectedTask) args.getArguments()[1];
+                                return (Optional<Document>) ct.execute(conn);
+                            }
+                        });
 
         handler.handleAuthenticated(ctx);
 
@@ -160,5 +177,4 @@ class TargetTemplateGetHandlerTest {
         Mockito.verify(resp).putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JFC.mime());
         Mockito.verify(resp).end("Mock Document XML");
     }
-
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandlerTest.java
@@ -60,6 +60,7 @@ import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.templates.TemplateService;
+import com.redhat.rhjmc.containerjfr.core.templates.TemplateType;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
@@ -95,7 +96,8 @@ class TargetTemplateGetHandlerTest {
     void shouldHandleCorrectPath() {
         MatcherAssert.assertThat(
                 handler.path(),
-                Matchers.equalTo("/api/v1/targets/:targetId/templates/:templateName"));
+                Matchers.equalTo(
+                        "/api/v1/targets/:targetId/templates/:templateName/type/:templateType"));
     }
 
     @Test
@@ -103,6 +105,7 @@ class TargetTemplateGetHandlerTest {
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
         Mockito.when(ctx.pathParam("targetId")).thenReturn("localhost");
         Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
+        Mockito.when(ctx.pathParam("templateType")).thenReturn("CUSTOM");
 
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
@@ -120,9 +123,11 @@ class TargetTemplateGetHandlerTest {
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
         Mockito.when(ctx.pathParam("targetId")).thenReturn("localhost");
         Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
+        Mockito.when(ctx.pathParam("templateType")).thenReturn("TARGET");
 
         Mockito.when(conn.getTemplateService()).thenReturn(templateService);
-        Mockito.when(templateService.getXml("FooTemplate")).thenReturn(Optional.empty());
+        Mockito.when(templateService.getXml("FooTemplate", TemplateType.TARGET))
+                .thenReturn(Optional.empty());
 
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
@@ -148,6 +153,7 @@ class TargetTemplateGetHandlerTest {
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
         Mockito.when(ctx.pathParam("targetId")).thenReturn("localhost");
         Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
+        Mockito.when(ctx.pathParam("templateType")).thenReturn("CUSTOM");
 
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
         Mockito.when(ctx.response()).thenReturn(resp);
@@ -155,7 +161,8 @@ class TargetTemplateGetHandlerTest {
         Mockito.when(conn.getTemplateService()).thenReturn(templateService);
 
         Document doc = Mockito.mock(Document.class);
-        Mockito.when(templateService.getXml("FooTemplate")).thenReturn(Optional.of(doc));
+        Mockito.when(templateService.getXml("FooTemplate", TemplateType.CUSTOM))
+                .thenReturn(Optional.of(doc));
         Mockito.when(doc.toString()).thenReturn("Mock Document XML");
 
         Mockito.when(

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplatesGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplatesGetHandlerTest.java
@@ -62,6 +62,7 @@ import com.redhat.rhjmc.containerjfr.commands.internal.AbstractRecordingCommand;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.templates.Template;
 import com.redhat.rhjmc.containerjfr.core.templates.TemplateService;
+import com.redhat.rhjmc.containerjfr.core.templates.TemplateType;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
@@ -114,8 +115,10 @@ class TargetTemplatesGetHandlerTest {
         JFRConnection connection = Mockito.mock(JFRConnection.class);
         TemplateService templateService = Mockito.mock(TemplateService.class);
 
-        Template template1 = new Template("FooTemplate", "Template for foo-ing", "Test 1");
-        Template template2 = new Template("BarTemplate", "Template for bar-ing", "Test 2");
+        Template template1 =
+                new Template("FooTemplate", "Template for foo-ing", "Test 1", TemplateType.TARGET);
+        Template template2 =
+                new Template("BarTemplate", "Template for bar-ing", "Test 2", TemplateType.CUSTOM);
 
         Mockito.when(connectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any()))
                 .thenAnswer(

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplateDeleteHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplateDeleteHandlerTest.java
@@ -1,0 +1,112 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.IOException;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.core.templates.LocalStorageTemplateService;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TemplateDeleteHandlerTest {
+
+    TemplateDeleteHandler handler;
+    @Mock AuthManager auth;
+    @Mock LocalStorageTemplateService templateService;
+
+    @BeforeEach
+    void setup() {
+        this.handler = new TemplateDeleteHandler(auth, templateService);
+    }
+
+    @Test
+    void shouldHandleDELETE() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.DELETE));
+    }
+
+    @Test
+    void sholdHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(), Matchers.equalTo("/api/v1/templates/:templateName"));
+    }
+
+    @Test
+    void shouldThrowIfServiceThrows() throws Exception {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
+        Mockito.doThrow(IOException.class).when(templateService).deleteTemplate("FooTemplate");
+
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Test
+    void shouldCallThroughToService() throws Exception {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
+        Mockito.when(ctx.response()).thenReturn(resp);
+
+        handler.handleAuthenticated(ctx);
+
+        Mockito.verify(templateService).deleteTemplate("FooTemplate");
+        Mockito.verify(ctx).response();
+        Mockito.verify(resp).end();
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandlerTest.java
@@ -1,0 +1,171 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Set;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.core.templates.LocalStorageTemplateService;
+import com.redhat.rhjmc.containerjfr.core.templates.MutableTemplateService.InvalidXmlException;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TemplatesPostHandlerTest {
+
+    TemplatesPostHandler handler;
+    @Mock AuthManager auth;
+    @Mock LocalStorageTemplateService templateService;
+    @Mock FileSystem fs;
+    @Mock Logger logger;
+
+    @BeforeEach
+    void setup() {
+        this.handler = new TemplatesPostHandler(auth, templateService, fs, logger);
+    }
+
+    @Test
+    void shouldHandlePOST() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v1/templates"));
+    }
+
+    @Test
+    void shouldThrowIfWriteFails() throws Exception {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        FileUpload upload = Mockito.mock(FileUpload.class);
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload));
+        Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
+
+        Path uploadPath = Mockito.mock(Path.class);
+        Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
+
+        Mockito.when(fs.newInputStream(Mockito.any())).thenThrow(IOException.class);
+
+        HttpStatusException ex = Assertions.assertThrows(HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Test
+    void shouldThrowIfXmlInvalid() throws Exception {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+
+        FileUpload upload = Mockito.mock(FileUpload.class);
+        Mockito.when(upload.name()).thenReturn("template");
+        Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
+
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload));
+
+        Path uploadPath = Mockito.mock(Path.class);
+        Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
+
+        InputStream stream = Mockito.mock(InputStream.class);
+        Mockito.when(fs.newInputStream(Mockito.any())).thenReturn(stream);
+
+        Mockito.doThrow(InvalidXmlException.class).when(templateService).addTemplate(stream);
+
+        HttpStatusException ex = Assertions.assertThrows(HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+        Mockito.verify(fs).deleteIfExists(uploadPath);
+    }
+
+    @Test
+    void shouldProcessGoodRequest() throws Exception {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.response()).thenReturn(resp);
+
+        FileUpload upload1 = Mockito.mock(FileUpload.class);
+        Mockito.when(upload1.name()).thenReturn("template");
+        Mockito.when(upload1.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
+
+        FileUpload upload2 = Mockito.mock(FileUpload.class);
+        Mockito.when(upload2.name()).thenReturn("unused");
+        Mockito.when(upload2.uploadedFileName()).thenReturn("/file-uploads/wxyz-9999");
+
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload1, upload2));
+
+        Path uploadPath1 = Mockito.mock(Path.class);
+        Path uploadPath2 = Mockito.mock(Path.class);
+        Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath1);
+        Mockito.when(fs.pathOf("/file-uploads/wxyz-9999")).thenReturn(uploadPath2);
+
+        InputStream stream1 = Mockito.mock(InputStream.class);
+        InputStream stream2 = Mockito.mock(InputStream.class);
+        Mockito.when(fs.newInputStream(uploadPath1)).thenReturn(stream1);
+        Mockito.when(fs.newInputStream(uploadPath2)).thenReturn(stream2);
+
+        handler.handleAuthenticated(ctx);
+
+        Mockito.verify(templateService).addTemplate(stream1);
+        Mockito.verifyNoMoreInteractions(templateService);
+        Mockito.verify(fs).deleteIfExists(uploadPath1);
+        Mockito.verify(fs).deleteIfExists(uploadPath2);
+        Mockito.verify(ctx).response();
+        Mockito.verify(resp).end();
+    }
+
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandlerTest.java
@@ -46,12 +46,6 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Set;
 
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
-import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
-import com.redhat.rhjmc.containerjfr.core.templates.LocalStorageTemplateService;
-import com.redhat.rhjmc.containerjfr.core.templates.MutableTemplateService.InvalidXmlException;
-import com.redhat.rhjmc.containerjfr.net.AuthManager;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -61,6 +55,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.core.templates.LocalStorageTemplateService;
+import com.redhat.rhjmc.containerjfr.core.templates.MutableTemplateService.InvalidXmlException;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
@@ -104,7 +104,9 @@ class TemplatesPostHandlerTest {
 
         Mockito.when(fs.newInputStream(Mockito.any())).thenThrow(IOException.class);
 
-        HttpStatusException ex = Assertions.assertThrows(HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 
@@ -126,7 +128,9 @@ class TemplatesPostHandlerTest {
 
         Mockito.doThrow(InvalidXmlException.class).when(templateService).addTemplate(stream);
 
-        HttpStatusException ex = Assertions.assertThrows(HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         Mockito.verify(fs).deleteIfExists(uploadPath);
     }
@@ -167,5 +171,4 @@ class TemplatesPostHandlerTest {
         Mockito.verify(ctx).response();
         Mockito.verify(resp).end();
     }
-
 }


### PR DESCRIPTION
Fixes #143

See also https://github.com/rh-jmc-team/container-jfr-core/pull/40 - -core dependency changes

This adds HTTP API endpoints to list available event templates, retrieve XML definitions of specific templates, and to add new templates (by XML file POST upload) to container-jfr's local filesystem storage. These templates can then be used when creating new flight recordings using the pre-existing `template=Foo` syntax.