### PR TITLE
Change Response Message from `validate()`

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -249,7 +249,7 @@ formatted as a JSON response.
 
 * #### `list`
     ###### usage
-    `list target`
+    `list targetId`
     ###### synopsis
     Lists recordings in the specified target JVM. The name provided in this list
     is the name to pass to other commands which operate upon recordings.
@@ -275,11 +275,11 @@ formatted as a JSON response.
 
 * #### `wait-for`
     ###### usage
-    `wait-for foo`
+    `wait-for targedId foo`
     ###### synopsis
-    Waits for the given recording (`foo`) to stop running. If the recording is
-    continuous and not already stopped then the command will refuse to wait for
-    the recording to complete, since this would lock up the client and require
-    another client to be connected in order to stop the recording. Once this
-    command has begun awaiting completion of the recording it cannot be
-    interrupted.
+    Waits for the given recording (`foo`) of the specified target JVM to stop
+    running. If the recording is continuous and not already stopped then the
+    command will refuse to wait for the recording to complete, since this would
+    lock up the client and require another client to be connected in order to
+    stop the recording. Once this command has begun awaiting completion of the
+    recording it cannot be interrupted.

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -275,7 +275,7 @@ formatted as a JSON response.
 
 * #### `wait-for`
     ###### usage
-    `wait-for targedId foo`
+    `wait-for targetId foo`
     ###### synopsis
     Waits for the given recording (`foo`) of the specified target JVM to stop
     running. If the recording is continuous and not already stopped then the

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/BaseCommandRegistry.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/BaseCommandRegistry.java
@@ -43,12 +43,14 @@ package com.redhat.rhjmc.containerjfr.commands;
 
 import java.util.Set;
 
+import com.redhat.rhjmc.containerjfr.commands.internal.FailedValidationException;
+
 public interface BaseCommandRegistry {
     Set<String> getRegisteredCommandNames();
 
     Set<String> getAvailableCommandNames();
 
-    boolean validate(String commandName, String[] args);
+    void validate(String commandName, String[] args) throws FailedValidationException;
 
     boolean isCommandAvailable(String commandName);
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/Command.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/Command.java
@@ -45,6 +45,7 @@ import java.net.MalformedURLException;
 
 import javax.management.remote.JMXServiceURL;
 
+import com.redhat.rhjmc.containerjfr.commands.internal.FailedValidationException;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 
 public interface Command {
@@ -53,7 +54,7 @@ public interface Command {
 
     void execute(String[] args) throws Exception;
 
-    boolean validate(String[] args);
+    void validate(String[] args) throws FailedValidationException;
 
     boolean isAvailable();
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommand.java
@@ -160,11 +160,6 @@ public abstract class AbstractRecordingCommand extends AbstractConnectedCommand 
     protected boolean validateEvents(String events) {
         // TODO better validation of entire events string (not just looking for one acceptable
         // setting)
-        if (!TEMPLATE_PATTERN.matcher(events).matches() && !EVENTS_PATTERN.matcher(events).find()) {
-            cw.println(String.format("%s is an invalid events pattern", events));
-            return false;
-        }
-
-        return true;
+        return TEMPLATE_PATTERN.matcher(events).matches() || EVENTS_PATTERN.matcher(events).find();
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandRegistryImpl.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandRegistryImpl.java
@@ -91,8 +91,11 @@ class CommandRegistryImpl implements CommandRegistry {
     }
 
     @Override
-    public boolean validate(String commandName, String[] args) {
-        return isCommandRegistered(commandName) && commandMap.get(commandName).validate(args);
+    public void validate(String commandName, String[] args) throws FailedValidationException {
+        if (!isCommandRegistered(commandName)) {
+            throw new FailedValidationException();
+        }
+        commandMap.get(commandName).validate(args);
     }
 
     private boolean isCommandRegistered(String commandName) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandRegistryImpl.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandRegistryImpl.java
@@ -93,7 +93,8 @@ class CommandRegistryImpl implements CommandRegistry {
     @Override
     public void validate(String commandName, String[] args) throws FailedValidationException {
         if (!isCommandRegistered(commandName)) {
-            throw new FailedValidationException();
+            throw new FailedValidationException(
+                    String.format("Command \"%s\" not recognized", commandName));
         }
         commandMap.get(commandName).validate(args);
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommand.java
@@ -123,16 +123,20 @@ class DeleteCommand extends AbstractConnectedCommand implements SerializableComm
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 2) {
-            throw new FailedValidationException(
-                    "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name");
+            String errorMessage =
+                    "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
         if (!validateTargetId(args[0])) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", args[0]));
+            String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
         if (!validateRecordingName(args[1])) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid recording name", args[1]));
+            String errorMessage = String.format("%s is an invalid recording name", args[1]);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommand.java
@@ -42,6 +42,7 @@
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
 import java.util.Optional;
+import java.util.StringJoiner;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -129,22 +130,22 @@ class DeleteCommand extends AbstractConnectedCommand implements SerializableComm
             throw new FailedValidationException(errorMessage);
         }
 
-        StringBuilder combinedErrorMessage = new StringBuilder();
+        StringJoiner combinedErrorMessage = new StringJoiner("; ");
 
         if (!validateTargetId(args[0])) {
             String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (!validateRecordingName(args[1])) {
             String errorMessage = String.format("%s is an invalid recording name", args[1]);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (combinedErrorMessage.length() > 0) {
-            throw new FailedValidationException(combinedErrorMessage.substring(2));
+            throw new FailedValidationException(combinedErrorMessage.toString());
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommand.java
@@ -128,15 +128,23 @@ class DeleteCommand extends AbstractConnectedCommand implements SerializableComm
             cw.println(errorMessage);
             throw new FailedValidationException(errorMessage);
         }
+
+        StringBuilder combinedErrorMessage = new StringBuilder();
+
         if (!validateTargetId(args[0])) {
             String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
             cw.println(errorMessage);
-            throw new FailedValidationException(errorMessage);
+            combinedErrorMessage.append("; ").append(errorMessage);
         }
+
         if (!validateRecordingName(args[1])) {
             String errorMessage = String.format("%s is an invalid recording name", args[1]);
             cw.println(errorMessage);
-            throw new FailedValidationException(errorMessage);
+            combinedErrorMessage.append("; ").append(errorMessage);
+        }
+
+        if (combinedErrorMessage.length() > 0) {
+            throw new FailedValidationException(combinedErrorMessage.substring(2));
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommand.java
@@ -121,20 +121,18 @@ class DeleteCommand extends AbstractConnectedCommand implements SerializableComm
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 2) {
-            cw.println(
+            throw new FailedValidationException(
                     "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name");
-            return false;
         }
-        boolean isValidTargetID = validateTargetId(args[0]);
-        if (!isValidTargetID) {
-            cw.println(String.format("%s is an invalid connection specifier", args[0]));
+        if (!validateTargetId(args[0])) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", args[0]));
         }
-        boolean isValidRecordingName = validateRecordingName(args[1]);
-        if (!isValidRecordingName) {
-            cw.println(String.format("%s is an invalid recording name", args[1]));
+        if (!validateRecordingName(args[1])) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid recording name", args[1]));
         }
-        return isValidTargetID && isValidRecordingName;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteSavedRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteSavedRecordingCommand.java
@@ -108,11 +108,14 @@ class DeleteSavedRecordingCommand implements SerializableCommand {
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            throw new FailedValidationException("Expected one argument: recording name");
+            String errorMessage = "Expected one argument: recording name";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
         if (!validateRecordingName(args[0])) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid recording name", args[0]));
+            String errorMessage = String.format("%s is an invalid recording name", args[0]);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteSavedRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteSavedRecordingCommand.java
@@ -106,16 +106,14 @@ class DeleteSavedRecordingCommand implements SerializableCommand {
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            cw.println("Expected one argument: recording name");
-            return false;
+            throw new FailedValidationException("Expected one argument: recording name");
         }
-        boolean isValidRecordingName = validateRecordingName(args[0]);
-        if (!isValidRecordingName) {
-            cw.println(String.format("%s is an invalid recording name", args[0]));
+        if (!validateRecordingName(args[0])) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid recording name", args[0]));
         }
-        return isValidRecordingName;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommand.java
@@ -152,28 +152,34 @@ class DumpCommand extends AbstractRecordingCommand implements SerializableComman
         String seconds = args[2];
         String events = args[3];
 
+        StringBuilder combinedErrorMessage = new StringBuilder();
+
         if (!validateTargetId(targetId)) {
             String errorMessage = String.format("%s is an invalid connection specifier", targetId);
             cw.println(errorMessage);
-            throw new FailedValidationException(errorMessage);
+            combinedErrorMessage.append("; ").append(errorMessage);
         }
 
         if (!validateRecordingName(name)) {
             String errorMessage = String.format("%s is an invalid recording name", name);
             cw.println(errorMessage);
-            throw new FailedValidationException(errorMessage);
+            combinedErrorMessage.append("; ").append(errorMessage);
         }
 
         if (!seconds.matches("\\d+")) {
             String errorMessage = String.format("%s is an invalid recording length", seconds);
             cw.println(errorMessage);
-            throw new FailedValidationException(errorMessage);
+            combinedErrorMessage.append("; ").append(errorMessage);
         }
 
         if (!validateEvents(events)) {
             String errorMessage = String.format("%s is an invalid events specifier", events);
             cw.println(errorMessage);
-            throw new FailedValidationException(errorMessage);
+            combinedErrorMessage.append("; ").append(errorMessage);
+        }
+
+        if (combinedErrorMessage.length() > 0) {
+            throw new FailedValidationException(combinedErrorMessage.substring(2));
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommand.java
@@ -41,6 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
+import java.util.StringJoiner;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -152,34 +154,34 @@ class DumpCommand extends AbstractRecordingCommand implements SerializableComman
         String seconds = args[2];
         String events = args[3];
 
-        StringBuilder combinedErrorMessage = new StringBuilder();
+        StringJoiner combinedErrorMessage = new StringJoiner("; ");
 
         if (!validateTargetId(targetId)) {
             String errorMessage = String.format("%s is an invalid connection specifier", targetId);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (!validateRecordingName(name)) {
             String errorMessage = String.format("%s is an invalid recording name", name);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (!seconds.matches("\\d+")) {
             String errorMessage = String.format("%s is an invalid recording length", seconds);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (!validateEvents(events)) {
             String errorMessage = String.format("%s is an invalid events specifier", events);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (combinedErrorMessage.length() > 0) {
-            throw new FailedValidationException(combinedErrorMessage.substring(2));
+            throw new FailedValidationException(combinedErrorMessage.toString());
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommand.java
@@ -139,11 +139,10 @@ class DumpCommand extends AbstractRecordingCommand implements SerializableComman
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 4) {
-            cw.println(
+            throw new FailedValidationException(
                     "Expected four arguments: target (host:port, ip:port, or JMX service URL), recording name, recording length, and event types");
-            return false;
         }
 
         String targetId = args[0];
@@ -151,27 +150,24 @@ class DumpCommand extends AbstractRecordingCommand implements SerializableComman
         String seconds = args[2];
         String events = args[3];
 
-        boolean isValidTargetId = validateTargetId(targetId);
-        boolean isValidName = validateRecordingName(name);
-        boolean isValidDuration = seconds.matches("\\d+");
-        boolean isValidEvents = validateEvents(events);
-
-        if (!isValidTargetId) {
-            cw.println(String.format("%s is an invalid connection specifier", args[0]));
+        if (!validateTargetId(targetId)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", args[0]));
         }
 
-        if (!isValidName) {
-            cw.println(String.format("%s is an invalid recording name", name));
+        if (!validateRecordingName(name)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid recording name", name));
         }
 
-        if (!isValidDuration) {
-            cw.println(String.format("%s is an invalid recording length", seconds));
+        if (!seconds.matches("\\d+")) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid recording length", seconds));
         }
 
-        if (!isValidEvents) {
-            cw.println(String.format("%s is an invalid events specifier", events));
+        if (!validateEvents(events)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid events specifier", events));
         }
-
-        return isValidTargetId && isValidName && isValidDuration && isValidEvents;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommand.java
@@ -141,8 +141,10 @@ class DumpCommand extends AbstractRecordingCommand implements SerializableComman
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 4) {
-            throw new FailedValidationException(
-                    "Expected four arguments: target (host:port, ip:port, or JMX service URL), recording name, recording length, and event types");
+            String errorMessage =
+                    "Expected four arguments: target (host:port, ip:port, or JMX service URL), recording name, recording length, and event types";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         String targetId = args[0];
@@ -151,23 +153,27 @@ class DumpCommand extends AbstractRecordingCommand implements SerializableComman
         String events = args[3];
 
         if (!validateTargetId(targetId)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", args[0]));
+            String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         if (!validateRecordingName(name)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid recording name", name));
+            String errorMessage = String.format("%s is an invalid recording name", name);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         if (!seconds.matches("\\d+")) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid recording length", seconds));
+            String errorMessage = String.format("%s is an invalid recording length", seconds);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         if (!validateEvents(events)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid events specifier", events));
+            String errorMessage = String.format("%s is an invalid events specifier", events);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommand.java
@@ -153,7 +153,7 @@ class DumpCommand extends AbstractRecordingCommand implements SerializableComman
         String events = args[3];
 
         if (!validateTargetId(targetId)) {
-            String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
+            String errorMessage = String.format("%s is an invalid connection specifier", targetId);
             cw.println(errorMessage);
             throw new FailedValidationException(errorMessage);
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ExitCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ExitCommand.java
@@ -65,7 +65,9 @@ public class ExitCommand implements Command {
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            throw new FailedValidationException("No arguments expected");
+            String errorMessage = "No arguments expected";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ExitCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ExitCommand.java
@@ -63,12 +63,10 @@ public class ExitCommand implements Command {
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            cw.println("No arguments expected");
-            return false;
+            throw new FailedValidationException("No arguments expected");
         }
-        return true;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/FailedValidationException.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/FailedValidationException.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.commands.internal;
+
+@SuppressWarnings("serial")
+public class FailedValidationException extends Exception {
+    FailedValidationException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/FailedValidationException.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/FailedValidationException.java
@@ -44,10 +44,6 @@ package com.redhat.rhjmc.containerjfr.commands.internal;
 @SuppressWarnings("serial")
 public class FailedValidationException extends Exception {
 
-    FailedValidationException() {
-        super();
-    }
-
     FailedValidationException(String errorMessage) {
         super(errorMessage);
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/FailedValidationException.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/FailedValidationException.java
@@ -44,7 +44,7 @@ package com.redhat.rhjmc.containerjfr.commands.internal;
 @SuppressWarnings("serial")
 public class FailedValidationException extends Exception {
 
-    FailedValidationException(String errorMessage) {
+    public FailedValidationException(String errorMessage) {
         super(errorMessage);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/FailedValidationException.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/FailedValidationException.java
@@ -43,6 +43,11 @@ package com.redhat.rhjmc.containerjfr.commands.internal;
 
 @SuppressWarnings("serial")
 public class FailedValidationException extends Exception {
+
+    FailedValidationException() {
+        super();
+    }
+
     FailedValidationException(String errorMessage) {
         super(errorMessage);
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/HelpCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/HelpCommand.java
@@ -73,12 +73,10 @@ class HelpCommand implements SerializableCommand {
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            cw.println("No arguments expected");
-            return false;
+            throw new FailedValidationException("No arguments expected");
         }
-        return true;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/HelpCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/HelpCommand.java
@@ -75,7 +75,9 @@ class HelpCommand implements SerializableCommand {
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            throw new FailedValidationException("No arguments expected");
+            String errorMessage = "No arguments expected";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/HostnameCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/HostnameCommand.java
@@ -66,7 +66,9 @@ class HostnameCommand implements SerializableCommand {
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            throw new FailedValidationException("No arguments expected");
+            String errorMessage = "No arguments expected";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/HostnameCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/HostnameCommand.java
@@ -64,12 +64,10 @@ class HostnameCommand implements SerializableCommand {
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            cw.println("No arguments expected");
-            return false;
+            throw new FailedValidationException("No arguments expected");
         }
-        return true;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/IpCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/IpCommand.java
@@ -64,12 +64,10 @@ class IpCommand implements SerializableCommand {
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            cw.println("No arguments expected");
-            return false;
+            throw new FailedValidationException("No arguments expected");
         }
-        return true;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/IpCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/IpCommand.java
@@ -66,7 +66,9 @@ class IpCommand implements SerializableCommand {
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            throw new FailedValidationException("No arguments expected");
+            String errorMessage = "No arguments expected";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
@@ -129,16 +129,15 @@ class ListCommand extends AbstractConnectedCommand implements SerializableComman
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            cw.println("Expected one argument: hostname:port, ip:port, or JMX service URL");
-            return false;
+            throw new FailedValidationException(
+                    "Expected one argument: hostname:port, ip:port, or JMX service URL");
         }
-        boolean isValidTargetId = validateTargetId(args[0]);
-        if (!isValidTargetId) {
-            cw.println(String.format("%s is an invalid connection specifier", args[0]));
+        if (!validateTargetId(args[0])) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", args[0]));
         }
-        return isValidTargetId;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommand.java
@@ -131,12 +131,15 @@ class ListCommand extends AbstractConnectedCommand implements SerializableComman
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            throw new FailedValidationException(
-                    "Expected one argument: hostname:port, ip:port, or JMX service URL");
+            String errorMessage =
+                    "Expected one argument: hostname:port, ip:port, or JMX service URL";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
         if (!validateTargetId(args[0])) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", args[0]));
+            String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommand.java
@@ -110,12 +110,15 @@ class ListEventTemplatesCommand extends AbstractConnectedCommand implements Seri
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            throw new FailedValidationException(
-                    "Expected one argument: hostname:port, ip:port, or JMX service URL");
+            String errorMessage =
+                    "Expected one argument: hostname:port, ip:port, or JMX service URL";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
         if (!validateTargetId(args[0])) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", args[0]));
+            String errorMessage = "%s is an invalid connection specifier";
+            cw.println(errorMessage);
+            throw new FailedValidationException(String.format(errorMessage, args[0]));
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommand.java
@@ -108,16 +108,15 @@ class ListEventTemplatesCommand extends AbstractConnectedCommand implements Seri
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            cw.println("Expected one argument: hostname:port, ip:port, or JMX service URL");
-            return false;
+            throw new FailedValidationException(
+                    "Expected one argument: hostname:port, ip:port, or JMX service URL");
         }
-        boolean isValidTargetId = validateTargetId(args[0]);
-        if (!isValidTargetId) {
-            cw.println(String.format("%s is an invalid connection specifier", args[0]));
+        if (!validateTargetId(args[0])) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", args[0]));
         }
-        return isValidTargetId;
     }
 
     private List<Template> getTemplates(JFRConnection connection) throws FlightRecorderException {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommand.java
@@ -116,9 +116,9 @@ class ListEventTemplatesCommand extends AbstractConnectedCommand implements Seri
             throw new FailedValidationException(errorMessage);
         }
         if (!validateTargetId(args[0])) {
-            String errorMessage = "%s is an invalid connection specifier";
+            String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
             cw.println(errorMessage);
-            throw new FailedValidationException(String.format(errorMessage, args[0]));
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTypesCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTypesCommand.java
@@ -104,16 +104,15 @@ class ListEventTypesCommand extends AbstractConnectedCommand implements Serializ
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            cw.println("Expected one argument: hostname:port, ip:port, or JMX service URL");
-            return false;
+            throw new FailedValidationException(
+                    "Expected one argument: hostname:port, ip:port, or JMX service URL");
         }
-        boolean isValidTargetId = validateTargetId(args[0]);
-        if (!isValidTargetId) {
-            cw.println(String.format("%s is an invalid connection specifier", args[0]));
+        if (!validateTargetId(args[0])) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", args[0]));
         }
-        return isValidTargetId;
     }
 
     private void printEvent(IEventTypeInfo event) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTypesCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTypesCommand.java
@@ -106,12 +106,15 @@ class ListEventTypesCommand extends AbstractConnectedCommand implements Serializ
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            throw new FailedValidationException(
-                    "Expected one argument: hostname:port, ip:port, or JMX service URL");
+            String errorMessage =
+                    "Expected one argument: hostname:port, ip:port, or JMX service URL";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
         if (!validateTargetId(args[0])) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", args[0]));
+            String errorMessage = "%s is an invalid connection specifier";
+            cw.println(errorMessage);
+            throw new FailedValidationException(String.format(errorMessage, args[0]));
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTypesCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTypesCommand.java
@@ -112,9 +112,9 @@ class ListEventTypesCommand extends AbstractConnectedCommand implements Serializ
             throw new FailedValidationException(errorMessage);
         }
         if (!validateTargetId(args[0])) {
-            String errorMessage = "%s is an invalid connection specifier";
+            String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
             cw.println(errorMessage);
-            throw new FailedValidationException(String.format(errorMessage, args[0]));
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListRecordingOptionsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListRecordingOptionsCommand.java
@@ -110,16 +110,15 @@ class ListRecordingOptionsCommand extends AbstractConnectedCommand implements Se
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            cw.println("Expected one argument: hostname:port, ip:port, or JMX service URL");
-            return false;
+            throw new FailedValidationException(
+                    "Expected one argument: hostname:port, ip:port, or JMX service URL");
         }
-        boolean isValidTargetId = validateTargetId(args[0]);
-        if (!isValidTargetId) {
-            cw.println(String.format("%s is an invalid connection specifier", args[0]));
+        if (!validateTargetId(args[0])) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", args[0]));
         }
-        return isValidTargetId;
     }
 
     private void printOptions(Map.Entry<String, IOptionDescriptor<?>> entry) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListRecordingOptionsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListRecordingOptionsCommand.java
@@ -112,12 +112,15 @@ class ListRecordingOptionsCommand extends AbstractConnectedCommand implements Se
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            throw new FailedValidationException(
-                    "Expected one argument: hostname:port, ip:port, or JMX service URL");
+            String errorMessage =
+                    "Expected one argument: hostname:port, ip:port, or JMX service URL";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
         if (!validateTargetId(args[0])) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", args[0]));
+            String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommand.java
@@ -126,7 +126,9 @@ class ListSavedRecordingsCommand implements SerializableCommand {
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            throw new FailedValidationException("No arguments expected");
+            String errorMessage = "No arguments expected";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommand.java
@@ -124,12 +124,10 @@ class ListSavedRecordingsCommand implements SerializableCommand {
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            cw.println("No arguments expected");
-            return false;
+            throw new FailedValidationException("No arguments expected");
         }
-        return true;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/PingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/PingCommand.java
@@ -61,12 +61,10 @@ class PingCommand implements SerializableCommand {
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            cw.println("No arguments expected");
-            return false;
+            throw new FailedValidationException("No arguments expected");
         }
-        return true;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/PingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/PingCommand.java
@@ -63,7 +63,9 @@ class PingCommand implements SerializableCommand {
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            throw new FailedValidationException("No arguments expected");
+            String errorMessage = "No arguments expected";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/PrintUrlCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/PrintUrlCommand.java
@@ -80,12 +80,10 @@ class PrintUrlCommand implements SerializableCommand {
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            cw.println("No arguments expected");
-            return false;
+            throw new FailedValidationException("No arguments expected");
         }
-        return true;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/PrintUrlCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/PrintUrlCommand.java
@@ -82,7 +82,9 @@ class PrintUrlCommand implements SerializableCommand {
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            throw new FailedValidationException("No arguments expected");
+            String errorMessage = "No arguments expected";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/RecordingOptionsCustomizerCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/RecordingOptionsCustomizerCommand.java
@@ -107,7 +107,9 @@ class RecordingOptionsCustomizerCommand implements SerializableCommand {
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            throw new FailedValidationException("Expected one argument: recording option name");
+            String errorMessage = "Expected one argument: recording option name";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
         String options = args[0];
 
@@ -116,15 +118,18 @@ class RecordingOptionsCustomizerCommand implements SerializableCommand {
         Matcher unsetMatcher = UNSET_PATTERN.matcher(options);
         boolean unsetMatch = unsetMatcher.find();
         if (!optionsMatch && !unsetMatch) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid option string", options));
+            String errorMessage = String.format("%s is an invalid option string", options);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         String option = (optionsMatch ? optionsMatcher : unsetMatcher).group(1);
         boolean recognizedOption = OptionKey.fromOptionName(option).isPresent();
         if (!recognizedOption) {
-            throw new FailedValidationException(
-                    String.format("%s is an unrecognized or unsupported option", option));
+            String errorMessage =
+                    String.format("%s is an unrecognized or unsupported option", option);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/RecordingOptionsCustomizerCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/RecordingOptionsCustomizerCommand.java
@@ -105,10 +105,9 @@ class RecordingOptionsCustomizerCommand implements SerializableCommand {
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            cw.println("Expected one argument: recording option name");
-            return false;
+            throw new FailedValidationException("Expected one argument: recording option name");
         }
         String options = args[0];
 
@@ -117,17 +116,15 @@ class RecordingOptionsCustomizerCommand implements SerializableCommand {
         Matcher unsetMatcher = UNSET_PATTERN.matcher(options);
         boolean unsetMatch = unsetMatcher.find();
         if (!optionsMatch && !unsetMatch) {
-            cw.println(String.format("%s is an invalid option string", options));
-            return false;
+            throw new FailedValidationException(
+                    String.format("%s is an invalid option string", options));
         }
 
         String option = (optionsMatch ? optionsMatcher : unsetMatcher).group(1);
         boolean recognizedOption = OptionKey.fromOptionName(option).isPresent();
         if (!recognizedOption) {
-            cw.println(String.format("%s is an unrecognized or unsupported option", option));
-            return false;
+            throw new FailedValidationException(
+                    String.format("%s is an unrecognized or unsupported option", option));
         }
-
-        return true;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
@@ -144,17 +144,22 @@ class SaveRecordingCommand extends AbstractConnectedCommand implements Serializa
 
         String targetId = args[0];
         String recordingName = args[1];
+        StringBuilder combinedErrorMessage = new StringBuilder();
 
         if (!validateTargetId(targetId)) {
-            String errorMessage = "%s is an invalid connection specifier";
+            String errorMessage = String.format("%s is an invalid connection specifier", targetId);
             cw.println(errorMessage);
-            throw new FailedValidationException(String.format(errorMessage, targetId));
+            combinedErrorMessage.append("; ").append(errorMessage);
         }
 
         if (!validateRecordingName(recordingName)) {
-            String errorMessage = "%s is an invalid recording name";
+            String errorMessage = String.format("%s is an invalid recording name", recordingName);
             cw.println(errorMessage);
-            throw new FailedValidationException(String.format(errorMessage, recordingName));
+            combinedErrorMessage.append("; ").append(errorMessage);
+        }
+
+        if (combinedErrorMessage.length() > 0) {
+            throw new FailedValidationException(combinedErrorMessage.substring(2));
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
@@ -136,8 +136,10 @@ class SaveRecordingCommand extends AbstractConnectedCommand implements Serializa
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 2) {
-            throw new FailedValidationException(
-                    "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name");
+            String errorMessage =
+                    "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         String targetId = args[0];

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
@@ -134,27 +134,24 @@ class SaveRecordingCommand extends AbstractConnectedCommand implements Serializa
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 2) {
-            cw.println(
+            throw new FailedValidationException(
                     "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name");
-            return false;
         }
 
         String targetId = args[0];
         String recordingName = args[1];
 
-        boolean isValidTargetId = validateTargetId(targetId);
-        if (!isValidTargetId) {
-            cw.println(String.format("%s is an invalid connection specifier", targetId));
+        if (!validateTargetId(targetId)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", targetId));
         }
 
-        boolean isValidRecordingName = validateRecordingName(recordingName);
-        if (!isValidRecordingName) {
-            cw.println(String.format("%s is an invalid recording name", recordingName));
+        if (!validateRecordingName(recordingName)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid recording name", recordingName));
         }
-
-        return isValidTargetId && isValidRecordingName;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
@@ -46,6 +46,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
+import java.util.StringJoiner;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -144,22 +145,22 @@ class SaveRecordingCommand extends AbstractConnectedCommand implements Serializa
 
         String targetId = args[0];
         String recordingName = args[1];
-        StringBuilder combinedErrorMessage = new StringBuilder();
+        StringJoiner combinedErrorMessage = new StringJoiner("; ");
 
         if (!validateTargetId(targetId)) {
             String errorMessage = String.format("%s is an invalid connection specifier", targetId);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (!validateRecordingName(recordingName)) {
             String errorMessage = String.format("%s is an invalid recording name", recordingName);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (combinedErrorMessage.length() > 0) {
-            throw new FailedValidationException(combinedErrorMessage.substring(2));
+            throw new FailedValidationException(combinedErrorMessage.toString());
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
@@ -144,13 +144,15 @@ class SaveRecordingCommand extends AbstractConnectedCommand implements Serializa
         String recordingName = args[1];
 
         if (!validateTargetId(targetId)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", targetId));
+            String errorMessage = "%s is an invalid connection specifier";
+            cw.println(errorMessage);
+            throw new FailedValidationException(String.format(errorMessage, targetId));
         }
 
         if (!validateRecordingName(recordingName)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid recording name", recordingName));
+            String errorMessage = "%s is an invalid recording name";
+            cw.println(errorMessage);
+            throw new FailedValidationException(String.format(errorMessage, recordingName));
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ScanTargetsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ScanTargetsCommand.java
@@ -73,12 +73,10 @@ class ScanTargetsCommand implements SerializableCommand {
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            cw.println("No arguments expected");
-            return false;
+            throw new FailedValidationException("No arguments expected");
         }
-        return true;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ScanTargetsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/ScanTargetsCommand.java
@@ -75,7 +75,9 @@ class ScanTargetsCommand implements SerializableCommand {
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 0) {
-            throw new FailedValidationException("No arguments expected");
+            String errorMessage = "No arguments expected";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SearchEventsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SearchEventsCommand.java
@@ -76,17 +76,15 @@ class SearchEventsCommand extends AbstractConnectedCommand implements Serializab
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 2) {
-            cw.println(
+            throw new FailedValidationException(
                     "Expected two arguments: target (hostname:port, ip:port, or JMX service URL) and search term");
-            return false;
         }
-        boolean isValidTargetId = validateTargetId(args[0]);
-        if (!isValidTargetId) {
-            cw.println(String.format("%s is an invalid connection specifier", args[0]));
+        if (!validateTargetId(args[0])) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", args[0]));
         }
-        return isValidTargetId;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SearchEventsCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SearchEventsCommand.java
@@ -78,12 +78,15 @@ class SearchEventsCommand extends AbstractConnectedCommand implements Serializab
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 2) {
-            throw new FailedValidationException(
-                    "Expected two arguments: target (hostname:port, ip:port, or JMX service URL) and search term");
+            String errorMessage =
+                    "Expected two arguments: target (hostname:port, ip:port, or JMX service URL) and search term";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
         if (!validateTargetId(args[0])) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", args[0]));
+            String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SerializableCommandRegistryImpl.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SerializableCommandRegistryImpl.java
@@ -108,8 +108,12 @@ class SerializableCommandRegistryImpl implements SerializableCommandRegistry {
     }
 
     @Override
-    public boolean validate(String commandName, String[] args) {
-        return isCommandRegistered(commandName) && commandMap.get(commandName).validate(args);
+    public void validate(String commandName, String[] args) throws FailedValidationException {
+        if (!isCommandRegistered(commandName)) {
+            throw new FailedValidationException(
+                    String.format("Command \"%s\" not recognized", commandName));
+        }
+        commandMap.get(commandName).validate(args);
     }
 
     private boolean isCommandRegistered(String commandName) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SnapshotCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SnapshotCommand.java
@@ -129,15 +129,14 @@ class SnapshotCommand extends AbstractRecordingCommand implements SerializableCo
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            cw.println("Expected one argument: hostname:port, ip:port, or JMX service URL");
-            return false;
+            throw new FailedValidationException(
+                    "Expected one argument: hostname:port, ip:port, or JMX service URL");
         }
-        boolean isValidTargetId = validateTargetId(args[0]);
-        if (!isValidTargetId) {
-            cw.println(String.format("%s is an invalid connection specifier", args[0]));
+        if (!validateTargetId(args[0])) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", args[0]));
         }
-        return isValidTargetId;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SnapshotCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SnapshotCommand.java
@@ -131,12 +131,15 @@ class SnapshotCommand extends AbstractRecordingCommand implements SerializableCo
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            throw new FailedValidationException(
-                    "Expected one argument: hostname:port, ip:port, or JMX service URL");
+            String errorMessage =
+                    "Expected one argument: hostname:port, ip:port, or JMX service URL";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
         if (!validateTargetId(args[0])) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", args[0]));
+            String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommand.java
@@ -135,33 +135,29 @@ class StartRecordingCommand extends AbstractRecordingCommand implements Serializ
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 3) {
-            cw.println(
+            throw new FailedValidationException(
                     "Expected three arguments: target (host:port, ip:port, or JMX service URL), recording name, and event types");
-            return false;
         }
 
         String targetId = args[0];
         String name = args[1];
         String events = args[2];
 
-        boolean isValidTargetId = validateTargetId(targetId);
-        boolean isValidName = validateRecordingName(name);
-        boolean isValidEvents = validateEvents(events);
-
-        if (!isValidTargetId) {
-            cw.println(String.format("%s is an invalid connection specifier", args[0]));
+        if (!validateTargetId(targetId)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", args[0]));
         }
 
-        if (!isValidName) {
-            cw.println(String.format("%s is an invalid recording name", name));
+        if (!validateRecordingName(name)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid recording name", name));
         }
 
-        if (!isValidEvents) {
-            cw.println(String.format("%s is an invalid events specifier", events));
+        if (!validateEvents(events)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid events specifier", events));
         }
-
-        return isValidTargetId && isValidName && isValidEvents;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommand.java
@@ -41,6 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
+import java.util.StringJoiner;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -146,28 +148,28 @@ class StartRecordingCommand extends AbstractRecordingCommand implements Serializ
         String targetId = args[0];
         String name = args[1];
         String events = args[2];
-        StringBuilder combinedErrorMessage = new StringBuilder();
+        StringJoiner combinedErrorMessage = new StringJoiner("; ");
 
         if (!validateTargetId(targetId)) {
             String errorMessage = String.format("%s is an invalid connection specifier", targetId);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (!validateRecordingName(name)) {
             String errorMessage = String.format("%s is an invalid recording name", name);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (!validateEvents(events)) {
             String errorMessage = String.format("%s is an invalid events specifier", events);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (combinedErrorMessage.length() > 0) {
-            throw new FailedValidationException(combinedErrorMessage.substring(2));
+            throw new FailedValidationException(combinedErrorMessage.toString());
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommand.java
@@ -146,23 +146,28 @@ class StartRecordingCommand extends AbstractRecordingCommand implements Serializ
         String targetId = args[0];
         String name = args[1];
         String events = args[2];
+        StringBuilder combinedErrorMessage = new StringBuilder();
 
         if (!validateTargetId(targetId)) {
-            String errorMessage = "%s is an invalid connection specifier";
+            String errorMessage = String.format("%s is an invalid connection specifier", targetId);
             cw.println(errorMessage);
-            throw new FailedValidationException(String.format(errorMessage, args[0]));
+            combinedErrorMessage.append("; ").append(errorMessage);
         }
 
         if (!validateRecordingName(name)) {
-            String errorMessage = "%s is an invalid recording name";
+            String errorMessage = String.format("%s is an invalid recording name", name);
             cw.println(errorMessage);
-            throw new FailedValidationException(String.format(errorMessage, name));
+            combinedErrorMessage.append("; ").append(errorMessage);
         }
 
         if (!validateEvents(events)) {
-            String errorMessage = "%s is an invalid events specifier";
+            String errorMessage = String.format("%s is an invalid events specifier", events);
             cw.println(errorMessage);
-            throw new FailedValidationException(String.format(errorMessage, events));
+            combinedErrorMessage.append("; ").append(errorMessage);
+        }
+
+        if (combinedErrorMessage.length() > 0) {
+            throw new FailedValidationException(combinedErrorMessage.substring(2));
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommand.java
@@ -137,8 +137,10 @@ class StartRecordingCommand extends AbstractRecordingCommand implements Serializ
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 3) {
-            throw new FailedValidationException(
-                    "Expected three arguments: target (host:port, ip:port, or JMX service URL), recording name, and event types");
+            String errorMessage =
+                    "Expected three arguments: target (host:port, ip:port, or JMX service URL), recording name, and event types";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         String targetId = args[0];
@@ -146,18 +148,21 @@ class StartRecordingCommand extends AbstractRecordingCommand implements Serializ
         String events = args[2];
 
         if (!validateTargetId(targetId)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", args[0]));
+            String errorMessage = "%s is an invalid connection specifier";
+            cw.println(errorMessage);
+            throw new FailedValidationException(String.format(errorMessage, args[0]));
         }
 
         if (!validateRecordingName(name)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid recording name", name));
+            String errorMessage = "%s is an invalid recording name";
+            cw.println(errorMessage);
+            throw new FailedValidationException(String.format(errorMessage, name));
         }
 
         if (!validateEvents(events)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid events specifier", events));
+            String errorMessage = "%s is an invalid events specifier";
+            cw.println(errorMessage);
+            throw new FailedValidationException(String.format(errorMessage, events));
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommand.java
@@ -42,6 +42,7 @@
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
 import java.util.Optional;
+import java.util.StringJoiner;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -121,22 +122,22 @@ class StopRecordingCommand extends AbstractConnectedCommand implements Serializa
 
         String targetId = args[0];
         String name = args[1];
-        StringBuilder combinedErrorMessage = new StringBuilder();
+        StringJoiner combinedErrorMessage = new StringJoiner("; ");
 
         if (!validateTargetId(targetId)) {
             String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (!validateRecordingName(name)) {
             String errorMessage = String.format("%s is an invalid recording name", name);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (combinedErrorMessage.length() > 0) {
-            throw new FailedValidationException(combinedErrorMessage.substring(2));
+            throw new FailedValidationException(combinedErrorMessage.toString());
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommand.java
@@ -121,17 +121,22 @@ class StopRecordingCommand extends AbstractConnectedCommand implements Serializa
 
         String targetId = args[0];
         String name = args[1];
+        StringBuilder combinedErrorMessage = new StringBuilder();
 
         if (!validateTargetId(targetId)) {
             String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
             cw.println(errorMessage);
-            throw new FailedValidationException(errorMessage);
+            combinedErrorMessage.append("; ").append(errorMessage);
         }
 
         if (!validateRecordingName(name)) {
             String errorMessage = String.format("%s is an invalid recording name", name);
             cw.println(errorMessage);
-            throw new FailedValidationException(errorMessage);
+            combinedErrorMessage.append("; ").append(errorMessage);
+        }
+
+        if (combinedErrorMessage.length() > 0) {
+            throw new FailedValidationException(combinedErrorMessage.substring(2));
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommand.java
@@ -111,27 +111,23 @@ class StopRecordingCommand extends AbstractConnectedCommand implements Serializa
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 2) {
-            cw.println(
+            throw new FailedValidationException(
                     "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name");
-            return false;
         }
 
         String targetId = args[0];
         String name = args[1];
 
-        boolean isValidTargetId = validateTargetId(targetId);
-        boolean isValidName = validateRecordingName(name);
-
-        if (!isValidTargetId) {
-            cw.println(String.format("%s is an invalid connection specifier", args[0]));
+        if (!validateTargetId(targetId)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", args[0]));
         }
 
-        if (!isValidName) {
-            cw.println(String.format("%s is an invalid recording name", name));
+        if (!validateRecordingName(name)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid recording name", name));
         }
-
-        return isValidTargetId && isValidName;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommand.java
@@ -113,21 +113,25 @@ class StopRecordingCommand extends AbstractConnectedCommand implements Serializa
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 2) {
-            throw new FailedValidationException(
-                    "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name");
+            String errorMessage =
+                    "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         String targetId = args[0];
         String name = args[1];
 
         if (!validateTargetId(targetId)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", args[0]));
+            String errorMessage = String.format("%s is an invalid connection specifier", args[0]);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         if (!validateRecordingName(name)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid recording name", name));
+            String errorMessage = String.format("%s is an invalid recording name", name);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -48,6 +48,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 
 import javax.inject.Inject;
@@ -185,22 +186,22 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
         String targetId = args[0];
         String recordingName = args[1];
         // String uploadUrl = args[2];
-        StringBuilder combinedErrorMessage = new StringBuilder();
+        StringJoiner combinedErrorMessage = new StringJoiner("; ");
 
         if (!validateTargetId(targetId)) {
             String errorMessage = String.format("%s is an invalid connection specifier", targetId);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (!validateRecordingName(recordingName)) {
             String errorMessage = String.format("%s is an invalid recording name", recordingName);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (combinedErrorMessage.length() > 0) {
-            throw new FailedValidationException(combinedErrorMessage.substring(2));
+            throw new FailedValidationException(combinedErrorMessage.toString());
         }
 
         // TODO validate upload URL

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -174,30 +174,27 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 3) {
-            cw.println(
+            throw new FailedValidationException(
                     "Expected three arguments: target (host:port, ip:port, or JMX service URL), recording name, and upload URL");
-            return false;
         }
 
         String targetId = args[0];
         String recordingName = args[1];
         // String uploadUrl = args[2];
 
-        boolean isValidTargetId = validateTargetId(targetId);
-        if (!isValidTargetId) {
-            cw.println(String.format("%s is an invalid connection specifier", args[0]));
+        if (!validateTargetId(targetId)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", args[0]));
         }
 
-        boolean isValidRecordingName = validateRecordingName(recordingName);
-        if (!isValidRecordingName) {
-            cw.println(String.format("%s is an invalid recording name", recordingName));
+        if (!validateRecordingName(recordingName)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid recording name", recordingName));
         }
 
         // TODO validate upload URL
-
-        return isValidTargetId && isValidRecordingName;
     }
 
     // returned stream should be cleaned up by HttpClient

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -176,8 +176,10 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 3) {
-            throw new FailedValidationException(
-                    "Expected three arguments: target (host:port, ip:port, or JMX service URL), recording name, and upload URL");
+            String errorMessage =
+                    "Expected three arguments: target (host:port, ip:port, or JMX service URL), recording name, and upload URL";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         String targetId = args[0];
@@ -185,13 +187,15 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
         // String uploadUrl = args[2];
 
         if (!validateTargetId(targetId)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", args[0]));
+            String errorMessage = "%s is an invalid connection specifier";
+            cw.println(errorMessage);
+            throw new FailedValidationException(String.format(errorMessage, args[0]));
         }
 
         if (!validateRecordingName(recordingName)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid recording name", recordingName));
+            String errorMessage = "%s is an invalid recording name";
+            cw.println(errorMessage);
+            throw new FailedValidationException(String.format(errorMessage, recordingName));
         }
 
         // TODO validate upload URL

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -185,17 +185,22 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
         String targetId = args[0];
         String recordingName = args[1];
         // String uploadUrl = args[2];
+        StringBuilder combinedErrorMessage = new StringBuilder();
 
         if (!validateTargetId(targetId)) {
-            String errorMessage = "%s is an invalid connection specifier";
+            String errorMessage = String.format("%s is an invalid connection specifier", targetId);
             cw.println(errorMessage);
-            throw new FailedValidationException(String.format(errorMessage, args[0]));
+            combinedErrorMessage.append("; ").append(errorMessage);
         }
 
         if (!validateRecordingName(recordingName)) {
-            String errorMessage = "%s is an invalid recording name";
+            String errorMessage = String.format("%s is an invalid recording name", recordingName);
             cw.println(errorMessage);
-            throw new FailedValidationException(String.format(errorMessage, recordingName));
+            combinedErrorMessage.append("; ").append(errorMessage);
+        }
+
+        if (combinedErrorMessage.length() > 0) {
+            throw new FailedValidationException(combinedErrorMessage.substring(2));
         }
 
         // TODO validate upload URL

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitCommand.java
@@ -88,11 +88,15 @@ class WaitCommand implements Command {
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            throw new FailedValidationException("Expected one argument");
+            String errorMessage = "Expected one argument";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         if (!args[0].matches("\\d+")) {
-            throw new FailedValidationException(String.format("%s is an invalid integer", args[0]));
+            String errorMessage = "%s is an invalid integer";
+            cw.println(errorMessage);
+            throw new FailedValidationException(String.format(errorMessage, args[0]));
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitCommand.java
@@ -86,18 +86,14 @@ class WaitCommand implements Command {
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 1) {
-            cw.println("Expected one argument");
-            return false;
+            throw new FailedValidationException("Expected one argument");
         }
 
         if (!args[0].matches("\\d+")) {
-            cw.println(String.format("%s is an invalid integer", args[0]));
-            return false;
+            throw new FailedValidationException(String.format("%s is an invalid integer", args[0]));
         }
-
-        return true;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitCommand.java
@@ -94,9 +94,9 @@ class WaitCommand implements Command {
         }
 
         if (!args[0].matches("\\d+")) {
-            String errorMessage = "%s is an invalid integer";
+            String errorMessage = String.format("%s is an invalid integer", args[0]);
             cw.println(errorMessage);
-            throw new FailedValidationException(String.format(errorMessage, args[0]));
+            throw new FailedValidationException(String.format(errorMessage));
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommand.java
@@ -42,6 +42,7 @@
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
@@ -147,22 +148,22 @@ class WaitForCommand extends AbstractConnectedCommand {
 
         String targetID = args[0];
         String recordingName = args[1];
-        StringBuilder combinedErrorMessage = new StringBuilder();
+        StringJoiner combinedErrorMessage = new StringJoiner("; ");
 
         if (!validateTargetId(targetID)) {
             String errorMessage = String.format("%s is an invalid connection specifier", targetID);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (!validateRecordingName(recordingName)) {
             String errorMessage = String.format("%s is an invalid recording name", recordingName);
             cw.println(errorMessage);
-            combinedErrorMessage.append("; ").append(errorMessage);
+            combinedErrorMessage.add(errorMessage);
         }
 
         if (combinedErrorMessage.length() > 0) {
-            throw new FailedValidationException(combinedErrorMessage.substring(2));
+            throw new FailedValidationException(combinedErrorMessage.toString());
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommand.java
@@ -139,21 +139,25 @@ class WaitForCommand extends AbstractConnectedCommand {
     @Override
     public void validate(String[] args) throws FailedValidationException {
         if (args.length != 2) {
-            throw new FailedValidationException(
-                    "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name");
+            String errorMessage =
+                    "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name";
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         String targetID = args[0];
         String recordingName = args[1];
 
         if (!validateTargetId(targetID)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid connection specifier", targetID));
+            String errorMessage = String.format("%s is an invalid connection specifier", targetID);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
 
         if (!validateRecordingName(recordingName)) {
-            throw new FailedValidationException(
-                    String.format("%s is an invalid recording name", recordingName));
+            String errorMessage = String.format("%s is an invalid recording name", recordingName);
+            cw.println(errorMessage);
+            throw new FailedValidationException(errorMessage);
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommand.java
@@ -137,26 +137,23 @@ class WaitForCommand extends AbstractConnectedCommand {
     }
 
     @Override
-    public boolean validate(String[] args) {
+    public void validate(String[] args) throws FailedValidationException {
         if (args.length != 2) {
-            cw.println(
+            throw new FailedValidationException(
                     "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name");
-            return false;
         }
 
         String targetID = args[0];
         String recordingName = args[1];
 
-        boolean isValidTargetId = validateTargetId(targetID);
-        if (!isValidTargetId) {
-            cw.println(String.format("%s is an invalid connection specifier", targetID));
+        if (!validateTargetId(targetID)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid connection specifier", targetID));
         }
 
-        boolean isValidRecordingName = validateRecordingName(recordingName);
-        if (!isValidRecordingName) {
-            cw.println(String.format("%s is an invalid recording name", recordingName));
+        if (!validateRecordingName(recordingName)) {
+            throw new FailedValidationException(
+                    String.format("%s is an invalid recording name", recordingName));
         }
-
-        return isValidTargetId && isValidRecordingName;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommand.java
@@ -147,17 +147,22 @@ class WaitForCommand extends AbstractConnectedCommand {
 
         String targetID = args[0];
         String recordingName = args[1];
+        StringBuilder combinedErrorMessage = new StringBuilder();
 
         if (!validateTargetId(targetID)) {
             String errorMessage = String.format("%s is an invalid connection specifier", targetID);
             cw.println(errorMessage);
-            throw new FailedValidationException(errorMessage);
+            combinedErrorMessage.append("; ").append(errorMessage);
         }
 
         if (!validateRecordingName(recordingName)) {
             String errorMessage = String.format("%s is an invalid recording name", recordingName);
             cw.println(errorMessage);
-            throw new FailedValidationException(errorMessage);
+            combinedErrorMessage.append("; ").append(errorMessage);
+        }
+
+        if (combinedErrorMessage.length() > 0) {
+            throw new FailedValidationException(combinedErrorMessage.substring(2));
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/AbstractCommandExecutor.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/AbstractCommandExecutor.java
@@ -112,7 +112,7 @@ public abstract class AbstractCommandExecutor implements CommandExecutor {
             } catch (FailedValidationException e) {
                 cw.println(
                         String.format(
-                                "Could not validate %s command; %s",
+                                "Could not validate \"%s\" command; %s",
                                 commandLine.command, e.getMessage()));
                 allValid = false;
             }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/AbstractCommandExecutor.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/AbstractCommandExecutor.java
@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
 
 import com.redhat.rhjmc.containerjfr.commands.CommandRegistry;
 import com.redhat.rhjmc.containerjfr.commands.internal.ExitCommand;
+import com.redhat.rhjmc.containerjfr.commands.internal.FailedValidationException;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientReader;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import dagger.Lazy;
@@ -106,15 +107,15 @@ public abstract class AbstractCommandExecutor implements CommandExecutor {
     protected boolean validateCommands(Collection<CommandLine> commandLines) {
         boolean allValid = true;
         for (CommandLine commandLine : commandLines) {
-            boolean valid =
-                    this.commandRegistry.get().validate(commandLine.command, commandLine.args);
-            if (!valid) {
+            try {
+                this.commandRegistry.get().validate(commandLine.command, commandLine.args);
+            } catch (FailedValidationException e) {
                 cw.println(
                         String.format(
-                                "\t\"%s\" are invalid arguments to %s",
-                                Arrays.asList(commandLine.args), commandLine.command));
+                                "Could not validate %s command; %s",
+                                commandLine.command, e.getMessage()));
+                allValid = false;
             }
-            allValid &= valid;
         }
         return allValid;
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/AbstractCommandExecutor.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/AbstractCommandExecutor.java
@@ -112,8 +112,7 @@ public abstract class AbstractCommandExecutor implements CommandExecutor {
             } catch (FailedValidationException e) {
                 cw.println(
                         String.format(
-                                "Could not validate \"%s\" command; %s",
-                                commandLine.command, e.getMessage()));
+                                "\tCommand \"%s\" could not be validated", commandLine.command));
                 allValid = false;
             }
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/FailedValidationResponseMessage.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/FailedValidationResponseMessage.java
@@ -47,6 +47,6 @@ class FailedValidationResponseMessage extends ResponseMessage<String> {
                 id,
                 -1,
                 commandName,
-                String.format("Could not validate %s command; %s", commandName, errorMessage));
+                String.format("Could not validate \"%s\" command; %s", commandName, errorMessage));
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/FailedValidationResponseMessage.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/FailedValidationResponseMessage.java
@@ -47,6 +47,6 @@ class FailedValidationResponseMessage extends ResponseMessage<String> {
                 id,
                 -1,
                 commandName,
-                String.format("Could not validate \"%s\" command; %s", commandName, errorMessage));
+                String.format("Could not validate \"%s\" command: %s", commandName, errorMessage));
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/FailedValidationResponseMessage.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/FailedValidationResponseMessage.java
@@ -41,14 +41,12 @@
  */
 package com.redhat.rhjmc.containerjfr.tui.ws;
 
-import java.util.Arrays;
-
-class InvalidCommandArgumentsResponseMessage extends ResponseMessage<String> {
-    InvalidCommandArgumentsResponseMessage(String id, String commandName, String[] args) {
+class FailedValidationResponseMessage extends ResponseMessage<String> {
+    FailedValidationResponseMessage(String id, String commandName, String errorMessage) {
         super(
                 id,
                 -1,
                 commandName,
-                String.format("%s are invalid arguments to %s", Arrays.asList(args), commandName));
+                String.format("Could not validate %s command; %s", commandName, errorMessage));
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/WsCommandExecutor.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/tui/ws/WsCommandExecutor.java
@@ -50,6 +50,7 @@ import com.google.gson.JsonSyntaxException;
 
 import com.redhat.rhjmc.containerjfr.commands.SerializableCommand;
 import com.redhat.rhjmc.containerjfr.commands.SerializableCommandRegistry;
+import com.redhat.rhjmc.containerjfr.commands.internal.FailedValidationException;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientReader;
 import com.redhat.rhjmc.containerjfr.tui.CommandExecutor;
@@ -108,10 +109,12 @@ class WsCommandExecutor implements CommandExecutor {
                         flush(new CommandUnavailableMessage(commandMessage.id, commandName));
                         continue;
                     }
-                    if (!registry.get().validate(commandName, args)) {
+                    try {
+                        registry.get().validate(commandName, args);
+                    } catch (FailedValidationException e) {
                         flush(
-                                new InvalidCommandArgumentsResponseMessage(
-                                        commandMessage.id, commandName, args));
+                                new FailedValidationResponseMessage(
+                                        commandMessage.id, commandName, e.getMessage()));
                         continue;
                     }
                     SerializableCommand.Output<?> out = registry.get().execute(commandName, args);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractConnectedCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractConnectedCommandTest.java
@@ -141,8 +141,8 @@ class AbstractConnectedCommandTest {
         public void execute(String[] args) {}
 
         @Override
-        public boolean validate(String[] args) {
-            return true;
+        public void validate(String[] args) throws FailedValidationException {
+            return;
         }
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractConnectedCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractConnectedCommandTest.java
@@ -141,8 +141,6 @@ class AbstractConnectedCommandTest {
         public void execute(String[] args) {}
 
         @Override
-        public void validate(String[] args) throws FailedValidationException {
-            return;
-        }
+        public void validate(String[] args) throws FailedValidationException {}
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommandTest.java
@@ -217,9 +217,7 @@ class AbstractRecordingCommandTest extends TestBase {
         }
 
         @Override
-        public void validate(String[] args) throws FailedValidationException {
-            return;
-        }
+        public void validate(String[] args) throws FailedValidationException {}
 
         @Override
         public void execute(String[] args) {}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommandTest.java
@@ -42,8 +42,6 @@
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -108,7 +106,6 @@ class AbstractRecordingCommandTest extends TestBase {
             })
     void shouldNotValidateInvalidEventString(String events) {
         assertFalse(command.validateEvents(events));
-        assertThat(stdout(), equalTo(events + " is an invalid events pattern\n"));
     }
 
     @ParameterizedTest
@@ -124,7 +121,6 @@ class AbstractRecordingCommandTest extends TestBase {
             })
     void shouldValidateValidEventString(String events) {
         assertTrue(command.validateEvents(events));
-        assertThat(stdout(), emptyString());
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/AbstractRecordingCommandTest.java
@@ -217,8 +217,8 @@ class AbstractRecordingCommandTest extends TestBase {
         }
 
         @Override
-        public boolean validate(String[] args) {
-            return true;
+        public void validate(String[] args) throws FailedValidationException {
+            return;
         }
 
         @Override

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandRegistryImplTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandRegistryImplTest.java
@@ -242,9 +242,7 @@ public class CommandRegistryImplTest extends TestBase {
         }
 
         @Override
-        public void validate(String[] args) throws FailedValidationException {
-            return;
-        }
+        public void validate(String[] args) throws FailedValidationException {}
 
         @Override
         public void execute(String[] args) {

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandRegistryImplTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandRegistryImplTest.java
@@ -54,7 +54,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -105,7 +104,7 @@ public class CommandRegistryImplTest extends TestBase {
         @Test
         public void shouldNotValidateCommands() throws Exception {
             Exception e =
-                    Assertions.assertThrows(
+                    assertThrows(
                             FailedValidationException.class,
                             () -> registry.validate("foo", new String[0]));
             assertThat(stdout(), equalTo("Command \"foo\" not recognized\n"));
@@ -174,7 +173,7 @@ public class CommandRegistryImplTest extends TestBase {
         @Test
         public void shouldNotValidateUnknownCommands() throws Exception {
             Exception e =
-                    Assertions.assertThrows(
+                    assertThrows(
                             FailedValidationException.class,
                             () -> registry.validate("baz", new String[0]));
             assertThat(stdout(), equalTo("Command \"baz\" not recognized\n"));
@@ -209,7 +208,7 @@ public class CommandRegistryImplTest extends TestBase {
         @Test
         public void shouldThrowCommandDefinitionException() {
             CommandRegistryImpl.CommandDefinitionException thrown =
-                    Assertions.assertThrows(
+                    assertThrows(
                             CommandRegistryImpl.CommandDefinitionException.class,
                             () ->
                                     new CommandRegistryImpl(

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommandTest.java
@@ -41,7 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -107,7 +107,13 @@ class DeleteCommandTest implements ValidatesTargetId, ValidatesRecordingName {
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 3})
     void shouldInvalidateIncorrectArgc(int c) {
-        assertFalse(command.validate(new String[c]));
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[c]));
+        String errorMessage =
+                "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommandTest.java
@@ -117,6 +117,19 @@ class DeleteCommandTest implements ValidatesTargetId, ValidatesRecordingName {
     }
 
     @Test
+    void shouldNotValidateInvalidTargetIdAndRecordingName() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () -> command.validate(new String[] {":", ":"}));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording name";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid recording name");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
     void shouldCloseNamedRecording() throws Exception {
         when(targetConnectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any()))
                 .thenAnswer(

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommandTest.java
@@ -106,10 +106,10 @@ class DeleteCommandTest implements ValidatesTargetId, ValidatesRecordingName {
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 3})
-    void shouldInvalidateIncorrectArgc(int c) {
+    void shouldNotValidateIncorrectArgc(int argc) {
         Exception e =
                 assertThrows(
-                        FailedValidationException.class, () -> command.validate(new String[c]));
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
         String errorMessage =
                 "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name";
         verify(cw).println(errorMessage);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteSavedRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteSavedRecordingCommandTest.java
@@ -99,8 +99,12 @@ class DeleteSavedRecordingCommandTest implements ValidatesRecordingName {
     @ParameterizedTest
     @ValueSource(ints = {0, 2})
     void shouldNotValidateWrongArgCounts(int count) {
-        Assertions.assertFalse(command.validate(new String[count]));
-        verify(cw).println("Expected one argument: recording name");
+        Exception e =
+                Assertions.assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[count]));
+        String errorMessage = "Expected one argument: recording name";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteSavedRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteSavedRecordingCommandTest.java
@@ -98,10 +98,10 @@ class DeleteSavedRecordingCommandTest implements ValidatesRecordingName {
 
     @ParameterizedTest
     @ValueSource(ints = {0, 2})
-    void shouldNotValidateWrongArgCounts(int count) {
+    void shouldNotValidateIncorrectArgc(int argc) {
         Exception e =
                 Assertions.assertThrows(
-                        FailedValidationException.class, () -> command.validate(new String[count]));
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
         String errorMessage = "Expected one argument: recording name";
         verify(cw).println(errorMessage);
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommandTest.java
@@ -126,6 +126,188 @@ class DumpCommandTest
     }
 
     @Test
+    void shouldNotValidateInvalidTargetIdAndRecordingName() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () ->
+                                command.validate(
+                                        new String[] {
+                                            ":",
+                                            ":",
+                                            MOCK_RECORDING_DURATION,
+                                            MOCK_RECORDING_EVENT_SPECIFIER
+                                        }));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording name";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid recording name");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidRecordingNameAndRecordingLength() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () ->
+                                command.validate(
+                                        new String[] {
+                                            MOCK_TARGET_ID, ":", ":", MOCK_RECORDING_EVENT_SPECIFIER
+                                        }));
+        String errorMessage = ": is an invalid recording name; : is an invalid recording length";
+        verify(cw).println(": is an invalid recording name");
+        verify(cw).println(": is an invalid recording length");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidRecordingLengthAndEventSpecifier() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () ->
+                                command.validate(
+                                        new String[] {
+                                            MOCK_TARGET_ID, MOCK_RECORDING_NAME, ":", ":"
+                                        }));
+        String errorMessage = ": is an invalid recording length; : is an invalid events specifier";
+        verify(cw).println(": is an invalid recording length");
+        verify(cw).println(": is an invalid events specifier");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidTargetIdAndRecordingLength() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () ->
+                                command.validate(
+                                        new String[] {
+                                            ":",
+                                            MOCK_RECORDING_NAME,
+                                            ":",
+                                            MOCK_RECORDING_EVENT_SPECIFIER
+                                        }));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording length";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid recording length");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidRecordingNameAndEventSpecifier() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () ->
+                                command.validate(
+                                        new String[] {
+                                            MOCK_TARGET_ID, ":", MOCK_RECORDING_DURATION, ":"
+                                        }));
+        String errorMessage = ": is an invalid recording name; : is an invalid events specifier";
+        verify(cw).println(": is an invalid recording name");
+        verify(cw).println(": is an invalid events specifier");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidTargetIdAndEventSpecifier() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () ->
+                                command.validate(
+                                        new String[] {
+                                            ":", MOCK_RECORDING_NAME, MOCK_RECORDING_DURATION, ":"
+                                        }));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid events specifier";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid events specifier");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidTargetIdRecordingNameRecordingLength() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () ->
+                                command.validate(
+                                        new String[] {
+                                            ":", ":", ":", MOCK_RECORDING_EVENT_SPECIFIER
+                                        }));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording name; : is an invalid recording length";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid recording name");
+        verify(cw).println(": is an invalid recording length");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidTargetIdRecordingNameEventSpecifier() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () ->
+                                command.validate(
+                                        new String[] {":", ":", MOCK_RECORDING_DURATION, ":"}));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording name; : is an invalid events specifier";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid recording name");
+        verify(cw).println(": is an invalid events specifier");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidTargetIdRecordingLengthEventSpecifier() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () -> command.validate(new String[] {":", MOCK_RECORDING_NAME, ":", ":"}));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording length; : is an invalid events specifier";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid recording length");
+        verify(cw).println(": is an invalid events specifier");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidRecordingNameRecordingLengthEventSpecifier() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () -> command.validate(new String[] {MOCK_TARGET_ID, ":", ":", ":"}));
+        String errorMessage =
+                ": is an invalid recording name; : is an invalid recording length; : is an invalid events specifier";
+        verify(cw).println(": is an invalid recording name");
+        verify(cw).println(": is an invalid recording length");
+        verify(cw).println(": is an invalid events specifier");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidTargetIdRecordingNameRecordingLengthEventSpecifier() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () -> command.validate(new String[] {":", ":", ":", ":"}));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording name; : is an invalid recording length; : is an invalid events specifier";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid recording name");
+        verify(cw).println(": is an invalid recording length");
+        verify(cw).println(": is an invalid events specifier");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
     void shouldNotValidateInvalidRecordingLength() {
         Exception e =
                 assertThrows(

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommandTest.java
@@ -115,7 +115,7 @@ class DumpCommandTest
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 3, 5})
-    void shouldPrintArgMessageWhenArgcInvalid(int argc) {
+    void shouldNotValidateIncorrectArgc(int argc) {
         Exception e =
                 assertThrows(
                         FailedValidationException.class, () -> command.validate(new String[argc]));
@@ -126,7 +126,7 @@ class DumpCommandTest
     }
 
     @Test
-    void shouldNotValidateRecordingLengthInvalid() {
+    void shouldNotValidateInvalidRecordingLength() {
         Exception e =
                 assertThrows(
                         FailedValidationException.class,

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ExitCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ExitCommandTest.java
@@ -41,7 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -79,14 +80,18 @@ class ExitCommandTest {
 
     @Test
     void shouldExpectNoArgs() {
-        assertTrue(command.validate(new String[0]));
+        assertDoesNotThrow(() -> command.validate(new String[0]));
         verifyZeroInteractions(cw);
     }
 
     @Test
     void shouldNotExpectArgs() {
-        assertFalse(command.validate(new String[1]));
-        verify(cw).println("No arguments expected");
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[1]));
+        String errorMessage = "No arguments expected";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/HelpCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/HelpCommandTest.java
@@ -41,7 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
@@ -87,13 +88,15 @@ class HelpCommandTest {
 
     @Test
     void shouldExpectNoArgs() {
-        assertTrue(command.validate(new String[0]));
+        assertDoesNotThrow(() -> command.validate(new String[0]));
         verifyZeroInteractions(cw);
     }
 
     @Test
     void shouldNotExpectArgs() {
-        assertFalse(command.validate(new String[1]));
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[1]));
         verify(cw).println("No arguments expected");
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/HostnameCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/HostnameCommandTest.java
@@ -41,7 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -80,14 +81,18 @@ class HostnameCommandTest {
 
     @Test
     void shouldExpectNoArgs() {
-        assertTrue(command.validate(new String[0]));
+        assertDoesNotThrow(() -> command.validate(new String[0]));
         verifyZeroInteractions(cw);
     }
 
     @Test
     void shouldNotExpectArgs() {
-        assertFalse(command.validate(new String[1]));
-        verify(cw).println("No arguments expected");
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[1]));
+        String errorMessage = "No arguments expected";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/IpCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/IpCommandTest.java
@@ -41,7 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -80,14 +81,18 @@ class IpCommandTest {
 
     @Test
     void shouldExpectNoArgs() {
-        assertTrue(command.validate(new String[0]));
+        assertDoesNotThrow(() -> command.validate(new String[0]));
         verifyZeroInteractions(cw);
     }
 
     @Test
     void shouldNotExpectArgs() {
-        assertFalse(command.validate(new String[1]));
-        verify(cw).println("No arguments expected");
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[1]));
+        String errorMessage = "No arguments expected";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListCommandTest.java
@@ -41,9 +41,10 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -118,7 +119,12 @@ class ListCommandTest implements ValidatesTargetId {
     @ParameterizedTest
     @ValueSource(ints = {0, 2})
     void shouldNotValidateIncorrectArgc(int argc) {
-        assertFalse(command.validate(new String[argc]));
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
+        String errorMessage = "Expected one argument: hostname:port, ip:port, or JMX service URL";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommandTest.java
@@ -101,7 +101,12 @@ class ListEventTemplatesCommandTest implements ValidatesTargetId {
     @ParameterizedTest
     @ValueSource(ints = {0, 2})
     void shouldNotValidateWrongArgc(int n) {
-        Assertions.assertFalse(cmd.validate(new String[n]));
+        Exception e =
+                Assertions.assertThrows(
+                        FailedValidationException.class, () -> cmd.validate(new String[n]));
+        String errorMessage = "Expected one argument: hostname:port, ip:port, or JMX service URL";
+        Mockito.verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTemplatesCommandTest.java
@@ -100,10 +100,10 @@ class ListEventTemplatesCommandTest implements ValidatesTargetId {
 
     @ParameterizedTest
     @ValueSource(ints = {0, 2})
-    void shouldNotValidateWrongArgc(int n) {
+    void shouldNotValidateWrongArgc(int argc) {
         Exception e =
                 Assertions.assertThrows(
-                        FailedValidationException.class, () -> cmd.validate(new String[n]));
+                        FailedValidationException.class, () -> cmd.validate(new String[argc]));
         String errorMessage = "Expected one argument: hostname:port, ip:port, or JMX service URL";
         Mockito.verify(cw).println(errorMessage);
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTypesCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListEventTypesCommandTest.java
@@ -41,7 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -109,8 +109,12 @@ class ListEventTypesCommandTest implements ValidatesTargetId {
     @ParameterizedTest
     @ValueSource(ints = {0, 2})
     void shouldNotValidateWrongArgc(int argc) {
-        assertFalse(command.validate(new String[argc]));
-        verify(cw).println("Expected one argument: hostname:port, ip:port, or JMX service URL");
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
+        String errorMessage = "Expected one argument: hostname:port, ip:port, or JMX service URL";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListRecordingOptionsCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListRecordingOptionsCommandTest.java
@@ -41,9 +41,10 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -105,7 +106,12 @@ class ListRecordingOptionsCommandTest implements ValidatesTargetId {
     @ParameterizedTest
     @ValueSource(ints = {0, 2})
     void shouldNotValidateIncorrectArgc(int argc) {
-        assertFalse(command.validate(new String[argc]));
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
+        String errorMessage = "Expected one argument: hostname:port, ip:port, or JMX service URL";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommandTest.java
@@ -93,17 +93,17 @@ class ListSavedRecordingsCommandTest {
 
     @ParameterizedTest
     @ValueSource(ints = {1, 2})
-    void shouldNotValidateIncorrectArgc(int count) {
+    void shouldNotValidateIncorrectArgc(int argc) {
         Exception e =
                 Assertions.assertThrows(
-                        FailedValidationException.class, () -> command.validate(new String[count]));
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
         String errorMessage = "No arguments expected";
         verify(cw).println(errorMessage);
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test
-    void shouldValidateEmptyArgs() {
+    void shouldExpectNoArgs() {
         Assertions.assertDoesNotThrow(() -> command.validate(new String[0]));
         verifyZeroInteractions(cw);
     }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ListSavedRecordingsCommandTest.java
@@ -94,13 +94,17 @@ class ListSavedRecordingsCommandTest {
     @ParameterizedTest
     @ValueSource(ints = {1, 2})
     void shouldNotValidateIncorrectArgc(int count) {
-        Assertions.assertFalse(command.validate(new String[count]));
-        verify(cw).println("No arguments expected");
+        Exception e =
+                Assertions.assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[count]));
+        String errorMessage = "No arguments expected";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test
     void shouldValidateEmptyArgs() {
-        Assertions.assertTrue(command.validate(new String[0]));
+        Assertions.assertDoesNotThrow(() -> command.validate(new String[0]));
         verifyZeroInteractions(cw);
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/PingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/PingCommandTest.java
@@ -42,9 +42,11 @@
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,7 +76,8 @@ class PingCommandTest {
 
     @Test
     void shouldExpectNoArgs() {
-        MatcherAssert.assertThat(command.validate(new String[0]), Matchers.is(true));
+        Assertions.assertDoesNotThrow(() -> command.validate(new String[0]));
+        verifyNoMoreInteractions(cw);
     }
 
     @ParameterizedTest
@@ -83,8 +86,12 @@ class PingCommandTest {
                 1, 2,
             })
     void shouldNotExpectArgs(int argc) {
-        MatcherAssert.assertThat(command.validate(new String[argc]), Matchers.is(false));
-        verify(cw).println("No arguments expected");
+        Exception e =
+                Assertions.assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
+        String errorMessage = "No arguments expected";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/PingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/PingCommandTest.java
@@ -50,8 +50,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -80,15 +78,11 @@ class PingCommandTest {
         verifyNoMoreInteractions(cw);
     }
 
-    @ParameterizedTest
-    @ValueSource(
-            ints = {
-                1, 2,
-            })
-    void shouldNotExpectArgs(int argc) {
+    @Test
+    void shouldNotExpectArgs() {
         Exception e =
                 Assertions.assertThrows(
-                        FailedValidationException.class, () -> command.validate(new String[argc]));
+                        FailedValidationException.class, () -> command.validate(new String[1]));
         String errorMessage = "No arguments expected";
         verify(cw).println(errorMessage);
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/PrintUrlCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/PrintUrlCommandTest.java
@@ -41,7 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -88,14 +89,18 @@ class PrintUrlCommandTest {
 
     @Test
     void shouldExpectNoArgs() {
-        assertTrue(command.validate(new String[0]));
+        assertDoesNotThrow(() -> command.validate(new String[0]));
         verifyZeroInteractions(cw);
     }
 
     @Test
     void shouldNotExpectArgs() {
-        assertFalse(command.validate(new String[1]));
-        verify(cw).println("No arguments expected");
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[1]));
+        String errorMessage = "No arguments expected";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommandTest.java
@@ -114,10 +114,13 @@ class SaveRecordingCommandTest implements ValidatesTargetId, ValidatesRecordingN
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 3})
     void shouldNotValidateIncorrectArgc(int count) {
-        Assertions.assertFalse(command.validate(new String[count]));
-        verify(cw)
-                .println(
-                        "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name");
+        Exception e =
+                Assertions.assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[count]));
+        String errorMessage =
+                "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommandTest.java
@@ -124,6 +124,19 @@ class SaveRecordingCommandTest implements ValidatesTargetId, ValidatesRecordingN
     }
 
     @Test
+    void shouldNotValidateInvalidTargetIdAndRecordingName() {
+        Exception e =
+                Assertions.assertThrows(
+                        FailedValidationException.class,
+                        () -> command.validate(new String[] {":", ":"}));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording name";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid recording name");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
     void shouldNotBeAvailableWhenRecordingsPathNotDirectory() {
         when(fs.isDirectory(Mockito.any())).thenReturn(false);
         Assertions.assertFalse(command.isAvailable());

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommandTest.java
@@ -113,10 +113,10 @@ class SaveRecordingCommandTest implements ValidatesTargetId, ValidatesRecordingN
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 3})
-    void shouldNotValidateIncorrectArgc(int count) {
+    void shouldNotValidateIncorrectArgc(int argc) {
         Exception e =
                 Assertions.assertThrows(
-                        FailedValidationException.class, () -> command.validate(new String[count]));
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
         String errorMessage =
                 "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name";
         verify(cw).println(errorMessage);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ScanTargetsCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ScanTargetsCommandTest.java
@@ -49,8 +49,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -83,12 +81,11 @@ class ScanTargetsCommandTest {
         MatcherAssert.assertThat(command.getName(), Matchers.equalTo("scan-targets"));
     }
 
-    @ParameterizedTest
-    @ValueSource(ints = {1, 2, 3})
-    void shouldNotExpectArgs(int argc) {
+    @Test
+    void shouldNotExpectArgs() {
         Exception e =
                 Assertions.assertThrows(
-                        FailedValidationException.class, () -> command.validate(new String[argc]));
+                        FailedValidationException.class, () -> command.validate(new String[1]));
         String errorMessage = "No arguments expected";
         Mockito.verify(cw).println(errorMessage);
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ScanTargetsCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ScanTargetsCommandTest.java
@@ -86,12 +86,18 @@ class ScanTargetsCommandTest {
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 3})
     void shouldNotExpectArgs(int argc) {
-        Assertions.assertFalse(command.validate(new String[argc]));
+        Exception e =
+                Assertions.assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
+        String errorMessage = "No arguments expected";
+        Mockito.verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test
     void shouldExpectNoArgs() {
-        Assertions.assertTrue(command.validate(new String[0]));
+        Assertions.assertDoesNotThrow(() -> command.validate(new String[0]));
+        Mockito.verifyNoMoreInteractions(cw);
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SearchEventsCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SearchEventsCommandTest.java
@@ -41,7 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -106,7 +106,13 @@ class SearchEventsCommandTest implements ValidatesTargetId {
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 3})
     void shouldNotValidateIncorrectArgc(int argc) {
-        assertFalse(command.validate(new String[argc]));
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
+        String errorMessage =
+                "Expected two arguments: target (hostname:port, ip:port, or JMX service URL) and search term";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SerializableCommandRegistryImplTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SerializableCommandRegistryImplTest.java
@@ -254,9 +254,7 @@ public class SerializableCommandRegistryImplTest {
         }
 
         @Override
-        public void validate(String[] args) throws FailedValidationException {
-            return;
-        }
+        public void validate(String[] args) throws FailedValidationException {}
 
         @Override
         public void execute(String[] args) {
@@ -336,9 +334,7 @@ public class SerializableCommandRegistryImplTest {
         }
 
         @Override
-        public void validate(String[] args) throws FailedValidationException {
-            return;
-        }
+        public void validate(String[] args) throws FailedValidationException {}
 
         @Override
         public void execute(String[] args) {}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SerializableCommandRegistryImplTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SerializableCommandRegistryImplTest.java
@@ -211,7 +211,7 @@ public class SerializableCommandRegistryImplTest {
         @ParameterizedTest
         @ValueSource(strings = {"  "})
         @NullAndEmptySource
-        public void shouldHandleBlankOrNullCommandAvailability(String cmd) throws Exception {
+        public void shouldHandleBlankNullEmptyCommandAvailability(String cmd) throws Exception {
             assertFalse(registry.isCommandAvailable(cmd));
         }
     }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SerializableCommandRegistryImplTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SerializableCommandRegistryImplTest.java
@@ -55,7 +55,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -105,7 +104,7 @@ public class SerializableCommandRegistryImplTest {
         @Test
         public void shouldNotValidateCommands() throws Exception {
             Exception e =
-                    Assertions.assertThrows(
+                    assertThrows(
                             FailedValidationException.class,
                             () -> registry.validate("foo", new String[0]));
             assertThat(e.getMessage(), equalTo("Command \"foo\" not recognized"));
@@ -188,7 +187,7 @@ public class SerializableCommandRegistryImplTest {
         @Test
         public void shouldNotValidateUnknownCommands() throws Exception {
             Exception e =
-                    Assertions.assertThrows(
+                    assertThrows(
                             FailedValidationException.class,
                             () -> registry.validate("baz", new String[0]));
             assertThat(e.getMessage(), equalTo("Command \"baz\" not recognized"));
@@ -222,7 +221,7 @@ public class SerializableCommandRegistryImplTest {
         @Test
         public void shouldThrowCommandDefinitionException() {
             CommandRegistryImpl.CommandDefinitionException thrown =
-                    Assertions.assertThrows(
+                    assertThrows(
                             CommandRegistryImpl.CommandDefinitionException.class,
                             () ->
                                     new SerializableCommandRegistryImpl(

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SnapshotCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SnapshotCommandTest.java
@@ -114,10 +114,10 @@ class SnapshotCommandTest implements ValidatesTargetId {
             ints = {
                 0, 2,
             })
-    void shouldInvalidateIncorrectArgc(int c) {
+    void shouldNotValidateIncorrectArgc(int argc) {
         Exception e =
                 assertThrows(
-                        FailedValidationException.class, () -> command.validate(new String[c]));
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
         String errorMessage = "Expected one argument: hostname:port, ip:port, or JMX service URL";
         verify(cw).println(errorMessage);
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SnapshotCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SnapshotCommandTest.java
@@ -41,7 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -115,8 +115,12 @@ class SnapshotCommandTest implements ValidatesTargetId {
                 0, 2,
             })
     void shouldInvalidateIncorrectArgc(int c) {
-        assertFalse(command.validate(new String[c]));
-        verify(cw).println("Expected one argument: hostname:port, ip:port, or JMX service URL");
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[c]));
+        String errorMessage = "Expected one argument: hostname:port, ip:port, or JMX service URL";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommandTest.java
@@ -117,7 +117,7 @@ class StartRecordingCommandTest
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 4, 5})
-    void shouldNotValidateWithIncorrectArgc(int argc) {
+    void shouldNotValidateIncorrectArgc(int argc) {
         Exception e =
                 assertThrows(
                         FailedValidationException.class, () -> command.validate(new String[argc]));

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommandTest.java
@@ -41,7 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -118,7 +118,13 @@ class StartRecordingCommandTest
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 4, 5})
     void shouldNotValidateWithIncorrectArgc(int argc) {
-        assertFalse(command.validate(new String[argc]));
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
+        String errorMessage =
+                "Expected three arguments: target (host:port, ip:port, or JMX service URL), recording name, and event types";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommandTest.java
@@ -128,6 +128,60 @@ class StartRecordingCommandTest
     }
 
     @Test
+    void shouldNotValidateInvalidTargetIdAndRecordingName() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () ->
+                                command.validate(
+                                        new String[] {":", ":", MOCK_RECORDING_EVENT_SPECIFIER}));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording name";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid recording name");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidTargetIdAndEventSpecifier() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () -> command.validate(new String[] {":", MOCK_RECORDING_NAME, ":"}));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid events specifier";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid events specifier");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidRecordingNameAndEventSpecifier() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () -> command.validate(new String[] {MOCK_TARGET_ID, ":", ":"}));
+        String errorMessage = ": is an invalid recording name; : is an invalid events specifier";
+        verify(cw).println(": is an invalid recording name");
+        verify(cw).println(": is an invalid events specifier");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidTargetIdRecordingNameEventSpecifier() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () -> command.validate(new String[] {":", ":", ":"}));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording name; : is an invalid events specifier";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid recording name");
+        verify(cw).println(": is an invalid events specifier");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
     void shouldStartRecordingOnExecute() throws Exception {
         when(targetConnectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any()))
                 .thenAnswer(

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommandTest.java
@@ -41,7 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -56,6 +56,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -101,9 +103,16 @@ class StopRecordingCommandTest implements ValidatesTargetId, ValidatesRecordingN
         MatcherAssert.assertThat(command.getName(), Matchers.equalTo("stop"));
     }
 
-    @Test
-    void shouldNotExpectNoArg() {
-        assertFalse(command.validate(new String[0]));
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 3})
+    void shouldNotValidateIncorrectArgc(int argc) {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
+        String errorMessage =
+                "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name";
+        verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommandTest.java
@@ -116,6 +116,19 @@ class StopRecordingCommandTest implements ValidatesTargetId, ValidatesRecordingN
     }
 
     @Test
+    void shouldNotValidateInvalidTargetIdAndRecordingName() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () -> command.validate(new String[] {":", ":"}));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording name";
+        verify(cw).println(": is an invalid connection specifier");
+        verify(cw).println(": is an invalid recording name");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
     void shouldHandleNoRecordingFound() throws Exception {
         when(targetConnectionManager.executeConnectedTask(Mockito.anyString(), Mockito.any()))
                 .thenAnswer(

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
@@ -137,6 +137,19 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
+    @Test
+    void shouldNotValidateInvalidTargetIdAndRecordingName() {
+        Exception e =
+                Assertions.assertThrows(
+                        FailedValidationException.class,
+                        () -> command.validate(new String[] {":", ":", ":"}));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording name";
+        Mockito.verify(cw).println(": is an invalid connection specifier");
+        Mockito.verify(cw).println(": is an invalid recording name");
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
     @Nested
     class RecordingSelection {
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
@@ -127,10 +127,10 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 4, 5})
-    void shouldNotValidateWrongArgc(int c) {
+    void shouldNotValidateIncorrectArgc(int argc) {
         Exception e =
                 Assertions.assertThrows(
-                        FailedValidationException.class, () -> command.validate(new String[c]));
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
         String errorMessage =
                 "Expected three arguments: target (host:port, ip:port, or JMX service URL), recording name, and upload URL";
         Mockito.verify(cw).println(errorMessage);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommandTest.java
@@ -128,24 +128,13 @@ class UploadRecordingCommandTest implements ValidatesTargetId, ValidatesRecordin
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 4, 5})
     void shouldNotValidateWrongArgc(int c) {
-        Assertions.assertFalse(command.validate(new String[c]));
-        Mockito.verify(cw)
-                .println(
-                        "Expected three arguments: target (host:port, ip:port, or JMX service URL), recording name, and upload URL");
-    }
-
-    @ParameterizedTest
-    @ValueSource(
-            strings = {"foo", "foo.jfr", "recording", "some-name", "another_name", "123", "abc123"})
-    void shouldValidateRecordingNames(String recordingName) {
-        Assertions.assertTrue(command.validate(new String[] {HOST_ID, recordingName, UPLOAD_URL}));
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {".", "some recording", ""})
-    void shouldNotValidateInvalidRecordingNames(String recordingName) {
-        Assertions.assertFalse(command.validate(new String[] {HOST_ID, recordingName, UPLOAD_URL}));
-        Mockito.verify(cw).println(recordingName + " is an invalid recording name");
+        Exception e =
+                Assertions.assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[c]));
+        String errorMessage =
+                "Expected three arguments: target (host:port, ip:port, or JMX service URL), recording name, and upload URL";
+        Mockito.verify(cw).println(errorMessage);
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Nested

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ValidatesEventSpecifier.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/ValidatesEventSpecifier.java
@@ -41,6 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
@@ -56,17 +58,18 @@ interface ValidatesEventSpecifier extends ValidationTestable {
                 "template=Foo"
             })
     default void shouldValidateAcceptableEventSpecifiers(String eventSpecifier) {
-        Assertions.assertTrue(
-                commandForValidationTesting()
-                        .validate(
-                                getArgs(
-                                        argumentSignature().stream()
-                                                .map(
-                                                        arg ->
-                                                                RECORDING_EVENT_SPECIFIER.equals(
-                                                                                arg)
-                                                                        ? eventSpecifier
-                                                                        : arg))),
+        Assertions.assertDoesNotThrow(
+                () ->
+                        commandForValidationTesting()
+                                .validate(
+                                        getArgs(
+                                                argumentSignature().stream()
+                                                        .map(
+                                                                arg ->
+                                                                        RECORDING_EVENT_SPECIFIER
+                                                                                        .equals(arg)
+                                                                                ? eventSpecifier
+                                                                                : arg))),
                 eventSpecifier);
     }
 
@@ -83,17 +86,25 @@ interface ValidatesEventSpecifier extends ValidationTestable {
                 "foo.Bar=true"
             })
     default void shouldNotValidateUnacceptableEventSpecifiers(String eventSpecifier) {
-        Assertions.assertFalse(
-                commandForValidationTesting()
-                        .validate(
-                                getArgs(
-                                        argumentSignature().stream()
-                                                .map(
-                                                        arg ->
-                                                                RECORDING_EVENT_SPECIFIER.equals(
-                                                                                arg)
-                                                                        ? eventSpecifier
-                                                                        : arg))),
-                eventSpecifier);
+        Exception e =
+                Assertions.assertThrows(
+                        FailedValidationException.class,
+                        () ->
+                                commandForValidationTesting()
+                                        .validate(
+                                                getArgs(
+                                                        argumentSignature().stream()
+                                                                .map(
+                                                                        arg ->
+                                                                                RECORDING_EVENT_SPECIFIER
+                                                                                                .equals(
+                                                                                                        arg)
+                                                                                        ? eventSpecifier
+                                                                                        : arg))),
+                        eventSpecifier);
+        MatcherAssert.assertThat(
+                e.getMessage(),
+                Matchers.equalTo(
+                        String.format("%s is an invalid events specifier", eventSpecifier)));
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitCommandTest.java
@@ -41,7 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,6 +54,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -76,27 +79,31 @@ class WaitCommandTest extends TestBase {
         MatcherAssert.assertThat(command.getName(), Matchers.equalTo("wait"));
     }
 
-    @Test
-    void shouldNotExpectZeroArgs() {
-        assertFalse(command.validate(new String[0]));
-        MatcherAssert.assertThat(stdout(), Matchers.equalTo("Expected one argument\n"));
-    }
-
-    @Test
-    void shouldNotExpectTwoArgs() {
-        assertFalse(command.validate(new String[2]));
-        MatcherAssert.assertThat(stdout(), Matchers.equalTo("Expected one argument\n"));
+    @ParameterizedTest
+    @ValueSource(ints = {0, 2})
+    void shouldNotExpectInvalidArgs() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[0]));
+        String errorMessage = "Expected one argument";
+        MatcherAssert.assertThat(stdout(), Matchers.equalTo(errorMessage + '\n'));
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test
     void shouldExpectIntegerFormattedArg() {
-        assertFalse(command.validate(new String[] {"f"}));
-        MatcherAssert.assertThat(stdout(), Matchers.equalTo("f is an invalid integer\n"));
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () -> command.validate(new String[] {"f"}));
+        String errorMessage = "f is an invalid integer";
+        MatcherAssert.assertThat(stdout(), Matchers.equalTo(errorMessage + '\n'));
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test
     void shouldValidateArgs() {
-        assertTrue(command.validate(new String[] {"10"}));
+        assertDoesNotThrow(() -> command.validate(new String[] {"10"}));
         MatcherAssert.assertThat(stdout(), Matchers.emptyString());
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitCommandTest.java
@@ -81,10 +81,10 @@ class WaitCommandTest extends TestBase {
 
     @ParameterizedTest
     @ValueSource(ints = {0, 2})
-    void shouldNotExpectInvalidArgs() {
+    void shouldNotValidateIncorrectArgc(int argc) {
         Exception e =
                 assertThrows(
-                        FailedValidationException.class, () -> command.validate(new String[0]));
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
         String errorMessage = "Expected one argument";
         MatcherAssert.assertThat(stdout(), Matchers.equalTo(errorMessage + '\n'));
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommandTest.java
@@ -41,20 +41,23 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -65,19 +68,30 @@ import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor.RecordingState;
 
 import com.redhat.rhjmc.containerjfr.TestBase;
+import com.redhat.rhjmc.containerjfr.commands.Command;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.sys.Clock;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 
 @ExtendWith(MockitoExtension.class)
-class WaitForCommandTest extends TestBase {
+class WaitForCommandTest extends TestBase implements ValidatesRecordingName, ValidatesTargetId {
 
     WaitForCommand command;
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock JFRConnection connection;
     @Mock IFlightRecorderService service;
     @Mock Clock clock;
+
+    @Override
+    public Command commandForValidationTesting() {
+        return command;
+    }
+
+    @Override
+    public List<String> argumentSignature() {
+        return List.of(TARGET_ID, RECORDING_NAME);
+    }
 
     @BeforeEach
     void setup() {
@@ -89,29 +103,21 @@ class WaitForCommandTest extends TestBase {
         MatcherAssert.assertThat(command.getName(), Matchers.equalTo("wait-for"));
     }
 
-    @Test
-    void shouldNotExpectZeroArgs() {
-        assertFalse(command.validate(new String[0]));
-    }
-
-    @Test
-    void shouldNotExpectTooManyArgs() {
-        assertFalse(command.validate(new String[3]));
-    }
-
-    @Test
-    void shouldNotValidateMalformedTargetId() {
-        assertFalse(command.validate(new String[] {":9091", "."}));
-    }
-
-    @Test
-    void shouldNotValidateMalformedRecordingName() {
-        assertFalse(command.validate(new String[] {"fooHost:9091", "."}));
+    @ParameterizedTest
+    @ValueSource(ints = {0, 3})
+    void shouldNotExpectInvalidArgc(int argc) {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class, () -> command.validate(new String[argc]));
+        String errorMessage =
+                "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name";
+        MatcherAssert.assertThat(stdout(), Matchers.equalTo(errorMessage + '\n'));
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 
     @Test
     void shouldValidateArgs() {
-        assertTrue(command.validate(new String[] {"fooHost:9091", "someRecording"}));
+        assertDoesNotThrow(() -> command.validate(new String[] {"fooHost:9091", "someRecording"}));
         MatcherAssert.assertThat(stdout(), Matchers.emptyString());
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommandTest.java
@@ -43,6 +43,7 @@ package com.redhat.rhjmc.containerjfr.commands.internal;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -112,6 +113,19 @@ class WaitForCommandTest extends TestBase implements ValidatesRecordingName, Val
         String errorMessage =
                 "Expected two arguments: target (host:port, ip:port, or JMX service URL) and recording name";
         MatcherAssert.assertThat(stdout(), Matchers.equalTo(errorMessage + '\n'));
+        MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
+    }
+
+    @Test
+    void shouldNotValidateInvalidTargetIdAndRecordingName() {
+        Exception e =
+                assertThrows(
+                        FailedValidationException.class,
+                        () -> command.validate(new String[] {":", ":"}));
+        String errorMessage =
+                ": is an invalid connection specifier; : is an invalid recording name";
+        assertTrue(stdout().contains(": is an invalid connection specifier\n"));
+        assertTrue(stdout().contains(": is an invalid recording name\n"));
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo(errorMessage));
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/WaitForCommandTest.java
@@ -105,7 +105,7 @@ class WaitForCommandTest extends TestBase implements ValidatesRecordingName, Val
 
     @ParameterizedTest
     @ValueSource(ints = {0, 3})
-    void shouldNotExpectInvalidArgc(int argc) {
+    void shouldNotValidateIncorrectArgc(int argc) {
         Exception e =
                 assertThrows(
                         FailedValidationException.class, () -> command.validate(new String[argc]));

--- a/src/test/java/com/redhat/rhjmc/containerjfr/tui/tty/BatchModeExecutorTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/tui/tty/BatchModeExecutorTest.java
@@ -238,9 +238,7 @@ class BatchModeExecutorTest extends TestBase {
         executor.run("help; connect foo; disconnect;");
 
         MatcherAssert.assertThat(
-                stdout(),
-                Matchers.containsString(
-                        "Could not validate \"connect\" command; \"[foo]\" are invalid arguments to connect"));
+                stdout(), Matchers.containsString("\tCommand \"connect\" could not be validated"));
 
         verify(mockRegistry).validate("help", new String[0]);
         verify(mockRegistry).validate("connect", new String[] {"foo"});

--- a/src/test/java/com/redhat/rhjmc/containerjfr/tui/tty/InteractiveShellExecutorTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/tui/tty/InteractiveShellExecutorTest.java
@@ -42,7 +42,6 @@
 package com.redhat.rhjmc.containerjfr.tui.tty;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
@@ -87,7 +86,6 @@ class InteractiveShellExecutorTest extends TestBase {
         verifyZeroInteractions(mockClientReader);
         verifyZeroInteractions(mockRegistry);
 
-        when(mockRegistry.validate(anyString(), any(String[].class))).thenReturn(true);
         when(mockClientReader.readLine()).thenReturn("help").thenReturn("exit");
         doThrow(UnsupportedOperationException.class)
                 .when(mockRegistry)
@@ -135,7 +133,6 @@ class InteractiveShellExecutorTest extends TestBase {
         verifyZeroInteractions(mockClientReader);
         verifyZeroInteractions(mockRegistry);
 
-        when(mockRegistry.validate(anyString(), any(String[].class))).thenReturn(true);
         when(mockClientReader.readLine()).thenThrow(NoSuchElementException.class);
 
         executor.run(null);
@@ -156,7 +153,6 @@ class InteractiveShellExecutorTest extends TestBase {
         verifyZeroInteractions(mockClientReader);
         verifyZeroInteractions(mockRegistry);
 
-        when(mockRegistry.validate(anyString(), any(String[].class))).thenReturn(true);
         when(mockClientReader.readLine()).thenReturn(null);
 
         executor.run(null);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/tui/ws/WsCommandExecutorTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/tui/ws/WsCommandExecutorTest.java
@@ -518,7 +518,7 @@ class WsCommandExecutorTest {
         MatcherAssert.assertThat(message.status, Matchers.equalTo(-1));
         MatcherAssert.assertThat(
                 message.payload,
-                Matchers.equalTo("Could not validate \"foo\" command; bar could not be found"));
+                Matchers.equalTo("Could not validate \"foo\" command: bar could not be found"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #195.

In commands, `validate()` is now a `void` method which `throws FailedValidationException`. If the validation fails, then the method prints the error message with its `ClientWriter`, and then throws a `FailedValidationException` which contains the same error message. If the validation is successful, the method simply returns. 

In command registries, the `validate()` method has been to match `Command.validate()`.

In `WsCommandExecutor`, the `ResponseMessage` from a failed validation has its `payload` changed to say that the command could not be validated, and includes the error message from the `validate()` call (obtained via the caught exception). Previously the response just said that the given arguments were invalid.
```
{command:list}
{"id":null,"commandName":"list","status":-1,"payload":"Could not validate \"list\" command; Expected one argument: hostname:port, ip:port, or JMX service URL"}
```

In the `AbstractCommandExecutor`, `validateCommands()` has been changed to output a more generic error message upon a failed validation; it now just says that the validation failed, whereas previously it specified that the arguments passed in were invalid. It prints a generic error message instead of the specific error message from the caught exception, because the `validate()` method in the commands will have already printed the specific error message.
```
> list
Expected one argument: hostname:port, ip:port, or JMX service URL
	Command "list" could not be validated
```

Additional, somewhat unrelated things of note: I did some light refactoring as I was working on the `*CommandTest` tests, like adding a check for the error message when there wasn't before, and changing `argc` validation test names to be more consistent. The `connect` and `disconnect` in `BatchModeExecutorTest` were changed to existing commands. Also I made a small fix to `COMMANDS.md`.

**Edit:** The commit, "Change tests to reflect the re-added cw.println() in validate()" should really just be, "Change Command unit tests to work with new validate()"; the unit tests for commands weren't actually ever modified before that commit.