### PR TITLE
HTTP REST API feature parity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
   <com.google.dagger.version>2.26</com.google.dagger.version>
 
-  <com.redhat.rhjmc.containerjfr.core.version>0.14.0</com.redhat.rhjmc.containerjfr.core.version>
+  <com.redhat.rhjmc.containerjfr.core.version>0.14.1</com.redhat.rhjmc.containerjfr.core.version>
 
   <org.apache.commons.lang3.version>3.9</org.apache.commons.lang3.version>
   <org.apache.commons.codec.version>1.13</org.apache.commons.codec.version>

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandsInternalModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandsInternalModule.java
@@ -52,6 +52,7 @@ import com.redhat.rhjmc.containerjfr.ExecutionMode;
 import com.redhat.rhjmc.containerjfr.commands.Command;
 import com.redhat.rhjmc.containerjfr.commands.CommandRegistry;
 import com.redhat.rhjmc.containerjfr.commands.SerializableCommandRegistry;
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 
 import dagger.Binds;
@@ -192,9 +193,9 @@ public abstract class CommandsInternalModule {
     @Nullable
     @Singleton
     static SerializableCommandRegistry provideSerializableCommandRegistry(
-            ExecutionMode mode, Set<Command> commands) {
+            ExecutionMode mode, Set<Command> commands, Logger logger) {
         if (mode.equals(ExecutionMode.WEBSOCKET)) {
-            return new SerializableCommandRegistryImpl(commands);
+            return new SerializableCommandRegistryImpl(commands, logger);
         } else {
             return null;
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommand.java
@@ -55,6 +55,8 @@ import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService;
 
+/** @deprecated Use HTTP DELETE /api/v1/targets/:targetId/recordings/:recordingName */
+@Deprecated
 @Singleton
 class DeleteCommand extends AbstractConnectedCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommand.java
@@ -82,14 +82,15 @@ class DeleteCommand extends AbstractConnectedCommand implements SerializableComm
     public void execute(String[] args) throws Exception {
         final String targetId = args[0];
         final String recordingName = args[1];
+        final ConnectionDescriptor connectionDescriptor = new ConnectionDescriptor(targetId);
         targetConnectionManager.executeConnectedTask(
-                new ConnectionDescriptor(targetId),
+                connectionDescriptor,
                 connection -> {
                     Optional<IRecordingDescriptor> descriptor =
                             getDescriptorByName(targetId, recordingName);
                     if (descriptor.isPresent()) {
                         connection.getService().close(descriptor.get());
-                        reportService.delete(targetId, recordingName);
+                        reportService.delete(connectionDescriptor, recordingName);
                     } else {
                         cw.println(
                                 String.format(
@@ -103,15 +104,16 @@ class DeleteCommand extends AbstractConnectedCommand implements SerializableComm
     public Output<?> serializableExecute(String[] args) {
         final String targetId = args[0];
         final String recordingName = args[1];
+        final ConnectionDescriptor connectionDescriptor = new ConnectionDescriptor(targetId);
         try {
             return targetConnectionManager.executeConnectedTask(
-                    new ConnectionDescriptor(targetId),
+                    connectionDescriptor,
                     connection -> {
                         Optional<IRecordingDescriptor> descriptor =
                                 getDescriptorByName(targetId, recordingName);
                         if (descriptor.isPresent()) {
                             connection.getService().close(descriptor.get());
-                            reportService.delete(targetId, recordingName);
+                            reportService.delete(connectionDescriptor, recordingName);
                             return new SuccessOutput();
                         } else {
                             return new FailureOutput(

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteSavedRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteSavedRecordingCommand.java
@@ -53,6 +53,8 @@ import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService;
 
+/** @deprecated use HTTTP DELETE /api/v1/recordings/:recordingName */
+@Deprecated
 @Singleton
 class DeleteSavedRecordingCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/DumpCommand.java
@@ -53,6 +53,8 @@ import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 
+/** @deprecated use HTTP POST /api/v1/targets/:targetId/recordings */
+@Deprecated
 @Singleton
 class DumpCommand extends AbstractRecordingCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/EventOptionsBuilder.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/EventOptionsBuilder.java
@@ -57,7 +57,7 @@ import org.openjdk.jmc.rjmx.services.jfr.internal.FlightRecorderServiceV2;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 
-class EventOptionsBuilder {
+public class EventOptionsBuilder {
 
     private final boolean isV2;
     private final IMutableConstrainedMap<EventOptionID> map;
@@ -89,7 +89,8 @@ class EventOptionsBuilder {
         }
     }
 
-    EventOptionsBuilder addEvent(String typeId, String option, String value) throws Exception {
+    public EventOptionsBuilder addEvent(String typeId, String option, String value)
+            throws Exception {
         if (!eventIds.containsKey(typeId)) {
             throw new EventTypeException(typeId);
         }
@@ -110,7 +111,7 @@ class EventOptionsBuilder {
         return (V) t;
     }
 
-    IConstrainedMap<EventOptionID> build() {
+    public IConstrainedMap<EventOptionID> build() {
         if (!isV2) {
             return null;
         }
@@ -118,7 +119,7 @@ class EventOptionsBuilder {
     }
 
     @SuppressWarnings("serial")
-    static class EventTypeException extends Exception {
+    public static class EventTypeException extends Exception {
         EventTypeException(String eventType) {
             super(String.format("Unknown event type \"%s\"", eventType));
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SaveRecordingCommand.java
@@ -63,6 +63,8 @@ import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 
+/** @deprecated use HTTP PATCH "SAVE" /api/v1/targets/:targetId/recordings/:recordingName */
+@Deprecated
 @Singleton
 class SaveRecordingCommand extends AbstractConnectedCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SnapshotCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/SnapshotCommand.java
@@ -52,6 +52,8 @@ import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 
+/** @deprecated Use HTTP PATCH "SNAPSHOT" /api/v1/targets/:targetId/recordings/:recordingName */
+@Deprecated
 @Singleton
 class SnapshotCommand extends AbstractRecordingCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StartRecordingCommand.java
@@ -54,6 +54,8 @@ import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.web.WebServer;
 
+/** @deprecated Use HTTP POST /api/v1/targets/:targetId/recordings */
+@Deprecated
 @Singleton
 class StartRecordingCommand extends AbstractRecordingCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/StopRecordingCommand.java
@@ -54,6 +54,8 @@ import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 
+/** @deprecated use HTTP PATCH "STOP" /api/v1/targets/:targetId/recordings/:recordingName */
+@Deprecated
 @Singleton
 class StopRecordingCommand extends AbstractConnectedCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -77,6 +77,11 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.multipart.MultipartForm;
 
+/**
+ * @deprecated Use HTTP POST /api/v1/recordings/:recordingName/upload or HTTP POST
+ *     /api/v1/targets/:targetId/recordings/:recordingName/upload
+ */
+@Deprecated
 @Singleton
 class UploadRecordingCommand extends AbstractConnectedCommand implements SerializableCommand {
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/ConnectionDescriptor.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/ConnectionDescriptor.java
@@ -43,6 +43,9 @@ package com.redhat.rhjmc.containerjfr.net;
 
 import java.util.Optional;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import com.redhat.rhjmc.containerjfr.core.net.Credentials;
 
 public class ConnectionDescriptor {
@@ -65,5 +68,28 @@ public class ConnectionDescriptor {
 
     public Optional<Credentials> getCredentials() {
         return credentials;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof ConnectionDescriptor)) {
+            return false;
+        }
+        ConnectionDescriptor cd = (ConnectionDescriptor) other;
+        return new EqualsBuilder()
+                .append(targetId, cd.targetId)
+                .append(credentials, cd.credentials)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(targetId).append(credentials).hashCode();
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/TargetConnectionManager.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/TargetConnectionManager.java
@@ -67,7 +67,7 @@ public class TargetConnectionManager {
     private final ReentrantLock lock = new ReentrantLock();
     // maintain a short-lived cache of connections to allow nested ConnectedTasks
     // without having to manage connection reuse
-    private final Map<String, JFRConnection> activeConnections = new HashMap<>();
+    private final Map<ConnectionDescriptor, JFRConnection> activeConnections = new HashMap<>();
     private final JFRConnectionToolkit jfrConnectionToolkit;
 
     TargetConnectionManager(Logger logger, JFRConnectionToolkit jfrConnectionToolkit) {
@@ -78,16 +78,16 @@ public class TargetConnectionManager {
     public <T> T executeConnectedTask(
             ConnectionDescriptor connectionDescriptor, ConnectedTask<T> task) throws Exception {
         try {
-            if (activeConnections.containsKey(connectionDescriptor.getTargetId())) {
-                return task.execute(activeConnections.get(connectionDescriptor.getTargetId()));
+            if (activeConnections.containsKey(connectionDescriptor)) {
+                return task.execute(activeConnections.get(connectionDescriptor));
             } else {
                 try (JFRConnection connection = connect(connectionDescriptor)) {
-                    activeConnections.put(connectionDescriptor.getTargetId(), connection);
+                    activeConnections.put(connectionDescriptor, connection);
                     return task.execute(connection);
                 }
             }
         } finally {
-            activeConnections.remove(connectionDescriptor.getTargetId());
+            activeConnections.remove(connectionDescriptor);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/internal/reports/ReportService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/internal/reports/ReportService.java
@@ -46,6 +46,8 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
+
 public class ReportService {
 
     private final ActiveRecordingReportCache activeCache;
@@ -65,12 +67,12 @@ public class ReportService {
         return archivedCache.delete(recordingName);
     }
 
-    public String get(String targetId, String recordingName) {
-        return activeCache.get(targetId, recordingName);
+    public String get(ConnectionDescriptor connectionDescriptor, String recordingName) {
+        return activeCache.get(connectionDescriptor, recordingName);
     }
 
-    public boolean delete(String targetId, String recordingName) {
-        return activeCache.delete(targetId, recordingName);
+    public boolean delete(ConnectionDescriptor connectionDescriptor, String recordingName) {
+        return activeCache.delete(connectionDescriptor, recordingName);
     }
 
     // FIXME This is basically duplicated from UploadRecordingCommand

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/internal/reports/ReportService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/internal/reports/ReportService.java
@@ -78,7 +78,7 @@ public class ReportService {
     // FIXME This is basically duplicated from UploadRecordingCommand
     public static class RecordingNotFoundException extends RuntimeException {
         public RecordingNotFoundException(String targetId, String recordingName) {
-            super(String.format("Recording %s not found in target %s", targetId, recordingName));
+            super(String.format("Recording %s not found in target %s", recordingName, targetId));
         }
 
         public RecordingNotFoundException(Pair<String, String> key) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
@@ -81,7 +81,7 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
             }
             throw new HttpStatusException(404, e);
         } catch (Exception e) {
-            throw new HttpStatusException(500, e);
+            throw new HttpStatusException(500, e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingDeleteHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingDeleteHandler.java
@@ -94,12 +94,17 @@ class RecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
                 .ifPresentOrElse(
                         path -> {
                             try {
+                                if (!fs.exists(path)) {
+                                    throw new HttpStatusException(404, recordingName);
+                                }
                                 fs.deleteIfExists(path);
                             } catch (IOException e) {
                                 throw new HttpStatusException(500, e.getMessage(), e);
                             } finally {
                                 reportService.delete(recordingName);
                             }
+                            ctx.response().setStatusCode(200);
+                            ctx.response().end();
                         },
                         () -> {
                             throw new HttpStatusException(404, recordingName);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingDeleteHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingDeleteHandler.java
@@ -1,0 +1,108 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class RecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
+
+    private final ReportService reportService;
+    private final FileSystem fs;
+    private final Path savedRecordingsPath;
+
+    @Inject
+    RecordingDeleteHandler(
+            AuthManager auth,
+            ReportService reportService,
+            FileSystem fs,
+            @Named(MainModule.RECORDINGS_PATH) Path savedRecordingsPath) {
+        super(auth);
+        this.reportService = reportService;
+        this.fs = fs;
+        this.savedRecordingsPath = savedRecordingsPath;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.DELETE;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/recordings/:recordingName";
+    }
+
+    @Override
+    public void handleAuthenticated(RoutingContext ctx) throws Exception {
+        String recordingName = ctx.pathParam("recordingName");
+        fs.listDirectoryChildren(savedRecordingsPath).stream()
+                .filter(saved -> saved.equals(recordingName))
+                .map(savedRecordingsPath::resolve)
+                .findFirst()
+                .ifPresentOrElse(
+                        path -> {
+                            try {
+                                fs.deleteIfExists(path);
+                            } catch (IOException e) {
+                                throw new HttpStatusException(500, e.getMessage(), e);
+                            } finally {
+                                reportService.delete(recordingName);
+                            }
+                        },
+                        () -> {
+                            throw new HttpStatusException(404, recordingName);
+                        });
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingUploadPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingUploadPostHandler.java
@@ -43,6 +43,7 @@ package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -150,11 +151,15 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     Optional<Path> getRecordingPath(String recordingName) throws Exception {
-        Path archivedRecording = savedRecordingsPath.resolve(recordingName);
-        if (fs.isRegularFile(archivedRecording) && fs.isReadable(archivedRecording)) {
-            return Optional.of(archivedRecording);
+        try {
+            Path archivedRecording = savedRecordingsPath.resolve(recordingName);
+            if (fs.isRegularFile(archivedRecording) && fs.isReadable(archivedRecording)) {
+                return Optional.of(archivedRecording);
+            }
+            return Optional.empty();
+        } catch (InvalidPathException e) {
+            throw new HttpStatusException(400, e.getMessage(), e);
         }
-        return Optional.empty();
     }
 
     private static class ResponseMessage {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingUploadPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingUploadPostHandler.java
@@ -102,7 +102,7 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
-    void handleAuthenticated(RoutingContext ctx) {
+    void handleAuthenticated(RoutingContext ctx) throws Exception {
         String recordingName = ctx.pathParam("recordingName");
         try {
             URL uploadUrl = new URL(env.getEnv("GRAFANA_DATASOURCE_URL"));
@@ -111,12 +111,8 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
             ctx.response().setStatusCode(response.statusCode);
             ctx.response().setStatusMessage(response.statusMessage);
             ctx.response().end(response.body);
-        } catch (HttpStatusException e) {
-            throw e;
         } catch (MalformedURLException e) {
             throw new HttpStatusException(501, e);
-        } catch (Exception e) {
-            throw new HttpStatusException(500, e);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingUploadPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingUploadPostHandler.java
@@ -56,7 +56,6 @@ import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
@@ -116,8 +115,6 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
         }
     }
 
-    // FindBugs thinks the recordingPath or its properties is null somehow
-    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private ResponseMessage doPost(String recordingName, URL uploadUrl) throws Exception {
         Path recordingPath =
                 getRecordingPath(recordingName)

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsGetHandler.java
@@ -104,19 +104,19 @@ class RecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         if (!fs.exists(savedRecordingsPath)) {
             throw new HttpStatusException(
-                    403,
+                    501,
                     String.format(
                             "Archive path %s does not exist", savedRecordingsPath.toString()));
         }
         if (!fs.isReadable(savedRecordingsPath)) {
             throw new HttpStatusException(
-                    403,
+                    501,
                     String.format(
                             "Archive path %s is not readable", savedRecordingsPath.toString()));
         }
         if (!fs.isDirectory(savedRecordingsPath)) {
             throw new HttpStatusException(
-                    403,
+                    501,
                     String.format(
                             "Archive path %s is not a directory", savedRecordingsPath.toString()));
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsGetHandler.java
@@ -41,16 +41,26 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
+import java.net.SocketException;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 
 import com.google.gson.Gson;
 
 import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.web.WebServer;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
@@ -60,18 +70,24 @@ class RecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
 
     private final Path savedRecordingsPath;
     private final FileSystem fs;
+    private final Provider<WebServer> webServerProvider;
     private final Gson gson;
+    private final Logger logger;
 
     @Inject
     RecordingsGetHandler(
             AuthManager auth,
             @Named(MainModule.RECORDINGS_PATH) Path savedRecordingsPath,
             FileSystem fs,
-            Gson gson) {
+            Provider<WebServer> webServerProvider,
+            Gson gson,
+            Logger logger) {
         super(auth);
         this.savedRecordingsPath = savedRecordingsPath;
         this.fs = fs;
+        this.webServerProvider = webServerProvider;
         this.gson = gson;
+        this.logger = logger;
     }
 
     @Override
@@ -104,6 +120,29 @@ class RecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
                     String.format(
                             "Archive path %s is not a directory", savedRecordingsPath.toString()));
         }
-        ctx.response().end(gson.toJson(this.fs.listDirectoryChildren(savedRecordingsPath)));
+        WebServer webServer = webServerProvider.get();
+        List<String> names = this.fs.listDirectoryChildren(savedRecordingsPath);
+        List<Map<String, String>> result =
+                names.stream()
+                        .map(
+                                name -> {
+                                    try {
+                                        return Map.of(
+                                                "name",
+                                                name,
+                                                "reportUrl",
+                                                webServer.getArchivedReportURL(name),
+                                                "downloadUrl",
+                                                webServer.getArchivedDownloadURL(name));
+                                    } catch (SocketException
+                                            | UnknownHostException
+                                            | URISyntaxException e) {
+                                        logger.warn(e);
+                                        return null;
+                                    }
+                                })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+        ctx.response().end(gson.toJson(result));
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostBodyHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostBodyHandler.java
@@ -66,7 +66,7 @@ class RecordingsPostBodyHandler extends AbstractAuthenticatedRequestHandler {
 
     @Override
     public String path() {
-        return "/api/v1/recordings";
+        return RecordingsPostHandler.PATH;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsPostHandler.java
@@ -77,6 +77,8 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
     private static final Pattern RECORDING_FILENAME_PATTERN =
             Pattern.compile("([A-Za-z\\d-]*)_([A-Za-z\\d-_]*)_([\\d]*T[\\d]*Z)(.[\\d]+)?");
 
+    static final String PATH = "/api/v1/recordings";
+
     private final Vertx vertx;
     private final FileSystem fs;
     private final Path savedRecordingsPath;
@@ -111,7 +113,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
 
     @Override
     public String path() {
-        return "/api/v1/recordings";
+        return PATH;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -162,6 +162,15 @@ public abstract class RequestHandlersModule {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindTargetRecordingsPostBodyHandler(
+            TargetRecordingsPostBodyHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTargetRecordingsPostHandler(TargetRecordingsPostHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindTargetTemplatesGetHandler(TargetTemplatesGetHandler handler);
 
     @Binds
@@ -170,7 +179,7 @@ public abstract class RequestHandlersModule {
 
     @Binds
     @IntoSet
-    abstract RequestHandler bindTemplatesBodyHandler(TemplatesBodyHandler handler);
+    abstract RequestHandler bindTemplatesPostBodyHandler(TemplatesPostBodyHandler handler);
 
     @Binds
     @IntoSet

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -41,6 +41,18 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
+import java.nio.file.Path;
+
+import javax.inject.Named;
+
+import com.google.inject.Provides;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.sys.Clock;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+
 import dagger.Binds;
 import dagger.Module;
 import dagger.multibindings.IntoSet;
@@ -81,6 +93,26 @@ public abstract class RequestHandlersModule {
     @Binds
     @IntoSet
     abstract RequestHandler bindTargetRecordingGetHandler(TargetRecordingGetHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTargetRecordingPatchHandler(TargetRecordingPatchHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTargetRecordingPatchBodyHandler(
+            TargetRecordingPatchBodyHandler handler);
+
+    @Provides
+    TargetRecordingPatchSave provideTargetRecordingPatchSave(
+            FileSystem fs,
+            @Named(MainModule.RECORDINGS_PATH) Path recordingsPath,
+            TargetConnectionManager targetConnectionManager,
+            Clock clock,
+            Logger logger) {
+        return new TargetRecordingPatchSave(
+                fs, recordingsPath, targetConnectionManager, clock, logger);
+    }
 
     @Binds
     @IntoSet

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -48,7 +48,6 @@ import javax.inject.Named;
 import com.google.inject.Provides;
 
 import com.redhat.rhjmc.containerjfr.MainModule;
-import com.redhat.rhjmc.containerjfr.commands.internal.RecordingOptionsBuilderFactory;
 import com.redhat.rhjmc.containerjfr.core.sys.Clock;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
@@ -127,14 +126,6 @@ public abstract class RequestHandlersModule {
         return new TargetRecordingPatchStop(targetConnectionManager);
     }
 
-    @Provides
-    TargetRecordingPatchSnapshot provideTargetRecordingPatchSnapshot(
-            TargetConnectionManager targetConnectionManager,
-            RecordingOptionsBuilderFactory recordingOptionsBuilderFactory) {
-        return new TargetRecordingPatchSnapshot(
-                targetConnectionManager, recordingOptionsBuilderFactory);
-    }
-
     @Binds
     @IntoSet
     abstract RequestHandler bindRecordingGetHandler(RecordingGetHandler handler);
@@ -211,4 +202,8 @@ public abstract class RequestHandlersModule {
     @Binds
     @IntoSet
     abstract RequestHandler bindTargetEventsGetHandler(TargetEventsGetHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTargetSnapshotPostHandler(TargetSnapshotPostHandler handler);
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -114,6 +114,12 @@ public abstract class RequestHandlersModule {
                 fs, recordingsPath, targetConnectionManager, clock, logger);
     }
 
+    @Provides
+    TargetRecordingPatchStop provideTargetRecordingPatchStop(
+            TargetConnectionManager targetConnectionManager) {
+        return new TargetRecordingPatchStop(targetConnectionManager);
+    }
+
     @Binds
     @IntoSet
     abstract RequestHandler bindRecordingGetHandler(RecordingGetHandler handler);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -100,6 +100,10 @@ public abstract class RequestHandlersModule {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindTargetRecordingDeleteHandler(TargetRecordingDeleteHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindTargetRecordingPatchBodyHandler(
             TargetRecordingPatchBodyHandler handler);
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -104,6 +104,11 @@ public abstract class RequestHandlersModule {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindTargetRecordingUploadPostHandler(
+            TargetRecordingUploadPostHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindTargetRecordingPatchBodyHandler(
             TargetRecordingPatchBodyHandler handler);
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -135,6 +135,10 @@ public abstract class RequestHandlersModule {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindRecordingUploadPostHandler(RecordingUploadPostHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindTargetReportGetHandler(TargetReportGetHandler handler);
 
     @Binds

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -132,6 +132,10 @@ public abstract class RequestHandlersModule {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindRecordingDeleteHandler(RecordingDeleteHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindRecordingUploadPostHandler(RecordingUploadPostHandler handler);
 
     @Binds

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RequestHandlersModule.java
@@ -48,7 +48,7 @@ import javax.inject.Named;
 import com.google.inject.Provides;
 
 import com.redhat.rhjmc.containerjfr.MainModule;
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.commands.internal.RecordingOptionsBuilderFactory;
 import com.redhat.rhjmc.containerjfr.core.sys.Clock;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
@@ -117,16 +117,22 @@ public abstract class RequestHandlersModule {
             FileSystem fs,
             @Named(MainModule.RECORDINGS_PATH) Path recordingsPath,
             TargetConnectionManager targetConnectionManager,
-            Clock clock,
-            Logger logger) {
-        return new TargetRecordingPatchSave(
-                fs, recordingsPath, targetConnectionManager, clock, logger);
+            Clock clock) {
+        return new TargetRecordingPatchSave(fs, recordingsPath, targetConnectionManager, clock);
     }
 
     @Provides
     TargetRecordingPatchStop provideTargetRecordingPatchStop(
             TargetConnectionManager targetConnectionManager) {
         return new TargetRecordingPatchStop(targetConnectionManager);
+    }
+
+    @Provides
+    TargetRecordingPatchSnapshot provideTargetRecordingPatchSnapshot(
+            TargetConnectionManager targetConnectionManager,
+            RecordingOptionsBuilderFactory recordingOptionsBuilderFactory) {
+        return new TargetRecordingPatchSnapshot(
+                targetConnectionManager, recordingOptionsBuilderFactory);
     }
 
     @Binds

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingDeleteHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingDeleteHandler.java
@@ -48,6 +48,7 @@ import javax.inject.Inject;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService;
 
@@ -82,10 +83,10 @@ class TargetRecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
 
     @Override
     void handleAuthenticated(RoutingContext ctx) throws Exception {
-        String targetId = ctx.pathParam("targetId");
         String recordingName = ctx.pathParam("recordingName");
+        ConnectionDescriptor connectionDescriptor = getConnectionDescriptorFromContext(ctx);
         targetConnectionManager.executeConnectedTask(
-                getConnectionDescriptorFromContext(ctx),
+                connectionDescriptor,
                 connection -> {
                     Optional<IRecordingDescriptor> descriptor =
                             connection.getService().getAvailableRecordings().stream()
@@ -93,7 +94,7 @@ class TargetRecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
                                     .findFirst();
                     if (descriptor.isPresent()) {
                         connection.getService().close(descriptor.get());
-                        reportService.delete(targetId, recordingName);
+                        reportService.delete(connectionDescriptor, recordingName);
                         ctx.response().setStatusCode(200);
                         ctx.response().end();
                     } else {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingDeleteHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingDeleteHandler.java
@@ -1,0 +1,116 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class TargetRecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
+
+    private final TargetConnectionManager targetConnectionManager;
+    private final ReportService reportService;
+
+    @Inject
+    TargetRecordingDeleteHandler(
+            AuthManager auth,
+            TargetConnectionManager targetConnectionManager,
+            ReportService reportService) {
+        super(auth);
+        this.targetConnectionManager = targetConnectionManager;
+        this.reportService = reportService;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.DELETE;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/targets/:targetId/recordings/:recordingName";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        String targetId = ctx.pathParam("targetId");
+        String recordingName = ctx.pathParam("recordingName");
+        try {
+            targetConnectionManager.executeConnectedTask(
+                    targetId,
+                    connection -> {
+                        Optional<IRecordingDescriptor> descriptor =
+                                connection.getService().getAvailableRecordings().stream()
+                                        .filter(
+                                                recording ->
+                                                        recording.getName().equals(recordingName))
+                                        .findFirst();
+                        if (descriptor.isPresent()) {
+                            connection.getService().close(descriptor.get());
+                            reportService.delete(targetId, recordingName);
+                            ctx.response().setStatusCode(200);
+                            ctx.response().end();
+                        } else {
+                            throw new HttpStatusException(
+                                    404,
+                                    String.format(
+                                            "No recording with name \"%s\" found", recordingName));
+                        }
+                        return null;
+                    });
+        } catch (HttpStatusException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new HttpStatusException(500, e);
+        }
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchBodyHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchBodyHandler.java
@@ -70,7 +70,7 @@ class TargetRecordingPatchBodyHandler extends AbstractAuthenticatedRequestHandle
 
     @Override
     public String path() {
-        return "/api/v1/targets/:targetId/recordings/:recordingName";
+        return TargetRecordingPatchHandler.PATH;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandler.java
@@ -82,7 +82,7 @@ class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
-    void handleAuthenticated(RoutingContext ctx) {
+    void handleAuthenticated(RoutingContext ctx) throws Exception {
         String mtd = ctx.getBodyAsString();
 
         if (mtd == null) {
@@ -90,10 +90,10 @@ class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHandler {
         }
         switch (mtd.toLowerCase()) {
             case "save":
-                patchSave.handle(ctx);
+                patchSave.handle(ctx, getConnectionDescriptorFromContext(ctx));
                 break;
             case "stop":
-                patchStop.handle(ctx);
+                patchStop.handle(ctx, getConnectionDescriptorFromContext(ctx));
                 break;
             default:
                 throw new HttpStatusException(400, "Unsupported operation " + mtd);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandler.java
@@ -51,6 +51,8 @@ import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHandler {
 
+    static final String PATH = "/api/v1/targets/:targetId/recordings/:recordingName";
+
     protected final TargetRecordingPatchSave patchSave;
     protected final TargetRecordingPatchStop patchStop;
 
@@ -71,7 +73,7 @@ class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHandler {
 
     @Override
     public String path() {
-        return "/api/v1/targets/:targetId/recordings/:recordingName";
+        return PATH;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandler.java
@@ -55,18 +55,15 @@ class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHandler {
 
     private final TargetRecordingPatchSave patchSave;
     private final TargetRecordingPatchStop patchStop;
-    private final TargetRecordingPatchSnapshot patchSnapshot;
 
     @Inject
     TargetRecordingPatchHandler(
             AuthManager auth,
             TargetRecordingPatchSave patchSave,
-            TargetRecordingPatchStop patchStop,
-            TargetRecordingPatchSnapshot patchSnapshot) {
+            TargetRecordingPatchStop patchStop) {
         super(auth);
         this.patchSave = patchSave;
         this.patchStop = patchStop;
-        this.patchSnapshot = patchSnapshot;
     }
 
     @Override
@@ -97,9 +94,6 @@ class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHandler {
                 break;
             case "stop":
                 patchStop.handle(ctx, getConnectionDescriptorFromContext(ctx));
-                break;
-            case "snapshot":
-                patchSnapshot.handle(ctx, getConnectionDescriptorFromContext(ctx));
                 break;
             default:
                 throw new HttpStatusException(400, "Unsupported operation " + mtd);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandler.java
@@ -47,6 +47,7 @@ import com.redhat.rhjmc.containerjfr.net.AuthManager;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -83,9 +84,7 @@ class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHandler {
         String mtd = ctx.getBodyAsString();
 
         if (mtd == null) {
-            ctx.response().setStatusCode(400);
-            ctx.response().end("Unsupported null operation");
-            return;
+            throw new HttpStatusException(400, "Unsupported null operation");
         }
         switch (mtd.toLowerCase()) {
             case "save":
@@ -95,9 +94,7 @@ class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHandler {
                 patchStop.handle(ctx);
                 break;
             default:
-                ctx.response().setStatusCode(400);
-                ctx.response().end("Unsupported operation " + mtd);
-                break;
+                throw new HttpStatusException(400, "Unsupported operation " + mtd);
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandler.java
@@ -53,17 +53,20 @@ class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHandler {
 
     static final String PATH = "/api/v1/targets/:targetId/recordings/:recordingName";
 
-    protected final TargetRecordingPatchSave patchSave;
-    protected final TargetRecordingPatchStop patchStop;
+    private final TargetRecordingPatchSave patchSave;
+    private final TargetRecordingPatchStop patchStop;
+    private final TargetRecordingPatchSnapshot patchSnapshot;
 
     @Inject
     TargetRecordingPatchHandler(
             AuthManager auth,
             TargetRecordingPatchSave patchSave,
-            TargetRecordingPatchStop patchStop) {
+            TargetRecordingPatchStop patchStop,
+            TargetRecordingPatchSnapshot patchSnapshot) {
         super(auth);
         this.patchSave = patchSave;
         this.patchStop = patchStop;
+        this.patchSnapshot = patchSnapshot;
     }
 
     @Override
@@ -94,6 +97,9 @@ class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHandler {
                 break;
             case "stop":
                 patchStop.handle(ctx, getConnectionDescriptorFromContext(ctx));
+                break;
+            case "snapshot":
+                patchSnapshot.handle(ctx, getConnectionDescriptorFromContext(ctx));
                 break;
             default:
                 throw new HttpStatusException(400, "Unsupported operation " + mtd);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchSave.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchSave.java
@@ -53,7 +53,6 @@ import javax.inject.Named;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import com.redhat.rhjmc.containerjfr.MainModule;
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.sys.Clock;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
@@ -65,24 +64,21 @@ import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 class TargetRecordingPatchSave {
 
-    protected final FileSystem fs;
-    protected final Path recordingsPath;
-    protected final TargetConnectionManager targetConnectionManager;
-    protected final Clock clock;
-    protected final Logger logger;
+    private final FileSystem fs;
+    private final Path recordingsPath;
+    private final TargetConnectionManager targetConnectionManager;
+    private final Clock clock;
 
     @Inject
     TargetRecordingPatchSave(
             FileSystem fs,
             @Named(MainModule.RECORDINGS_PATH) Path recordingsPath,
             TargetConnectionManager targetConnectionManager,
-            Clock clock,
-            Logger logger) {
+            Clock clock) {
         this.fs = fs;
         this.recordingsPath = recordingsPath;
         this.targetConnectionManager = targetConnectionManager;
         this.clock = clock;
-        this.logger = logger;
     }
 
     void handle(RoutingContext ctx, ConnectionDescriptor connectionDescriptor) throws Exception {
@@ -114,7 +110,7 @@ class TargetRecordingPatchSave {
         ctx.response().end(saveName);
     }
 
-    protected String saveRecording(JFRConnection connection, IRecordingDescriptor descriptor)
+    private String saveRecording(JFRConnection connection, IRecordingDescriptor descriptor)
             throws Exception {
         String recordingName = descriptor.getName();
         if (recordingName.endsWith(".jfr")) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchSave.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchSave.java
@@ -1,0 +1,151 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.sys.Clock;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class TargetRecordingPatchSave {
+
+    protected final FileSystem fs;
+    protected final Path recordingsPath;
+    protected final TargetConnectionManager targetConnectionManager;
+    protected final Clock clock;
+    protected final Logger logger;
+
+    @Inject
+    TargetRecordingPatchSave(
+            FileSystem fs,
+            @Named(MainModule.RECORDINGS_PATH) Path recordingsPath,
+            TargetConnectionManager targetConnectionManager,
+            Clock clock,
+            Logger logger) {
+        this.fs = fs;
+        this.recordingsPath = recordingsPath;
+        this.targetConnectionManager = targetConnectionManager;
+        this.clock = clock;
+        this.logger = logger;
+    }
+
+    void handle(RoutingContext ctx) {
+        String targetId = ctx.pathParam("targetId");
+        String recordingName = ctx.pathParam("recordingName");
+
+        try {
+            String saveName =
+                    targetConnectionManager.executeConnectedTask(
+                            targetId,
+                            connection -> {
+                                Optional<IRecordingDescriptor> descriptor =
+                                        connection.getService().getAvailableRecordings().stream()
+                                                .filter(
+                                                        recording ->
+                                                                recording
+                                                                        .getName()
+                                                                        .equals(recordingName))
+                                                .findFirst();
+                                if (descriptor.isPresent()) {
+                                    return saveRecording(connection, descriptor.get());
+                                } else {
+                                    throw new HttpStatusException(
+                                            404,
+                                            String.format(
+                                                    "Recording with name \"%s\" not found",
+                                                    recordingName));
+                                }
+                            });
+            ctx.response().setStatusCode(200);
+            ctx.response().end(saveName);
+        } catch (HttpStatusException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new HttpStatusException(500, e);
+        }
+    }
+
+    protected String saveRecording(JFRConnection connection, IRecordingDescriptor descriptor)
+            throws IOException, FlightRecorderException {
+        String recordingName = descriptor.getName();
+        if (recordingName.endsWith(".jfr")) {
+            recordingName = recordingName.substring(0, recordingName.length() - 4);
+        }
+        String targetName = connection.getHost().replaceAll("[\\._]+", "-");
+        String timestamp =
+                clock.now().truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
+        String destination = String.format("%s_%s_%s", targetName, recordingName, timestamp);
+        // TODO byte-sized rename limit is arbitrary. Probably plenty since recordings are also
+        // differentiated by second-resolution timestamp
+        byte count = 1;
+        while (fs.exists(recordingsPath.resolve(destination + ".jfr"))) {
+            destination =
+                    String.format("%s_%s_%s.%d", targetName, recordingName, timestamp, count++);
+            if (count == Byte.MAX_VALUE) {
+                throw new IOException(
+                        "Recording could not be saved. File already exists and rename attempts were exhausted.");
+            }
+        }
+        destination += ".jfr";
+        try (InputStream stream = connection.getService().openStream(descriptor, false)) {
+            fs.copy(stream, recordingsPath.resolve(destination));
+        }
+        return destination;
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingUploadPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingUploadPostHandler.java
@@ -115,6 +115,8 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
             ctx.response().end(response.body);
         } catch (MalformedURLException e) {
             throw new HttpStatusException(501, e);
+        } catch (RecordingNotFoundException e) {
+            throw new HttpStatusException(404, e);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingUploadPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingUploadPostHandler.java
@@ -1,0 +1,214 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService.RecordingNotFoundException;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.multipart.MultipartForm;
+
+class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
+
+    private final TargetConnectionManager targetConnectionManager;
+    private final WebClient webClient;
+    private final FileSystem fs;
+    private final Path savedRecordingsPath;
+
+    @Inject
+    TargetRecordingUploadPostHandler(
+            AuthManager auth,
+            TargetConnectionManager targetConnectionManager,
+            WebClient webClient,
+            FileSystem fs,
+            @Named(MainModule.RECORDINGS_PATH) Path savedRecordingsPath) {
+        super(auth);
+        this.targetConnectionManager = targetConnectionManager;
+        this.webClient = webClient;
+        this.fs = fs;
+        this.savedRecordingsPath = savedRecordingsPath;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public String path() {
+        return "/api/v1/targets/:targetId/recordings/:recordingName/upload";
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        String targetId = ctx.pathParam("targetId");
+        String recordingName = ctx.pathParam("recordingName");
+        String uploadUrl = "FIXME"; // rebase on top of Victor's patch to fill this in
+        try {
+            ResponseMessage response = doPost(targetId, recordingName, uploadUrl);
+            ctx.response().setStatusCode(response.statusCode);
+            ctx.response().setStatusMessage(response.statusMessage);
+            ctx.response().end(response.body);
+        } catch (HttpStatusException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new HttpStatusException(500, e);
+        }
+    }
+
+    private ResponseMessage doPost(String targetId, String recordingName, String uploadUrl)
+            throws Exception {
+        Pair<Path, Boolean> recordingPath =
+                targetConnectionManager.executeConnectedTask(
+                        targetId,
+                        connection -> {
+                            return getBestRecordingForName(connection, targetId, recordingName)
+                                    .orElseThrow(
+                                            () ->
+                                                    new RecordingNotFoundException(
+                                                            targetId, recordingName));
+                        });
+
+        Path path = recordingPath.getLeft();
+        if (path == null) {
+            throw new IOException("Recording path could not be determined");
+        }
+        Path fileName = path.getFileName();
+        path = path.toAbsolutePath();
+        if (fileName == null || path == null) {
+            throw new IOException("File name or path could not be determined");
+        }
+
+        MultipartForm form = MultipartForm.create();
+        form.binaryFileUpload(
+                "file", fileName.toString(), path.toString(), HttpMimeType.OCTET_STREAM.toString());
+
+        CompletableFuture<ResponseMessage> future = new CompletableFuture<>();
+        try {
+            webClient
+                    .postAbs(uploadUrl)
+                    .sendMultipartForm(
+                            form,
+                            uploadHandler -> {
+                                if (uploadHandler.failed()) {
+                                    future.completeExceptionally(uploadHandler.cause());
+                                    return;
+                                }
+                                HttpResponse<Buffer> response = uploadHandler.result();
+                                future.complete(
+                                        new ResponseMessage(
+                                                response.statusCode(),
+                                                response.statusMessage(),
+                                                response.bodyAsString()));
+                            });
+            return future.get();
+        } finally {
+            if (recordingPath.getRight()) {
+                fs.deleteIfExists(path);
+            }
+        }
+    }
+
+    // FIXME get rid of this. This handler should be split into one for active recordings and one
+    // for archived, so this would be unnecessary
+    Optional<Pair<Path, Boolean>> getBestRecordingForName(
+            JFRConnection connection, String targetId, String recordingName) throws Exception {
+        Optional<IRecordingDescriptor> currentRecording =
+                connection.getService().getAvailableRecordings().stream()
+                        .filter(recording -> recording.getName().equals(recordingName))
+                        .findFirst();
+        if (currentRecording.isPresent()) {
+            // FIXME extract createTempFile wrapper into FileSystem
+            Path tempFile = Files.createTempFile(null, null);
+            InputStream stream = connection.getService().openStream(currentRecording.get(), false);
+            try (stream) {
+                fs.copy(stream, tempFile, StandardCopyOption.REPLACE_EXISTING);
+            }
+            return Optional.of(Pair.of(tempFile, true));
+        }
+
+        Path archivedRecording = savedRecordingsPath.resolve(recordingName);
+        if (fs.isRegularFile(archivedRecording) && fs.isReadable(archivedRecording)) {
+            return Optional.of(Pair.of(archivedRecording, false));
+        }
+        return Optional.empty();
+    }
+
+    private static class ResponseMessage {
+        final int statusCode;
+        final String statusMessage;
+        final String body;
+
+        ResponseMessage(int statusCode, String statusMessage, String body) {
+            this.statusCode = statusCode;
+            this.statusMessage = statusMessage;
+            this.body = body;
+        }
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostBodyHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostBodyHandler.java
@@ -49,13 +49,14 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 
-class TemplatesBodyHandler extends AbstractAuthenticatedRequestHandler {
+class TargetRecordingsPostBodyHandler extends AbstractAuthenticatedRequestHandler {
 
-    static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
+    private final BodyHandler bodyHandler;
 
     @Inject
-    TemplatesBodyHandler(AuthManager auth) {
+    TargetRecordingsPostBodyHandler(AuthManager auth) {
         super(auth);
+        this.bodyHandler = BodyHandler.create(true);
     }
 
     @Override
@@ -70,11 +71,11 @@ class TemplatesBodyHandler extends AbstractAuthenticatedRequestHandler {
 
     @Override
     public String path() {
-        return "/api/v1/templates";
+        return TargetRecordingsPostHandler.PATH;
     }
 
     @Override
     void handleAuthenticated(RoutingContext ctx) {
-        BODY_HANDLER.handle(ctx);
+        this.bodyHandler.handle(ctx);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostHandler.java
@@ -1,0 +1,298 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openjdk.jmc.common.unit.IConstrainedMap;
+import org.openjdk.jmc.common.unit.QuantityConversionException;
+import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
+import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
+import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.google.gson.Gson;
+
+import com.redhat.rhjmc.containerjfr.commands.internal.EventOptionsBuilder;
+import com.redhat.rhjmc.containerjfr.commands.internal.RecordingOptionsBuilderFactory;
+import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.templates.Template;
+import com.redhat.rhjmc.containerjfr.core.templates.TemplateType;
+import com.redhat.rhjmc.containerjfr.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
+import com.redhat.rhjmc.containerjfr.net.web.WebServer;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
+
+    // TODO extract this somewhere more appropriate
+    public static final Template ALL_EVENTS_TEMPLATE =
+            new Template(
+                    "ALL",
+                    "Enable all available events in the target JVM, with default option values. This will be very expensive and is intended primarily for testing ContainerJFR's own capabilities.",
+                    "ContainerJFR",
+                    TemplateType.TARGET);
+
+    private static final Pattern TEMPLATE_PATTERN =
+            Pattern.compile("^template=([\\w]+)(?:,type=([\\w]+))?$");
+    private static final Pattern EVENTS_PATTERN =
+            Pattern.compile("([\\w\\.\\$]+):([\\w]+)=([\\w\\d\\.]+)");
+
+    static final String PATH = "/api/v1/targets/:targetId/recordings";
+    private final TargetConnectionManager targetConnectionManager;
+    private final RecordingOptionsBuilderFactory recordingOptionsBuilderFactory;
+    private final EventOptionsBuilder.Factory eventOptionsBuilderFactory;
+    private final Provider<WebServer> webServerProvider;
+    private final Gson gson;
+
+    @Inject
+    TargetRecordingsPostHandler(
+            AuthManager auth,
+            TargetConnectionManager targetConnectionManager,
+            RecordingOptionsBuilderFactory recordingOptionsBuilderFactory,
+            EventOptionsBuilder.Factory eventOptionsBuilderFactory,
+            Provider<WebServer> webServerProvider,
+            Gson gson) {
+        super(auth);
+        this.targetConnectionManager = targetConnectionManager;
+        this.recordingOptionsBuilderFactory = recordingOptionsBuilderFactory;
+        this.eventOptionsBuilderFactory = eventOptionsBuilderFactory;
+        this.webServerProvider = webServerProvider;
+        this.gson = gson;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public String path() {
+        return PATH;
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        MultiMap attrs = ctx.request().formAttributes();
+        String recordingName = attrs.get("recordingName");
+        if (StringUtils.isBlank(recordingName)) {
+            throw new HttpStatusException(400, "\"recordingName\" form parameter must be provided");
+        }
+        String eventSpecifier = attrs.get("events");
+        if (StringUtils.isBlank(eventSpecifier)) {
+            throw new HttpStatusException(400, "\"events\" form parameter must be provided");
+        }
+
+        try {
+            Optional<HyperlinkedSerializableRecordingDescriptor> descriptor =
+                    targetConnectionManager.executeConnectedTask(
+                            ctx.pathParam("targetId"),
+                            connection -> {
+                                if (getDescriptorByName(connection, recordingName).isPresent()) {
+                                    throw new HttpStatusException(
+                                            400,
+                                            String.format(
+                                                    "Recording with name \"%s\" already exists",
+                                                    recordingName));
+                                }
+
+                                RecordingOptionsBuilder builder =
+                                        recordingOptionsBuilderFactory
+                                                .create(connection.getService())
+                                                .name(recordingName);
+                                if (attrs.contains("duration")) {
+                                    builder =
+                                            builder.duration(
+                                                    TimeUnit.SECONDS.toMillis(
+                                                            Long.parseLong(attrs.get("duration"))));
+                                }
+                                IConstrainedMap<String> recordingOptions = builder.build();
+                                connection
+                                        .getService()
+                                        .start(
+                                                recordingOptions,
+                                                enableEvents(connection, eventSpecifier));
+
+                                return getDescriptorByName(connection, recordingName)
+                                        .map(
+                                                d -> {
+                                                    try {
+                                                        WebServer webServer =
+                                                                webServerProvider.get();
+                                                        return new HyperlinkedSerializableRecordingDescriptor(
+                                                                d,
+                                                                webServer.getDownloadURL(
+                                                                        connection, d.getName()),
+                                                                webServer.getReportURL(
+                                                                        connection, d.getName()));
+                                                    } catch (QuantityConversionException
+                                                            | URISyntaxException
+                                                            | IOException e) {
+                                                        throw new HttpStatusException(500, e);
+                                                    }
+                                                });
+                            });
+
+            descriptor.ifPresentOrElse(
+                    linkedDescriptor -> {
+                        ctx.response().setStatusCode(201);
+                        ctx.response().putHeader(HttpHeaders.LOCATION, "/" + recordingName);
+                        ctx.response()
+                                .putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
+                        ctx.response().end(gson.toJson(linkedDescriptor));
+                    },
+                    () -> {
+                        throw new HttpStatusException(
+                                500, "Unexpected failure to create recording");
+                    });
+        } catch (HttpStatusException hse) {
+            throw hse;
+        } catch (NumberFormatException nfe) {
+            throw new HttpStatusException(
+                    400, String.format("Recording duration invalid: %s", nfe.getMessage()), nfe);
+        } catch (IllegalArgumentException iae) {
+            throw new HttpStatusException(400, iae.getMessage(), iae);
+        } catch (Exception e) {
+            throw new HttpStatusException(500, e);
+        }
+    }
+
+    protected Optional<IRecordingDescriptor> getDescriptorByName(
+            JFRConnection connection, String recordingName)
+            throws org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException {
+        return connection.getService().getAvailableRecordings().stream()
+                .filter(recording -> recording.getName().equals(recordingName))
+                .findFirst();
+    }
+
+    protected IConstrainedMap<EventOptionID> enableEvents(JFRConnection connection, String events)
+            throws Exception {
+        if (TEMPLATE_PATTERN.matcher(events).matches()) {
+            Matcher m = TEMPLATE_PATTERN.matcher(events);
+            m.find();
+            String templateName = m.group(1);
+            String typeName = m.group(2);
+            if (ALL_EVENTS_TEMPLATE.getName().equals(templateName)) {
+                return enableAllEvents(connection);
+            }
+            if (typeName != null) {
+                return connection
+                        .getTemplateService()
+                        .getEvents(templateName, TemplateType.valueOf(typeName))
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                String.format(
+                                                        "No template \"%s\" found with type %s",
+                                                        templateName, typeName)));
+            }
+            // if template type not specified, try to find a Custom template by that name. If none,
+            // fall back on finding a Target built-in template by the name. If not, throw an
+            // exception and bail out.
+            return connection
+                    .getTemplateService()
+                    .getEvents(templateName, TemplateType.CUSTOM)
+                    .or(
+                            () -> {
+                                try {
+                                    return connection
+                                            .getTemplateService()
+                                            .getEvents(templateName, TemplateType.TARGET);
+                                } catch (FlightRecorderException e) {
+                                    return Optional.empty();
+                                }
+                            })
+                    .orElseThrow(
+                            () ->
+                                    new IllegalArgumentException(
+                                            String.format(
+                                                    "Invalid/unknown event template %s",
+                                                    templateName)));
+        }
+
+        return enableSelectedEvents(connection, events);
+    }
+
+    protected IConstrainedMap<EventOptionID> enableAllEvents(JFRConnection connection)
+            throws Exception {
+        EventOptionsBuilder builder = eventOptionsBuilderFactory.create(connection);
+
+        for (IEventTypeInfo eventTypeInfo : connection.getService().getAvailableEventTypes()) {
+            builder.addEvent(eventTypeInfo.getEventTypeID().getFullKey(), "enabled", "true");
+        }
+
+        return builder.build();
+    }
+
+    protected IConstrainedMap<EventOptionID> enableSelectedEvents(
+            JFRConnection connection, String events) throws Exception {
+        EventOptionsBuilder builder = eventOptionsBuilderFactory.create(connection);
+
+        Matcher matcher = EVENTS_PATTERN.matcher(events);
+        while (matcher.find()) {
+            String eventTypeId = matcher.group(1);
+            String option = matcher.group(2);
+            String value = matcher.group(3);
+
+            builder.addEvent(eventTypeId, option, value);
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostHandler.java
@@ -52,6 +52,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 
 import org.apache.commons.lang3.StringUtils;
+
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandler.java
@@ -88,11 +88,11 @@ class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
 
     @Override
     void handleAuthenticated(RoutingContext ctx) throws Exception {
-        String targetId = ctx.pathParam("targetId");
         String recordingName = ctx.pathParam("recordingName");
         ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.HTML.mime());
         try {
-            ctx.response().end(reportService.get(targetId, recordingName));
+            ctx.response()
+                    .end(reportService.get(getConnectionDescriptorFromContext(ctx), recordingName));
         } catch (RecordingNotFoundException rnfe) {
             throw new HttpStatusException(404, rnfe);
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplateDeleteHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplateDeleteHandler.java
@@ -41,8 +41,6 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import java.io.IOException;
-
 import javax.inject.Inject;
 
 import com.redhat.rhjmc.containerjfr.core.templates.LocalStorageTemplateService;
@@ -74,13 +72,11 @@ class TemplateDeleteHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
-    void handleAuthenticated(RoutingContext ctx) {
+    void handleAuthenticated(RoutingContext ctx) throws Exception {
         String templateName = ctx.pathParam("templateName");
         try {
             this.templateService.deleteTemplate(templateName);
             ctx.response().end();
-        } catch (IOException ioe) {
-            throw new HttpStatusException(500, ioe.getMessage(), ioe);
         } catch (InvalidEventTemplateException iete) {
             throw new HttpStatusException(400, iete.getMessage(), iete);
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostBodyHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostBodyHandler.java
@@ -39,15 +39,42 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr.commands.internal;
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import org.openjdk.jmc.common.unit.QuantityConversionException;
-import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
-import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import javax.inject.Inject;
 
-// FIXME this should be in a more general package, not commands/internal. This is also used in
-// net/web/handlers, for example
-public interface RecordingOptionsBuilderFactory {
-    RecordingOptionsBuilder create(IFlightRecorderService service)
-            throws QuantityConversionException;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+
+class TemplatesPostBodyHandler extends AbstractAuthenticatedRequestHandler {
+
+    static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
+
+    @Inject
+    TemplatesPostBodyHandler(AuthManager auth) {
+        super(auth);
+    }
+
+    @Override
+    public int getPriority() {
+        return DEFAULT_PRIORITY - 1;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public String path() {
+        return TemplatesPostHandler.PATH;
+    }
+
+    @Override
+    void handleAuthenticated(RoutingContext ctx) {
+        BODY_HANDLER.handle(ctx);
+    }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandler.java
@@ -41,7 +41,6 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 
@@ -90,7 +89,7 @@ class TemplatesPostHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
-    void handleAuthenticated(RoutingContext ctx) {
+    void handleAuthenticated(RoutingContext ctx) throws Exception {
         try {
             for (FileUpload u : ctx.fileUploads()) {
                 Path path = fs.pathOf(u.uploadedFileName());
@@ -106,8 +105,6 @@ class TemplatesPostHandler extends AbstractAuthenticatedRequestHandler {
                     fs.deleteIfExists(path);
                 }
             }
-        } catch (IOException ioe) {
-            throw new HttpStatusException(500, ioe.getMessage(), ioe);
         } catch (InvalidXmlException | InvalidEventTemplateException e) {
             throw new HttpStatusException(400, e.getMessage(), e);
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandler.java
@@ -61,6 +61,8 @@ import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 class TemplatesPostHandler extends AbstractAuthenticatedRequestHandler {
 
+    static final String PATH = "/api/v1/templates";
+
     private final LocalStorageTemplateService templateService;
     private final FileSystem fs;
     private final Logger logger;
@@ -84,7 +86,7 @@ class TemplatesPostHandler extends AbstractAuthenticatedRequestHandler {
 
     @Override
     public String path() {
-        return "/api/v1/templates";
+        return PATH;
     }
 
     @Override

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommandTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/DeleteCommandTest.java
@@ -144,7 +144,14 @@ class DeleteCommandTest implements ValidatesTargetId, ValidatesRecordingName {
 
         command.execute(new String[] {"fooHost:9091", "foo-recording"});
         verify(connection.getService()).close(recordingDescriptor);
-        verify(reportService).delete("fooHost:9091", "foo-recording");
+        ConnectionDescriptor connectionDescriptor = new ConnectionDescriptor("fooHost:9091");
+        verify(reportService)
+                .delete(
+                        Mockito.argThat(
+                                arg ->
+                                        arg.getTargetId()
+                                                .equals(connectionDescriptor.getTargetId())),
+                        Mockito.eq("foo-recording"));
     }
 
     @Test
@@ -164,7 +171,14 @@ class DeleteCommandTest implements ValidatesTargetId, ValidatesRecordingName {
         MatcherAssert.assertThat(out, Matchers.instanceOf(SerializableCommand.SuccessOutput.class));
 
         verify(connection.getService()).close(recordingDescriptor);
-        verify(reportService).delete("fooHost:9091", "foo-recording");
+        ConnectionDescriptor connectionDescriptor = new ConnectionDescriptor("fooHost:9091");
+        verify(reportService)
+                .delete(
+                        Mockito.argThat(
+                                arg ->
+                                        arg.getTargetId()
+                                                .equals(connectionDescriptor.getTargetId())),
+                        Mockito.eq("foo-recording"));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SerializableCommandRegistryImplTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/commands/internal/SerializableCommandRegistryImplTest.java
@@ -62,10 +62,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.redhat.rhjmc.containerjfr.commands.Command;
 import com.redhat.rhjmc.containerjfr.commands.SerializableCommand;
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
 
 @ExtendWith(MockitoExtension.class)
 public class SerializableCommandRegistryImplTest {
@@ -77,7 +79,9 @@ public class SerializableCommandRegistryImplTest {
 
         @BeforeEach
         public void setup() {
-            registry = new SerializableCommandRegistryImpl(Collections.emptySet());
+            registry =
+                    new SerializableCommandRegistryImpl(
+                            Collections.emptySet(), Mockito.mock(Logger.class));
         }
 
         @Test
@@ -125,7 +129,8 @@ public class SerializableCommandRegistryImplTest {
         public void setup() {
             registry =
                     new SerializableCommandRegistryImpl(
-                            new HashSet<Command>(Arrays.asList(commands)));
+                            new HashSet<Command>(Arrays.asList(commands)),
+                            Mockito.mock(Logger.class));
         }
 
         @Test
@@ -228,7 +233,8 @@ public class SerializableCommandRegistryImplTest {
                                             new HashSet<Command>(
                                                     Arrays.asList(
                                                             new FooCommand(),
-                                                            new DuplicateFooCommand()))),
+                                                            new DuplicateFooCommand())),
+                                            Mockito.mock(Logger.class)),
                             "should throw CommandDefinitionException for duplicate definitions");
             assertThat(
                     thrown.getMessage(),

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/internal/reports/ActiveRecordingReportCacheTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/internal/reports/ActiveRecordingReportCacheTest.java
@@ -89,7 +89,7 @@ class ActiveRecordingReportCacheTest {
 
     @Test
     void shouldReturnFalseWhenDeletingNonExistentReport() {
-        Assertions.assertFalse(cache.delete("foo", "bar"));
+        Assertions.assertFalse(cache.delete(new ConnectionDescriptor("foo"), "bar"));
     }
 
     @Test
@@ -117,8 +117,9 @@ class ActiveRecordingReportCacheTest {
 
         String targetId = "foo";
 
-        cache.get(targetId, recordingName);
-        Assertions.assertTrue(cache.delete(targetId, recordingName));
+        ConnectionDescriptor connectionDescriptor = new ConnectionDescriptor(targetId);
+        cache.get(connectionDescriptor, recordingName);
+        Assertions.assertTrue(cache.delete(connectionDescriptor, recordingName));
     }
 
     @Test
@@ -146,7 +147,8 @@ class ActiveRecordingReportCacheTest {
 
         String targetId = "foo";
 
-        String report = cache.get(targetId, recordingName);
+        ConnectionDescriptor connectionDescriptor = new ConnectionDescriptor(targetId);
+        String report = cache.get(connectionDescriptor, recordingName);
         MatcherAssert.assertThat(report, Matchers.equalTo("Generated Report"));
 
         InOrder inOrder =
@@ -197,9 +199,10 @@ class ActiveRecordingReportCacheTest {
 
         String targetId = "foo";
 
-        String report1 = cache.get(targetId, recordingName);
+        ConnectionDescriptor connectionDescriptor = new ConnectionDescriptor(targetId);
+        String report1 = cache.get(connectionDescriptor, recordingName);
         MatcherAssert.assertThat(report1, Matchers.equalTo("Generated Report"));
-        String report2 = cache.get(targetId, recordingName);
+        String report2 = cache.get(connectionDescriptor, recordingName);
         MatcherAssert.assertThat(report2, Matchers.equalTo(report1));
 
         InOrder inOrder =
@@ -235,7 +238,9 @@ class ActiveRecordingReportCacheTest {
 
         Mockito.when(service.getAvailableRecordings()).thenReturn(List.of());
 
-        Assertions.assertThrows(RecordingNotFoundException.class, () -> cache.get("foo", "bar"));
+        ConnectionDescriptor connectionDescriptor = new ConnectionDescriptor("foo");
+        Assertions.assertThrows(
+                RecordingNotFoundException.class, () -> cache.get(connectionDescriptor, "bar"));
     }
 
     @Test
@@ -252,6 +257,8 @@ class ActiveRecordingReportCacheTest {
         Mockito.when(service.openStream(Mockito.any(), Mockito.anyBoolean()))
                 .thenThrow(FlightRecorderException.class);
 
-        Assertions.assertThrows(RecordingNotFoundException.class, () -> cache.get("foo", "bar"));
+        ConnectionDescriptor connectionDescriptor = new ConnectionDescriptor("foo");
+        Assertions.assertThrows(
+                RecordingNotFoundException.class, () -> cache.get(connectionDescriptor, "bar"));
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandlerTest.java
@@ -146,7 +146,7 @@ class CorsEnablingHandlerTest {
         @ParameterizedTest
         @EnumSource(
                 value = HttpMethod.class,
-                names = {"GET", "POST", "OPTIONS", "HEAD", "DELETE"})
+                names = {"GET", "POST", "PATCH", "OPTIONS", "HEAD", "DELETE"})
         void shouldRespondOKToOPTIONSWithAcceptedMethod(HttpMethod method) {
             Mockito.when(req.method()).thenReturn(HttpMethod.OPTIONS);
             Mockito.when(headers.get(HttpHeaders.ORIGIN)).thenReturn(CUSTOM_ORIGIN);
@@ -161,7 +161,7 @@ class CorsEnablingHandlerTest {
             Mockito.verify(res)
                     .putHeader(
                             HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
-                            "GET,POST,OPTIONS,HEAD,DELETE");
+                            "GET,POST,PATCH,OPTIONS,HEAD,DELETE");
             Mockito.verify(res)
                     .putHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "Authorization");
             Mockito.verify(res).setStatusCode(200);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingDeleteHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingDeleteHandlerTest.java
@@ -61,6 +61,7 @@ import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService;
 
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 
@@ -74,6 +75,7 @@ class RecordingDeleteHandlerTest {
     @Mock Path savedRecordingsPath;
 
     @Mock RoutingContext ctx;
+    @Mock HttpServerResponse resp;
 
     @BeforeEach
     void setup() {
@@ -113,13 +115,17 @@ class RecordingDeleteHandlerTest {
 
         Path path = Mockito.mock(Path.class);
         Mockito.when(savedRecordingsPath.resolve(Mockito.anyString())).thenReturn(path);
+        Mockito.when(fs.exists(path)).thenReturn(true);
 
+        Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
 
         handler.handle(ctx);
 
         Mockito.verify(fs).deleteIfExists(path);
         Mockito.verify(reportService).delete(recordingName);
+        Mockito.verify(resp).setStatusCode(200);
+        Mockito.verify(resp).end();
     }
 
     @Test
@@ -132,6 +138,7 @@ class RecordingDeleteHandlerTest {
 
         Path path = Mockito.mock(Path.class);
         Mockito.when(savedRecordingsPath.resolve(Mockito.anyString())).thenReturn(path);
+        Mockito.when(fs.exists(path)).thenReturn(true);
         Mockito.when(fs.deleteIfExists(path)).thenThrow(IOException.class);
 
         Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingDeleteHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingDeleteHandlerTest.java
@@ -1,0 +1,145 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class RecordingDeleteHandlerTest {
+
+    RecordingDeleteHandler handler;
+    @Mock AuthManager auth;
+    @Mock ReportService reportService;
+    @Mock FileSystem fs;
+    @Mock Path savedRecordingsPath;
+
+    @Mock RoutingContext ctx;
+
+    @BeforeEach
+    void setup() {
+        this.handler = new RecordingDeleteHandler(auth, reportService, fs, savedRecordingsPath);
+    }
+
+    @Test
+    void shouldHandleDELETE() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.DELETE));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(), Matchers.equalTo("/api/v1/recordings/:recordingName"));
+    }
+
+    @Test
+    void shouldThrow404IfNoMatchingRecordingFound() throws Exception {
+        Mockito.when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        Mockito.when(fs.listDirectoryChildren(Mockito.any())).thenReturn(List.of());
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+    }
+
+    @Test
+    void shouldDeleteIfRecordingFound() throws Exception {
+        Mockito.when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        String recordingName = "someRecording";
+        Mockito.when(fs.listDirectoryChildren(Mockito.any())).thenReturn(List.of(recordingName));
+
+        Path path = Mockito.mock(Path.class);
+        Mockito.when(savedRecordingsPath.resolve(Mockito.anyString())).thenReturn(path);
+
+        Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
+
+        handler.handle(ctx);
+
+        Mockito.verify(fs).deleteIfExists(path);
+        Mockito.verify(reportService).delete(recordingName);
+    }
+
+    @Test
+    void shouldThrowExceptionIfDeletionFails() throws Exception {
+        Mockito.when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        String recordingName = "someRecording";
+        Mockito.when(fs.listDirectoryChildren(Mockito.any())).thenReturn(List.of(recordingName));
+
+        Path path = Mockito.mock(Path.class);
+        Mockito.when(savedRecordingsPath.resolve(Mockito.anyString())).thenReturn(path);
+        Mockito.when(fs.deleteIfExists(path)).thenThrow(IOException.class);
+
+        Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+
+        Mockito.verify(reportService).delete(recordingName);
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingUploadPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingUploadPostHandlerTest.java
@@ -1,0 +1,183 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class RecordingUploadPostHandlerTest {
+
+    RecordingUploadPostHandler handler;
+    @Mock AuthManager auth;
+    @Mock Environment env;
+    @Mock WebClient webClient;
+    @Mock FileSystem fs;
+    @Mock Path savedRecordingsPath;
+
+    @Mock RoutingContext ctx;
+
+    static final String DATASOURCE_URL = "http://localhost:8080";
+
+    @BeforeEach
+    void setup() {
+        this.handler =
+                new RecordingUploadPostHandler(auth, env, webClient, fs, savedRecordingsPath);
+    }
+
+    @Test
+    void shouldHandlePOST() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(), Matchers.equalTo("/api/v1/recordings/:recordingName/upload"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"notaurl", "almost:/valid", "*notok"})
+    @NullAndEmptySource
+    void shouldThrow501IfDatasourceUrlMalformed(String rawUrl) {
+        Mockito.when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        Mockito.when(env.getEnv("GRAFANA_DATASOURCE_URL")).thenReturn(rawUrl);
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(501));
+    }
+
+    @Test
+    void shouldThrowExceptionIfRecordingNotFound() throws Exception {
+        Mockito.when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        Mockito.when(env.getEnv("GRAFANA_DATASOURCE_URL")).thenReturn(DATASOURCE_URL);
+        Mockito.when(fs.isRegularFile(Mockito.any())).thenReturn(false);
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+    }
+
+    @Test
+    void shouldDoUpload() throws Exception {
+        Mockito.when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        Mockito.when(env.getEnv("GRAFANA_DATASOURCE_URL")).thenReturn(DATASOURCE_URL);
+
+        Mockito.when(ctx.pathParam("recordingName")).thenReturn("foo");
+
+        Mockito.when(savedRecordingsPath.resolve(Mockito.anyString()))
+                .thenReturn(Mockito.mock(Path.class));
+        Mockito.when(fs.isRegularFile(Mockito.any())).thenReturn(true);
+        Mockito.when(fs.isReadable(Mockito.any())).thenReturn(true);
+
+        HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
+        HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
+        Mockito.when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+        Mockito.when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
+        Mockito.doAnswer(
+                        new Answer<Void>() {
+                            @Override
+                            public Void answer(InvocationOnMock args) throws Throwable {
+                                AsyncResult<HttpResponse<Buffer>> asyncResult =
+                                        Mockito.mock(AsyncResult.class);
+                                Mockito.when(asyncResult.result()).thenReturn(httpResp);
+                                Mockito.when(httpResp.statusCode()).thenReturn(200);
+                                Mockito.when(httpResp.statusMessage()).thenReturn("OK");
+                                Mockito.when(httpResp.bodyAsString()).thenReturn("HELLO");
+                                ((Handler<AsyncResult<HttpResponse<Buffer>>>) args.getArgument(1))
+                                        .handle(asyncResult);
+                                return null;
+                            }
+                        })
+                .when(httpReq)
+                .sendMultipartForm(Mockito.any(), Mockito.any());
+
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.response()).thenReturn(resp);
+
+        handler.handle(ctx);
+
+        Mockito.verify(resp).setStatusCode(200);
+        Mockito.verify(resp).setStatusMessage("OK");
+        Mockito.verify(resp).end("HELLO");
+
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(webClient).postAbs(urlCaptor.capture());
+        MatcherAssert.assertThat(
+                urlCaptor.getValue(), Matchers.equalTo(DATASOURCE_URL.concat("/load")));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingsGetHandlerTest.java
@@ -100,7 +100,7 @@ class RecordingsGetHandlerTest {
     }
 
     @Test
-    void shouldRespondWith403IfDirectoryDoesNotExist() throws IOException {
+    void shouldRespondWith501IfDirectoryDoesNotExist() throws IOException {
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
 
         Mockito.when(fs.exists(Mockito.any())).thenReturn(false);
@@ -108,11 +108,11 @@ class RecordingsGetHandlerTest {
         HttpStatusException httpEx =
                 Assertions.assertThrows(
                         HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
-        MatcherAssert.assertThat(httpEx.getStatusCode(), Matchers.equalTo(403));
+        MatcherAssert.assertThat(httpEx.getStatusCode(), Matchers.equalTo(501));
     }
 
     @Test
-    void shouldResponseWith403IfDirectoryNotReadable() throws IOException {
+    void shouldResponseWith501IfDirectoryNotReadable() throws IOException {
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
 
         Mockito.when(fs.exists(Mockito.any())).thenReturn(true);
@@ -121,11 +121,11 @@ class RecordingsGetHandlerTest {
         HttpStatusException httpEx =
                 Assertions.assertThrows(
                         HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
-        MatcherAssert.assertThat(httpEx.getStatusCode(), Matchers.equalTo(403));
+        MatcherAssert.assertThat(httpEx.getStatusCode(), Matchers.equalTo(501));
     }
 
     @Test
-    void shouldRespondWith403IfPathNotDirectory() throws IOException {
+    void shouldRespondWith501IfPathNotDirectory() throws IOException {
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
 
         Mockito.when(fs.exists(Mockito.any())).thenReturn(true);
@@ -135,7 +135,7 @@ class RecordingsGetHandlerTest {
         HttpStatusException httpEx =
                 Assertions.assertThrows(
                         HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
-        MatcherAssert.assertThat(httpEx.getStatusCode(), Matchers.equalTo(403));
+        MatcherAssert.assertThat(httpEx.getStatusCode(), Matchers.equalTo(501));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ReportGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/ReportGetHandlerTest.java
@@ -114,7 +114,6 @@ class ReportGetHandlerTest {
 
         HttpStatusException ex =
                 Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
-        ex.printStackTrace();
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingDeleteHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingDeleteHandlerTest.java
@@ -63,6 +63,7 @@ import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService;
@@ -125,7 +126,14 @@ class TargetRecordingDeleteHandlerTest {
         handler.handleAuthenticated(ctx);
 
         Mockito.verify(service).close(descriptor);
-        Mockito.verify(reportService).delete("fooTarget", "someRecording");
+        ConnectionDescriptor connectionDescriptor = new ConnectionDescriptor("fooTarget");
+        Mockito.verify(reportService)
+                .delete(
+                        Mockito.argThat(
+                                arg ->
+                                        arg.getTargetId()
+                                                .equals(connectionDescriptor.getTargetId())),
+                        Mockito.eq("someRecording"));
         InOrder inOrder = Mockito.inOrder(resp);
         inOrder.verify(resp).setStatusCode(200);
         inOrder.verify(resp).end();

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingDeleteHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingDeleteHandlerTest.java
@@ -1,0 +1,178 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.List;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.QuantityConversionException;
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
+import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TargetRecordingDeleteHandlerTest {
+
+    TargetRecordingDeleteHandler handler;
+    @Mock AuthManager auth;
+    @Mock TargetConnectionManager targetConnectionManager;
+    @Mock ReportService reportService;
+
+    @Mock RoutingContext ctx;
+    @Mock HttpServerResponse resp;
+    @Mock JFRConnection connection;
+    @Mock IFlightRecorderService service;
+
+    @BeforeEach
+    void setup() {
+        this.handler =
+                new TargetRecordingDeleteHandler(auth, targetConnectionManager, reportService);
+    }
+
+    @Test
+    void shouldHandleDELETE() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.DELETE));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(),
+                Matchers.equalTo("/api/v1/targets/:targetId/recordings/:recordingName"));
+    }
+
+    @Test
+    void shouldDeleteRecording() throws Exception {
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("fooTarget");
+        Mockito.when(ctx.pathParam("recordingName")).thenReturn("someRecording");
+        Mockito.when(ctx.response()).thenReturn(resp);
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any()))
+                .thenAnswer(
+                        new Answer() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                ConnectedTask task = (ConnectedTask) invocation.getArgument(1);
+                                return task.execute(connection);
+                            }
+                        });
+
+        Mockito.when(connection.getService()).thenReturn(service);
+        IRecordingDescriptor descriptor = createDescriptor("someRecording");
+        Mockito.when(service.getAvailableRecordings()).thenReturn(List.of(descriptor));
+
+        handler.handleAuthenticated(ctx);
+
+        Mockito.verify(service).close(descriptor);
+        Mockito.verify(reportService).delete("fooTarget", "someRecording");
+        InOrder inOrder = Mockito.inOrder(resp);
+        inOrder.verify(resp).setStatusCode(200);
+        inOrder.verify(resp).end();
+    }
+
+    @Test
+    void shouldHandleRecordingNotFound() throws Exception {
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("fooTarget");
+        Mockito.when(ctx.pathParam("recordingName")).thenReturn("someRecording");
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any()))
+                .thenAnswer(
+                        new Answer() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                ConnectedTask task = (ConnectedTask) invocation.getArgument(1);
+                                return task.execute(connection);
+                            }
+                        });
+
+        Mockito.when(connection.getService()).thenReturn(service);
+        Mockito.when(service.getAvailableRecordings()).thenReturn(List.of());
+
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+    }
+
+    private static IRecordingDescriptor createDescriptor(String name)
+            throws QuantityConversionException {
+        IQuantity zeroQuantity = Mockito.mock(IQuantity.class);
+        IRecordingDescriptor descriptor = Mockito.mock(IRecordingDescriptor.class);
+        Mockito.lenient().when(descriptor.getId()).thenReturn(1L);
+        Mockito.lenient().when(descriptor.getName()).thenReturn(name);
+        Mockito.lenient()
+                .when(descriptor.getState())
+                .thenReturn(IRecordingDescriptor.RecordingState.STOPPED);
+        Mockito.lenient().when(descriptor.getStartTime()).thenReturn(zeroQuantity);
+        Mockito.lenient().when(descriptor.getDuration()).thenReturn(zeroQuantity);
+        Mockito.lenient().when(descriptor.isContinuous()).thenReturn(false);
+        Mockito.lenient().when(descriptor.getToDisk()).thenReturn(false);
+        Mockito.lenient().when(descriptor.getMaxSize()).thenReturn(zeroQuantity);
+        Mockito.lenient().when(descriptor.getMaxAge()).thenReturn(zeroQuantity);
+        return descriptor;
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingDeleteHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingDeleteHandlerTest.java
@@ -108,9 +108,7 @@ class TargetRecordingDeleteHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("fooTarget");
         Mockito.when(ctx.pathParam("recordingName")).thenReturn("someRecording");
         Mockito.when(ctx.response()).thenReturn(resp);
-        Mockito.when(
-                        targetConnectionManager.executeConnectedTask(
-                                Mockito.anyString(), Mockito.any()))
+        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
                 .thenAnswer(
                         new Answer() {
                             @Override
@@ -137,9 +135,7 @@ class TargetRecordingDeleteHandlerTest {
     void shouldHandleRecordingNotFound() throws Exception {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("fooTarget");
         Mockito.when(ctx.pathParam("recordingName")).thenReturn("someRecording");
-        Mockito.when(
-                        targetConnectionManager.executeConnectedTask(
-                                Mockito.anyString(), Mockito.any()))
+        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
                 .thenAnswer(
                         new Answer() {
                             @Override

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandlerTest.java
@@ -223,7 +223,6 @@ class TargetRecordingGetHandlerTest {
 
         HttpStatusException ex =
                 Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
-        ex.printStackTrace();
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 
@@ -246,7 +245,6 @@ class TargetRecordingGetHandlerTest {
 
         HttpStatusException ex =
                 Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
-        ex.printStackTrace();
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandlerTest.java
@@ -70,14 +70,12 @@ class TargetRecordingPatchHandlerTest {
     @Mock AuthManager authManager;
     @Mock TargetRecordingPatchSave patchSave;
     @Mock TargetRecordingPatchStop patchStop;
-    @Mock TargetRecordingPatchSnapshot patchSnapshot;
     @Mock RoutingContext ctx;
     @Mock ConnectionDescriptor connectionDescriptor;
 
     @BeforeEach
     void setup() {
-        this.handler =
-                new TargetRecordingPatchHandler(authManager, patchSave, patchStop, patchSnapshot);
+        this.handler = new TargetRecordingPatchHandler(authManager, patchSave, patchStop);
     }
 
     @Test
@@ -122,7 +120,7 @@ class TargetRecordingPatchHandlerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"save", "stop", "snapshot"})
+    @ValueSource(strings = {"save", "stop"})
     void shouldDelegateSupportedOperations(String mtd) throws Exception {
         Mockito.when(authManager.validateHttpHeader(Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
@@ -137,10 +135,6 @@ class TargetRecordingPatchHandlerTest {
                 break;
             case "stop":
                 Mockito.verify(patchStop)
-                        .handle(Mockito.eq(ctx), Mockito.any(ConnectionDescriptor.class));
-                break;
-            case "snapshot":
-                Mockito.verify(patchSnapshot)
                         .handle(Mockito.eq(ctx), Mockito.any(ConnectionDescriptor.class));
                 break;
             default:

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandlerTest.java
@@ -70,12 +70,14 @@ class TargetRecordingPatchHandlerTest {
     @Mock AuthManager authManager;
     @Mock TargetRecordingPatchSave patchSave;
     @Mock TargetRecordingPatchStop patchStop;
+    @Mock TargetRecordingPatchSnapshot patchSnapshot;
     @Mock RoutingContext ctx;
     @Mock ConnectionDescriptor connectionDescriptor;
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetRecordingPatchHandler(authManager, patchSave, patchStop);
+        this.handler =
+                new TargetRecordingPatchHandler(authManager, patchSave, patchStop, patchSnapshot);
     }
 
     @Test
@@ -120,7 +122,7 @@ class TargetRecordingPatchHandlerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"save", "stop"})
+    @ValueSource(strings = {"save", "stop", "snapshot"})
     void shouldDelegateSupportedOperations(String mtd) throws Exception {
         Mockito.when(authManager.validateHttpHeader(Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
@@ -135,6 +137,10 @@ class TargetRecordingPatchHandlerTest {
                 break;
             case "stop":
                 Mockito.verify(patchStop)
+                        .handle(Mockito.eq(ctx), Mockito.any(ConnectionDescriptor.class));
+                break;
+            case "snapshot":
+                Mockito.verify(patchSnapshot)
                         .handle(Mockito.eq(ctx), Mockito.any(ConnectionDescriptor.class));
                 break;
             default:

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandlerTest.java
@@ -57,6 +57,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
@@ -70,6 +71,7 @@ class TargetRecordingPatchHandlerTest {
     @Mock TargetRecordingPatchSave patchSave;
     @Mock TargetRecordingPatchStop patchStop;
     @Mock RoutingContext ctx;
+    @Mock ConnectionDescriptor connectionDescriptor;
 
     @BeforeEach
     void setup() {
@@ -119,7 +121,7 @@ class TargetRecordingPatchHandlerTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"save", "stop"})
-    void shouldDelegateSupportedOperations(String mtd) {
+    void shouldDelegateSupportedOperations(String mtd) throws Exception {
         Mockito.when(authManager.validateHttpHeader(Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
         Mockito.when(ctx.getBodyAsString()).thenReturn(mtd);
@@ -128,10 +130,12 @@ class TargetRecordingPatchHandlerTest {
 
         switch (mtd) {
             case "save":
-                Mockito.verify(patchSave).handle(ctx);
+                Mockito.verify(patchSave)
+                        .handle(Mockito.eq(ctx), Mockito.any(ConnectionDescriptor.class));
                 break;
             case "stop":
-                Mockito.verify(patchStop).handle(ctx);
+                Mockito.verify(patchStop)
+                        .handle(Mockito.eq(ctx), Mockito.any(ConnectionDescriptor.class));
                 break;
             default:
                 throw new IllegalArgumentException(mtd);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandlerTest.java
@@ -1,0 +1,140 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TargetRecordingPatchHandlerTest {
+
+    TargetRecordingPatchHandler handler;
+    @Mock AuthManager authManager;
+    @Mock TargetRecordingPatchSave patchSave;
+    @Mock TargetRecordingPatchStop patchStop;
+    @Mock RoutingContext ctx;
+
+    @BeforeEach
+    void setup() {
+        this.handler = new TargetRecordingPatchHandler(authManager, patchSave, patchStop);
+    }
+
+    @Test
+    void shouldHandlePATCH() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.PATCH));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(),
+                Matchers.equalTo("/api/v1/targets/:targetId/recordings/:recordingName"));
+    }
+
+    @Test
+    void shouldNotBeAsync() {
+        // recording saving is a blocking operation, so the handler should be marked as such
+        Assertions.assertFalse(handler.isAsync());
+    }
+
+    @Test
+    void shouldThrow401IfAuthFails() {
+        Mockito.when(authManager.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(false));
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"unknown", "start", "dump"})
+    @NullAndEmptySource
+    void shouldThrow400InvalidOperations(String mtd) {
+        Mockito.when(authManager.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        Mockito.when(ctx.getBodyAsString()).thenReturn(mtd);
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"save", "stop"})
+    void shouldDelegateSupportedOperations(String mtd) {
+        Mockito.when(authManager.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        Mockito.when(ctx.getBodyAsString()).thenReturn(mtd);
+
+        handler.handle(ctx);
+
+        switch (mtd) {
+            case "save":
+                Mockito.verify(patchSave).handle(ctx);
+                break;
+            case "stop":
+                Mockito.verify(patchStop).handle(ctx);
+                break;
+            default:
+                throw new IllegalArgumentException(mtd);
+        }
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchSaveTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchSaveTest.java
@@ -1,0 +1,269 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.sys.Clock;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
+
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TargetRecordingPatchSaveTest {
+
+    TargetRecordingPatchSave patchSave;
+    @Mock FileSystem fs;
+    @Mock Path recordingsPath;
+    @Mock TargetConnectionManager targetConnectionManager;
+    @Mock Clock clock;
+    @Mock Logger logger;
+
+    @Mock RoutingContext ctx;
+    @Mock HttpServerResponse resp;
+    @Mock JFRConnection jfrConnection;
+    @Mock IFlightRecorderService service;
+
+    String targetId = "fooTarget";
+    String recordingName = "someRecording";
+
+    @BeforeEach
+    void setup() {
+        this.patchSave =
+                new TargetRecordingPatchSave(
+                        fs, recordingsPath, targetConnectionManager, clock, logger);
+        Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
+        Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
+    }
+
+    @Test
+    void shouldThrow500IfTargetConnectionManagerThrows() throws Exception {
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any()))
+                .thenThrow(NullPointerException.class);
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> patchSave.handle(ctx));
+
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Test
+    void shouldThrow500IfTaskThrows() throws Exception {
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any(ConnectedTask.class)))
+                .thenAnswer(
+                        new Answer<>() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                ConnectedTask task = (ConnectedTask) invocation.getArgument(1);
+                                return task.execute(jfrConnection);
+                            }
+                        });
+        Mockito.when(jfrConnection.getService()).thenThrow(NullPointerException.class);
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> patchSave.handle(ctx));
+
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Test
+    void shouldThrow404IfNoMatchingRecordingFound() throws Exception {
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any(ConnectedTask.class)))
+                .thenAnswer(
+                        new Answer<>() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                ConnectedTask task = (ConnectedTask) invocation.getArgument(1);
+                                return task.execute(jfrConnection);
+                            }
+                        });
+        Mockito.when(jfrConnection.getService()).thenReturn(service);
+        Mockito.when(service.getAvailableRecordings()).thenReturn(List.of());
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> patchSave.handle(ctx));
+
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+    }
+
+    @Test
+    void shouldSaveRecording() throws Exception {
+        Mockito.when(ctx.response()).thenReturn(resp);
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any(ConnectedTask.class)))
+                .thenAnswer(
+                        new Answer<>() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                ConnectedTask task = (ConnectedTask) invocation.getArgument(1);
+                                return task.execute(jfrConnection);
+                            }
+                        });
+        Mockito.when(jfrConnection.getService()).thenReturn(service);
+        IRecordingDescriptor descriptor = Mockito.mock(IRecordingDescriptor.class);
+        Mockito.when(descriptor.getName()).thenReturn(recordingName);
+        Mockito.when(service.getAvailableRecordings()).thenReturn(List.of(descriptor));
+        Mockito.when(jfrConnection.getHost()).thenReturn("some-hostname.local");
+        Instant now = Instant.now();
+        Mockito.when(clock.now()).thenReturn(now);
+        Mockito.when(fs.exists(Mockito.any())).thenReturn(false);
+        InputStream stream = Mockito.mock(InputStream.class);
+        Mockito.when(service.openStream(descriptor, false)).thenReturn(stream);
+        Path destination = Mockito.mock(Path.class);
+        Mockito.when(recordingsPath.resolve(Mockito.anyString())).thenReturn(destination);
+
+        patchSave.handle(ctx);
+
+        InOrder inOrder = Mockito.inOrder(resp);
+        inOrder.verify(resp).setStatusCode(200);
+        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
+        inOrder.verify(resp).end("some-hostname-local_someRecording_" + timestamp + ".jfr");
+        Mockito.verify(fs).copy(Mockito.eq(stream), Mockito.eq(destination));
+    }
+
+    @Test
+    void shouldSaveRecordingThatEndsWithJfr() throws Exception {
+        String recordingName = "someRecording.jfr";
+        Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
+        Mockito.when(ctx.response()).thenReturn(resp);
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any(ConnectedTask.class)))
+                .thenAnswer(
+                        new Answer<>() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                ConnectedTask task = (ConnectedTask) invocation.getArgument(1);
+                                return task.execute(jfrConnection);
+                            }
+                        });
+        Mockito.when(jfrConnection.getService()).thenReturn(service);
+        IRecordingDescriptor descriptor = Mockito.mock(IRecordingDescriptor.class);
+        Mockito.when(descriptor.getName()).thenReturn(recordingName);
+        Mockito.when(service.getAvailableRecordings()).thenReturn(List.of(descriptor));
+        Mockito.when(jfrConnection.getHost()).thenReturn("some-hostname.local");
+        Instant now = Instant.now();
+        Mockito.when(clock.now()).thenReturn(now);
+        Mockito.when(fs.exists(Mockito.any())).thenReturn(false);
+        InputStream stream = Mockito.mock(InputStream.class);
+        Mockito.when(service.openStream(descriptor, false)).thenReturn(stream);
+        Path destination = Mockito.mock(Path.class);
+        Mockito.when(recordingsPath.resolve(Mockito.anyString())).thenReturn(destination);
+
+        patchSave.handle(ctx);
+
+        InOrder inOrder = Mockito.inOrder(resp);
+        inOrder.verify(resp).setStatusCode(200);
+        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
+        inOrder.verify(resp).end("some-hostname-local_someRecording_" + timestamp + ".jfr");
+        Mockito.verify(fs).copy(Mockito.eq(stream), Mockito.eq(destination));
+    }
+
+    @Test
+    void shouldSaveRecordingNumberedCopy() throws Exception {
+        Mockito.when(ctx.response()).thenReturn(resp);
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any(ConnectedTask.class)))
+                .thenAnswer(
+                        new Answer<>() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                ConnectedTask task = (ConnectedTask) invocation.getArgument(1);
+                                return task.execute(jfrConnection);
+                            }
+                        });
+        Mockito.when(jfrConnection.getService()).thenReturn(service);
+        IRecordingDescriptor descriptor = Mockito.mock(IRecordingDescriptor.class);
+        Mockito.when(descriptor.getName()).thenReturn(recordingName);
+        Mockito.when(service.getAvailableRecordings()).thenReturn(List.of(descriptor));
+        Mockito.when(jfrConnection.getHost()).thenReturn("some-hostname.local");
+        Instant now = Instant.now();
+        Mockito.when(clock.now()).thenReturn(now);
+        Mockito.when(fs.exists(Mockito.any())).thenReturn(true).thenReturn(false);
+        InputStream stream = Mockito.mock(InputStream.class);
+        Mockito.when(service.openStream(descriptor, false)).thenReturn(stream);
+        Path destination = Mockito.mock(Path.class);
+        Mockito.when(recordingsPath.resolve(Mockito.anyString())).thenReturn(destination);
+
+        patchSave.handle(ctx);
+
+        InOrder inOrder = Mockito.inOrder(resp);
+        inOrder.verify(resp).setStatusCode(200);
+        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
+        inOrder.verify(resp).end("some-hostname-local_someRecording_" + timestamp + ".1.jfr");
+        Mockito.verify(fs).copy(Mockito.eq(stream), Mockito.eq(destination));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchSaveTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchSaveTest.java
@@ -67,6 +67,7 @@ import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.sys.Clock;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 
@@ -97,49 +98,14 @@ class TargetRecordingPatchSaveTest {
         this.patchSave =
                 new TargetRecordingPatchSave(
                         fs, recordingsPath, targetConnectionManager, clock, logger);
-        Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
         Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
-    }
-
-    @Test
-    void shouldThrow500IfTargetConnectionManagerThrows() throws Exception {
-        Mockito.when(
-                        targetConnectionManager.executeConnectedTask(
-                                Mockito.anyString(), Mockito.any()))
-                .thenThrow(NullPointerException.class);
-
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> patchSave.handle(ctx));
-
-        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
-    }
-
-    @Test
-    void shouldThrow500IfTaskThrows() throws Exception {
-        Mockito.when(
-                        targetConnectionManager.executeConnectedTask(
-                                Mockito.anyString(), Mockito.any(ConnectedTask.class)))
-                .thenAnswer(
-                        new Answer<>() {
-                            @Override
-                            public Object answer(InvocationOnMock invocation) throws Throwable {
-                                ConnectedTask task = (ConnectedTask) invocation.getArgument(1);
-                                return task.execute(jfrConnection);
-                            }
-                        });
-        Mockito.when(jfrConnection.getService()).thenThrow(NullPointerException.class);
-
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> patchSave.handle(ctx));
-
-        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 
     @Test
     void shouldThrow404IfNoMatchingRecordingFound() throws Exception {
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
-                                Mockito.anyString(), Mockito.any(ConnectedTask.class)))
+                                Mockito.any(), Mockito.any(ConnectedTask.class)))
                 .thenAnswer(
                         new Answer<>() {
                             @Override
@@ -152,7 +118,9 @@ class TargetRecordingPatchSaveTest {
         Mockito.when(service.getAvailableRecordings()).thenReturn(List.of());
 
         HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> patchSave.handle(ctx));
+                Assertions.assertThrows(
+                        HttpStatusException.class,
+                        () -> patchSave.handle(ctx, new ConnectionDescriptor(targetId)));
 
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
@@ -162,7 +130,7 @@ class TargetRecordingPatchSaveTest {
         Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
-                                Mockito.anyString(), Mockito.any(ConnectedTask.class)))
+                                Mockito.any(), Mockito.any(ConnectedTask.class)))
                 .thenAnswer(
                         new Answer<>() {
                             @Override
@@ -184,7 +152,7 @@ class TargetRecordingPatchSaveTest {
         Path destination = Mockito.mock(Path.class);
         Mockito.when(recordingsPath.resolve(Mockito.anyString())).thenReturn(destination);
 
-        patchSave.handle(ctx);
+        patchSave.handle(ctx, new ConnectionDescriptor(targetId));
 
         InOrder inOrder = Mockito.inOrder(resp);
         inOrder.verify(resp).setStatusCode(200);
@@ -200,7 +168,7 @@ class TargetRecordingPatchSaveTest {
         Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
-                                Mockito.anyString(), Mockito.any(ConnectedTask.class)))
+                                Mockito.any(), Mockito.any(ConnectedTask.class)))
                 .thenAnswer(
                         new Answer<>() {
                             @Override
@@ -222,7 +190,7 @@ class TargetRecordingPatchSaveTest {
         Path destination = Mockito.mock(Path.class);
         Mockito.when(recordingsPath.resolve(Mockito.anyString())).thenReturn(destination);
 
-        patchSave.handle(ctx);
+        patchSave.handle(ctx, new ConnectionDescriptor(targetId));
 
         InOrder inOrder = Mockito.inOrder(resp);
         inOrder.verify(resp).setStatusCode(200);
@@ -236,7 +204,7 @@ class TargetRecordingPatchSaveTest {
         Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
-                                Mockito.anyString(), Mockito.any(ConnectedTask.class)))
+                                Mockito.any(), Mockito.any(ConnectedTask.class)))
                 .thenAnswer(
                         new Answer<>() {
                             @Override
@@ -258,7 +226,7 @@ class TargetRecordingPatchSaveTest {
         Path destination = Mockito.mock(Path.class);
         Mockito.when(recordingsPath.resolve(Mockito.anyString())).thenReturn(destination);
 
-        patchSave.handle(ctx);
+        patchSave.handle(ctx, new ConnectionDescriptor(targetId));
 
         InOrder inOrder = Mockito.inOrder(resp);
         inOrder.verify(resp).setStatusCode(200);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchSaveTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchSaveTest.java
@@ -63,7 +63,6 @@ import org.mockito.stubbing.Answer;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.sys.Clock;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
@@ -83,7 +82,6 @@ class TargetRecordingPatchSaveTest {
     @Mock Path recordingsPath;
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock Clock clock;
-    @Mock Logger logger;
 
     @Mock RoutingContext ctx;
     @Mock HttpServerResponse resp;
@@ -96,8 +94,7 @@ class TargetRecordingPatchSaveTest {
     @BeforeEach
     void setup() {
         this.patchSave =
-                new TargetRecordingPatchSave(
-                        fs, recordingsPath, targetConnectionManager, clock, logger);
+                new TargetRecordingPatchSave(fs, recordingsPath, targetConnectionManager, clock);
         Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
     }
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchSnapshotTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchSnapshotTest.java
@@ -1,0 +1,125 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import org.openjdk.jmc.common.unit.IConstrainedMap;
+import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.commands.internal.RecordingOptionsBuilderFactory;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
+
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+
+@ExtendWith(MockitoExtension.class)
+class TargetRecordingPatchSnapshotTest {
+
+    TargetRecordingPatchSnapshot snapshot;
+    @Mock TargetConnectionManager targetConnectionManager;
+    @Mock RecordingOptionsBuilderFactory recordingOptionsBuilderFactory;
+
+    @BeforeEach
+    void setup() {
+        this.snapshot =
+                new TargetRecordingPatchSnapshot(
+                        targetConnectionManager, recordingOptionsBuilderFactory);
+    }
+
+    @Test
+    void shouldCreateSnapshot() throws Exception {
+        RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.response()).thenReturn(resp);
+        ConnectionDescriptor connectionDescriptor = Mockito.mock(ConnectionDescriptor.class);
+
+        IRecordingDescriptor recordingDescriptor = Mockito.mock(IRecordingDescriptor.class);
+        Mockito.when(recordingDescriptor.getName()).thenReturn("THESNAPSHOT");
+        Mockito.when(recordingDescriptor.getId()).thenReturn(1234L);
+
+        IFlightRecorderService svc = Mockito.mock(IFlightRecorderService.class);
+        JFRConnection conn = Mockito.mock(JFRConnection.class);
+        Mockito.when(conn.getService()).thenReturn(svc);
+        Mockito.when(svc.getSnapshotRecording()).thenReturn(recordingDescriptor);
+
+        RecordingOptionsBuilder recordingOptionsBuilder =
+                Mockito.mock(RecordingOptionsBuilder.class);
+        Mockito.when(recordingOptionsBuilderFactory.create(svc))
+                .thenReturn(recordingOptionsBuilder);
+        IConstrainedMap map = Mockito.mock(IConstrainedMap.class);
+        Mockito.when(recordingOptionsBuilder.build()).thenReturn(map);
+
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.any(ConnectionDescriptor.class), Mockito.any()))
+                .thenAnswer(
+                        new Answer() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                ConnectedTask task = (ConnectedTask) invocation.getArgument(1);
+                                return task.execute(conn);
+                            }
+                        });
+
+        snapshot.handle(ctx, connectionDescriptor);
+
+        Mockito.verify(svc).getSnapshotRecording();
+        Mockito.verify(recordingOptionsBuilder).name("thesnapshot-1234");
+        Mockito.verify(recordingOptionsBuilder).build();
+        Mockito.verify(svc).updateRecordingOptions(recordingDescriptor, map);
+        Mockito.verify(resp).setStatusCode(200);
+        Mockito.verify(resp).end("thesnapshot-1234");
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchStopTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchStopTest.java
@@ -1,0 +1,148 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.List;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
+
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TargetRecordingPatchStopTest {
+
+    TargetRecordingPatchStop patchStop;
+    @Mock TargetConnectionManager targetConnectionManager;
+    @Mock RoutingContext ctx;
+    @Mock HttpServerResponse resp;
+    @Mock JFRConnection connection;
+    @Mock IFlightRecorderService service;
+
+    @BeforeEach
+    void setup() {
+        this.patchStop = new TargetRecordingPatchStop(targetConnectionManager);
+    }
+
+    @Test
+    void shouldThrow500IfTargetConnectionManagerThrows() throws Exception {
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any()))
+                .thenThrow(NullPointerException.class);
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> patchStop.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Test
+    void shouldThrow404IfNoMatchingRecordingFound() throws Exception {
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("fooTarget");
+        Mockito.when(ctx.pathParam("recordingName")).thenReturn("someRecording");
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any()))
+                .thenAnswer(
+                        new Answer<>() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                ConnectedTask task = (ConnectedTask) invocation.getArgument(1);
+                                return task.execute(connection);
+                            }
+                        });
+        Mockito.when(connection.getService()).thenReturn(service);
+        Mockito.when(service.getAvailableRecordings()).thenReturn(List.of());
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> patchStop.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+    }
+
+    @Test
+    void shouldStopRecording() throws Exception {
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("fooTarget");
+        Mockito.when(ctx.pathParam("recordingName")).thenReturn("someRecording");
+        Mockito.when(ctx.response()).thenReturn(resp);
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any()))
+                .thenAnswer(
+                        new Answer<>() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                ConnectedTask task = (ConnectedTask) invocation.getArgument(1);
+                                return task.execute(connection);
+                            }
+                        });
+        Mockito.when(connection.getService()).thenReturn(service);
+        IRecordingDescriptor descriptor = Mockito.mock(IRecordingDescriptor.class);
+        Mockito.when(descriptor.getName()).thenReturn("someRecording");
+        Mockito.when(service.getAvailableRecordings()).thenReturn(List.of(descriptor));
+
+        patchStop.handle(ctx);
+
+        Mockito.verify(service).stop(descriptor);
+        InOrder inOrder = Mockito.inOrder(resp);
+        inOrder.verify(resp).setStatusCode(200);
+        inOrder.verify(resp).end();
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingUploadPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingUploadPostHandlerTest.java
@@ -1,0 +1,215 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
+import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService.RecordingNotFoundException;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TargetRecordingUploadPostHandlerTest {
+
+    TargetRecordingUploadPostHandler handler;
+    @Mock AuthManager auth;
+    @Mock Environment env;
+    @Mock TargetConnectionManager targetConnectionManager;
+    @Mock WebClient webClient;
+    @Mock FileSystem fs;
+
+    @Mock RoutingContext ctx;
+    @Mock JFRConnection conn;
+
+    static final String DATASOURCE_URL = "http://localhost:8080";
+
+    @BeforeEach
+    void setup() {
+        this.handler =
+                new TargetRecordingUploadPostHandler(
+                        auth, env, targetConnectionManager, webClient, fs);
+    }
+
+    @Test
+    void shouldHandlePOST() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(),
+                Matchers.equalTo("/api/v1/targets/:targetId/recordings/:recordingName/upload"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"notaurl", "almost:/valid", "*notok"})
+    @NullAndEmptySource
+    void shouldThrow501IfDatasourceUrlMalformed(String rawUrl) {
+        Mockito.when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        Mockito.when(env.getEnv("GRAFANA_DATASOURCE_URL")).thenReturn(rawUrl);
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(501));
+    }
+
+    @Test
+    void shouldThrowExceptionIfRecordingNotFound() throws Exception {
+        Mockito.when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.any(ConnectionDescriptor.class), Mockito.any()))
+                .thenAnswer(arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(conn));
+        IFlightRecorderService svc = Mockito.mock(IFlightRecorderService.class);
+        Mockito.when(conn.getService()).thenReturn(svc);
+        Mockito.when(svc.getAvailableRecordings()).thenReturn(Collections.emptyList());
+        Mockito.when(env.getEnv("GRAFANA_DATASOURCE_URL")).thenReturn(DATASOURCE_URL);
+
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class,
+                        () -> {
+                            handler.handle(ctx);
+                        });
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+        MatcherAssert.assertThat(
+                ex.getCause(), Matchers.instanceOf(RecordingNotFoundException.class));
+    }
+
+    @Test
+    void shouldDoUpload() throws Exception {
+        Mockito.when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.any(ConnectionDescriptor.class), Mockito.any()))
+                .thenAnswer(arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(conn));
+        IFlightRecorderService svc = Mockito.mock(IFlightRecorderService.class);
+        IRecordingDescriptor rec = Mockito.mock(IRecordingDescriptor.class);
+        InputStream stream = Mockito.mock(InputStream.class);
+        Mockito.when(conn.getService()).thenReturn(svc);
+        Mockito.when(svc.getAvailableRecordings()).thenReturn(List.of(rec));
+        Mockito.when(rec.getName()).thenReturn("foo");
+        Mockito.when(svc.openStream(Mockito.any(), Mockito.anyBoolean())).thenReturn(stream);
+        Mockito.when(env.getEnv("GRAFANA_DATASOURCE_URL")).thenReturn(DATASOURCE_URL);
+
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("fooTarget");
+        Mockito.when(ctx.pathParam("recordingName")).thenReturn("foo");
+
+        HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
+        HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
+        Mockito.when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+        Mockito.when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
+        Mockito.doAnswer(
+                        new Answer<Void>() {
+                            @Override
+                            public Void answer(InvocationOnMock args) throws Throwable {
+                                AsyncResult<HttpResponse<Buffer>> asyncResult =
+                                        Mockito.mock(AsyncResult.class);
+                                Mockito.when(asyncResult.result()).thenReturn(httpResp);
+                                Mockito.when(httpResp.statusCode()).thenReturn(200);
+                                Mockito.when(httpResp.statusMessage()).thenReturn("OK");
+                                Mockito.when(httpResp.bodyAsString()).thenReturn("HELLO");
+                                ((Handler<AsyncResult<HttpResponse<Buffer>>>) args.getArgument(1))
+                                        .handle(asyncResult);
+                                return null;
+                            }
+                        })
+                .when(httpReq)
+                .sendMultipartForm(Mockito.any(), Mockito.any());
+
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.response()).thenReturn(resp);
+
+        handler.handle(ctx);
+
+        Mockito.verify(resp).setStatusCode(200);
+        Mockito.verify(resp).setStatusMessage("OK");
+        Mockito.verify(resp).end("HELLO");
+
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(webClient).postAbs(urlCaptor.capture());
+        MatcherAssert.assertThat(
+                urlCaptor.getValue(), Matchers.equalTo(DATASOURCE_URL.concat("/load")));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingUploadPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingUploadPostHandlerTest.java
@@ -151,7 +151,7 @@ class TargetRecordingUploadPostHandlerTest {
                         () -> {
                             handler.handle(ctx);
                         });
-        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(
                 ex.getCause(), Matchers.instanceOf(RecordingNotFoundException.class));
     }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostHandlerTest.java
@@ -1,0 +1,263 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.handlers;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.openjdk.jmc.common.unit.IConstrainedMap;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.QuantityConversionException;
+import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
+import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.google.gson.Gson;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.commands.internal.EventOptionsBuilder;
+import com.redhat.rhjmc.containerjfr.commands.internal.RecordingOptionsBuilderFactory;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
+import com.redhat.rhjmc.containerjfr.net.web.WebServer;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TargetRecordingsPostHandlerTest {
+
+    TargetRecordingsPostHandler handler;
+    @Mock AuthManager auth;
+    @Mock TargetConnectionManager targetConnectionManager;
+    @Mock RecordingOptionsBuilderFactory recordingOptionsBuilderFactory;
+    @Mock EventOptionsBuilder.Factory eventOptionsBuilderFactory;
+    @Mock WebServer webServer;
+    Gson gson = MainModule.provideGson();
+
+    @Mock JFRConnection connection;
+    @Mock IFlightRecorderService service;
+    @Mock RoutingContext ctx;
+    @Mock HttpServerRequest req;
+    @Mock HttpServerResponse resp;
+
+    @BeforeEach
+    void setup() {
+        this.handler =
+                new TargetRecordingsPostHandler(
+                        auth,
+                        targetConnectionManager,
+                        recordingOptionsBuilderFactory,
+                        eventOptionsBuilderFactory,
+                        () -> webServer,
+                        gson);
+    }
+
+    @Test
+    void shouldHandlePOST() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(
+                handler.path(), Matchers.equalTo("/api/v1/targets/:targetId/recordings"));
+    }
+
+    @Test
+    void shouldStartRecording() throws Exception {
+        Mockito.when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any()))
+                .thenAnswer(
+                        arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(connection));
+        Mockito.when(connection.getService()).thenReturn(service);
+        IConstrainedMap<String> recordingOptions = Mockito.mock(IConstrainedMap.class);
+        RecordingOptionsBuilder recordingOptionsBuilder =
+                Mockito.mock(RecordingOptionsBuilder.class);
+        Mockito.when(recordingOptionsBuilderFactory.create(Mockito.any()))
+                .thenReturn(recordingOptionsBuilder);
+        Mockito.when(recordingOptionsBuilder.name(Mockito.any()))
+                .thenReturn(recordingOptionsBuilder);
+        Mockito.when(recordingOptionsBuilder.duration(Mockito.anyLong()))
+                .thenReturn(recordingOptionsBuilder);
+        Mockito.when(recordingOptionsBuilder.build()).thenReturn(recordingOptions);
+        EventOptionsBuilder builder = Mockito.mock(EventOptionsBuilder.class);
+        Mockito.when(eventOptionsBuilderFactory.create(Mockito.any())).thenReturn(builder);
+        IConstrainedMap<EventOptionID> events = Mockito.mock(IConstrainedMap.class);
+        Mockito.when(builder.build()).thenReturn(events);
+
+        Mockito.when(
+                        webServer.getDownloadURL(
+                                Mockito.any(JFRConnection.class), Mockito.anyString()))
+                .thenReturn("example-download-url");
+        Mockito.when(webServer.getReportURL(Mockito.any(JFRConnection.class), Mockito.anyString()))
+                .thenReturn("example-report-url");
+
+        IRecordingDescriptor descriptor = createDescriptor("someRecording");
+        Mockito.when(service.start(Mockito.any(), Mockito.any())).thenReturn(descriptor);
+        Mockito.when(service.getAvailableRecordings())
+                .thenReturn(Collections.emptyList())
+                .thenReturn(List.of(descriptor));
+
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("fooHost:9091");
+        MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.formAttributes()).thenReturn(attrs);
+        attrs.add("recordingName", "someRecording");
+        attrs.add("events", "foo.Bar:enabled=true");
+        attrs.add("duration", "10");
+        Mockito.when(ctx.response()).thenReturn(resp);
+
+        handler.handle(ctx);
+
+        Mockito.verify(resp).setStatusCode(201);
+        Mockito.verify(resp).putHeader(HttpHeaders.LOCATION, "/someRecording");
+        Mockito.verify(resp).putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        Mockito.verify(resp)
+                .end(
+                        "{\"downloadUrl\":\"example-download-url\",\"reportUrl\":\"example-report-url\",\"id\":1,\"name\":\"someRecording\",\"state\":\"STOPPED\",\"startTime\":0,\"duration\":0,\"continuous\":false,\"toDisk\":false,\"maxSize\":0,\"maxAge\":0}");
+
+        ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<IConstrainedMap<String>> recordingOptionsCaptor =
+                ArgumentCaptor.forClass(IConstrainedMap.class);
+        ArgumentCaptor<IConstrainedMap<EventOptionID>> eventsCaptor =
+                ArgumentCaptor.forClass(IConstrainedMap.class);
+        Mockito.verify(recordingOptionsBuilder).name(nameCaptor.capture());
+        Mockito.verify(service, Mockito.atLeastOnce()).getAvailableRecordings();
+        Mockito.verify(service).start(recordingOptionsCaptor.capture(), eventsCaptor.capture());
+
+        String actualName = nameCaptor.getValue();
+        IConstrainedMap<String> actualRecordingOptions = recordingOptionsCaptor.getValue();
+        IConstrainedMap<EventOptionID> actualEvents = eventsCaptor.getValue();
+
+        MatcherAssert.assertThat(actualName, Matchers.equalTo("someRecording"));
+        MatcherAssert.assertThat(actualEvents, Matchers.sameInstance(events));
+        MatcherAssert.assertThat(actualRecordingOptions, Matchers.sameInstance(recordingOptions));
+        ArgumentCaptor<String> eventCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> optionCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> valueCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(builder)
+                .addEvent(eventCaptor.capture(), optionCaptor.capture(), valueCaptor.capture());
+        Mockito.verify(builder).build();
+
+        MatcherAssert.assertThat(eventCaptor.getValue(), Matchers.equalTo("foo.Bar"));
+        MatcherAssert.assertThat(optionCaptor.getValue(), Matchers.equalTo("enabled"));
+        MatcherAssert.assertThat(valueCaptor.getValue(), Matchers.equalTo("true"));
+    }
+
+    @Test
+    void shouldHandleNameCollision() throws Exception {
+        Mockito.when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        IRecordingDescriptor existingRecording = createDescriptor("someRecording");
+
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.anyString(), Mockito.any()))
+                .thenAnswer(
+                        arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(connection));
+        Mockito.when(connection.getService()).thenReturn(service);
+        Mockito.when(service.getAvailableRecordings()).thenReturn(Arrays.asList(existingRecording));
+
+        Mockito.when(ctx.pathParam("targetId")).thenReturn("fooHost:9091");
+        MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.formAttributes()).thenReturn(attrs);
+        attrs.add("recordingName", "someRecording");
+        attrs.add("events", "foo.Bar:enabled=true");
+
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+
+        Mockito.verify(service).getAvailableRecordings();
+    }
+
+    @Test
+    void shouldHandleException() throws Exception {
+        HttpStatusException ex =
+                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    private static IRecordingDescriptor createDescriptor(String name)
+            throws QuantityConversionException {
+        IQuantity zeroQuantity = Mockito.mock(IQuantity.class);
+        IRecordingDescriptor descriptor = Mockito.mock(IRecordingDescriptor.class);
+        Mockito.lenient().when(descriptor.getId()).thenReturn(1L);
+        Mockito.lenient().when(descriptor.getName()).thenReturn(name);
+        Mockito.lenient()
+                .when(descriptor.getState())
+                .thenReturn(IRecordingDescriptor.RecordingState.STOPPED);
+        Mockito.lenient().when(descriptor.getStartTime()).thenReturn(zeroQuantity);
+        Mockito.lenient().when(descriptor.getDuration()).thenReturn(zeroQuantity);
+        Mockito.lenient().when(descriptor.isContinuous()).thenReturn(false);
+        Mockito.lenient().when(descriptor.getToDisk()).thenReturn(false);
+        Mockito.lenient().when(descriptor.getMaxSize()).thenReturn(zeroQuantity);
+        Mockito.lenient().when(descriptor.getMaxAge()).thenReturn(zeroQuantity);
+        return descriptor;
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostHandlerTest.java
@@ -128,9 +128,7 @@ class TargetRecordingsPostHandlerTest {
     void shouldStartRecording() throws Exception {
         Mockito.when(auth.validateHttpHeader(Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
-        Mockito.when(
-                        targetConnectionManager.executeConnectedTask(
-                                Mockito.anyString(), Mockito.any()))
+        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
                 .thenAnswer(
                         arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(connection));
         Mockito.when(connection.getService()).thenReturn(service);
@@ -214,9 +212,7 @@ class TargetRecordingsPostHandlerTest {
                 .thenReturn(CompletableFuture.completedFuture(true));
         IRecordingDescriptor existingRecording = createDescriptor("someRecording");
 
-        Mockito.when(
-                        targetConnectionManager.executeConnectedTask(
-                                Mockito.anyString(), Mockito.any()))
+        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
                 .thenAnswer(
                         arg0 -> ((ConnectedTask<Object>) arg0.getArgument(1)).execute(connection));
         Mockito.when(connection.getService()).thenReturn(service);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostHandlerTest.java
@@ -70,6 +70,7 @@ import com.google.gson.Gson;
 import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.commands.internal.EventOptionsBuilder;
 import com.redhat.rhjmc.containerjfr.commands.internal.RecordingOptionsBuilderFactory;
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
@@ -93,7 +94,8 @@ class TargetRecordingsPostHandlerTest {
     @Mock RecordingOptionsBuilderFactory recordingOptionsBuilderFactory;
     @Mock EventOptionsBuilder.Factory eventOptionsBuilderFactory;
     @Mock WebServer webServer;
-    Gson gson = MainModule.provideGson();
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
 
     @Mock JFRConnection connection;
     @Mock IFlightRecorderService service;

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandlerTest.java
@@ -109,7 +109,7 @@ class TargetReportGetHandlerTest {
         String targetId = "fooHost:0";
         String recordingName = "foo";
         String content = "foobar";
-        when(reportService.get(Mockito.anyString(), Mockito.anyString())).thenReturn(content);
+        when(reportService.get(Mockito.any(), Mockito.anyString())).thenReturn(content);
 
         Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
         Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
@@ -131,7 +131,7 @@ class TargetReportGetHandlerTest {
         HttpServerResponse resp = mock(HttpServerResponse.class);
         when(ctx.response()).thenReturn(resp);
 
-        when(reportService.get(Mockito.anyString(), Mockito.anyString()))
+        when(reportService.get(Mockito.any(), Mockito.anyString()))
                 .thenThrow(new RecordingNotFoundException("fooHost:0", "someRecording"));
 
         when(ctx.pathParam("targetId")).thenReturn("fooHost:0");

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandlerTest.java
@@ -57,7 +57,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 
 import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.templates.TemplateService;
 import com.redhat.rhjmc.containerjfr.core.templates.TemplateType;
@@ -79,13 +78,12 @@ class TargetTemplateGetHandlerTest {
     TargetTemplateGetHandler handler;
     @Mock AuthManager auth;
     @Mock TargetConnectionManager targetConnectionManager;
-    @Mock Logger logger;
     @Mock JFRConnection conn;
     @Mock TemplateService templateService;
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetTemplateGetHandler(auth, targetConnectionManager, logger);
+        this.handler = new TargetTemplateGetHandler(auth, targetConnectionManager);
     }
 
     @Test
@@ -113,10 +111,8 @@ class TargetTemplateGetHandlerTest {
                                 Mockito.any(ConnectionDescriptor.class), Mockito.any()))
                 .thenThrow(FlightRecorderException.class);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(
-                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
-        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+        Assertions.assertThrows(
+                FlightRecorderException.class, () -> handler.handleAuthenticated(ctx));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplateDeleteHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplateDeleteHandlerTest.java
@@ -59,7 +59,6 @@ import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 @ExtendWith(MockitoExtension.class)
 class TemplateDeleteHandlerTest {
@@ -90,10 +89,7 @@ class TemplateDeleteHandlerTest {
         Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
         Mockito.doThrow(IOException.class).when(templateService).deleteTemplate("FooTemplate");
 
-        HttpStatusException ex =
-                Assertions.assertThrows(
-                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
-        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+        Assertions.assertThrows(IOException.class, () -> handler.handleAuthenticated(ctx));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TemplatesPostHandlerTest.java
@@ -104,10 +104,7 @@ class TemplatesPostHandlerTest {
 
         Mockito.when(fs.newInputStream(Mockito.any())).thenThrow(IOException.class);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(
-                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
-        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+        Assertions.assertThrows(IOException.class, () -> handler.handleAuthenticated(ctx));
     }
 
     @Test


### PR DESCRIPTION
This series of commits brings the HTTP REST API up to feature parity with the WebSocket Command Channel - that is, anything (recording-related, anyway - there is no equivalent for `help`, `hostname`, etc.) that can be accomplished using a Command can now also be accomplished using an HTTP request. The immediate benefit here is in the easier extensibility of HTTP requests with various headers, which will be used in a follow-up PR (#225) to enable JMX authentication credentials. All commands that operate upon a specific target have been marked deprecated as they are not planned to gain JMX authentication support. When any such command is run the registry will log a warning to indicate this.

TODO as followups:
- create a document outlining the HTTP REST API, similar to the current COMMANDS.md
- update -web and -operator to send these requests whenever applicable, rather than using command channel

Requires:
https://github.com/rh-jmc-team/container-jfr-core/pull/45