### PR TITLE
Add Checks for `upload-recording` ResponseMessage

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -41,6 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.commands.internal;
 
+import static com.redhat.rhjmc.containerjfr.util.HttpStatusCodeIdentifier.isSuccessCode;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -114,7 +116,9 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
         String datasourceUrl = env.getEnv(GRAFANA_DATASOURCE_ENV).concat("/load");
         ResponseMessage response = doPost(targetId, recordingName, datasourceUrl);
 
-        if (response.statusCode != 200 || response.statusMessage == null || response.body == null) {
+        if (!isSuccessCode(response.statusCode)
+                || response.statusMessage == null
+                || response.body == null) {
             cw.println(
                     String.format(
                             "Invalid response from server; datasource URL may be incorrect, or server may not be functioning properly: status=\"%d %s\"; body=\"%s\"",
@@ -136,7 +140,7 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
         try {
             ResponseMessage response = doPost(targetId, recordingName, datasourceUrl);
 
-            if (response.statusCode != 200
+            if (!isSuccessCode(response.statusCode)
                     || response.statusMessage == null
                     || response.body == null) {
                 return new FailureOutput(

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/UploadRecordingCommand.java
@@ -113,6 +113,15 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
         String recordingName = args[1];
         String datasourceUrl = env.getEnv(GRAFANA_DATASOURCE_ENV).concat("/load");
         ResponseMessage response = doPost(targetId, recordingName, datasourceUrl);
+
+        if (response.statusCode != 200 || response.statusMessage == null || response.body == null) {
+            cw.println(
+                    String.format(
+                            "Invalid response from server; datasource URL may be incorrect, or server may not be functioning properly: status=\"%d %s\"; body=\"%s\"",
+                            response.statusCode, response.statusMessage, response.body));
+            return;
+        }
+
         cw.println(
                 String.format(
                         "[%d %s] %s", response.statusCode, response.statusMessage, response.body));
@@ -126,6 +135,16 @@ class UploadRecordingCommand extends AbstractConnectedCommand implements Seriali
 
         try {
             ResponseMessage response = doPost(targetId, recordingName, datasourceUrl);
+
+            if (response.statusCode != 200
+                    || response.statusMessage == null
+                    || response.body == null) {
+                return new FailureOutput(
+                        String.format(
+                                "Invalid response from server; datasource URL may be incorrect, or server may not be functioning properly: status=\"%d %s\"; body=\"%s\"",
+                                response.statusCode, response.statusMessage, response.body));
+            }
+
             return new MapOutput<>(
                     Map.of(
                             "status",

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -41,6 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web;
 
+import static com.redhat.rhjmc.containerjfr.util.HttpStatusCodeIdentifier.isServerErrorCode;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -121,7 +123,7 @@ public class WebServer {
                         exception = new HttpStatusException(500, ctx.failure());
                     }
 
-                    if (exception.getStatusCode() < 500) {
+                    if (!isServerErrorCode(exception.getStatusCode())) {
                         logger.warn(exception);
                     } else {
                         logger.error(exception);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/util/HttpStatusCodeIdentifier.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/util/HttpStatusCodeIdentifier.java
@@ -1,0 +1,67 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.util;
+
+public final class HttpStatusCodeIdentifier {
+
+    private HttpStatusCodeIdentifier() {}
+
+    public static boolean isInformationCode(int code) {
+        return 100 <= code && code < 200;
+    }
+
+    public static boolean isSuccessCode(int code) {
+        return 200 <= code && code < 300;
+    }
+
+    public static boolean isRedirectCode(int code) {
+        return 300 <= code && code < 400;
+    }
+
+    public static boolean isClientErrorCode(int code) {
+        return 400 <= code && code < 500;
+    }
+
+    public static boolean isServerErrorCode(int code) {
+        return 500 <= code && code < 600;
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/util/HttpStatusCodeIdentifierTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/util/HttpStatusCodeIdentifierTest.java
@@ -1,0 +1,110 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+
+package com.redhat.rhjmc.containerjfr.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class HttpStatusCodeIdentifierTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {100, 150, 199})
+    void shouldIdentifyInformationCodes(int code) {
+        Assertions.assertTrue(HttpStatusCodeIdentifier.isInformationCode(code));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0, 99, 200})
+    void shouldIdentifyNonInformationCodes(int code) {
+        Assertions.assertFalse(HttpStatusCodeIdentifier.isInformationCode(code));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {200, 250, 299})
+    void shouldIdentifySuccessCodes(int code) {
+        Assertions.assertTrue(HttpStatusCodeIdentifier.isSuccessCode(code));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0, 199, 300})
+    void shouldIdentifyNonSuccessCodes(int code) {
+        Assertions.assertFalse(HttpStatusCodeIdentifier.isSuccessCode(code));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {300, 350, 399})
+    void shouldIdentifyRedirectCodes(int code) {
+        Assertions.assertTrue(HttpStatusCodeIdentifier.isRedirectCode(code));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0, 299, 400})
+    void shouldIdentifyNonRedirectCodes(int code) {
+        Assertions.assertFalse(HttpStatusCodeIdentifier.isRedirectCode(code));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {400, 450, 499})
+    void shouldIdentifyClientErrorCodes(int code) {
+        Assertions.assertTrue(HttpStatusCodeIdentifier.isClientErrorCode(code));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0, 399, 500})
+    void shouldIdentifyNonClientErrorCodes(int code) {
+        Assertions.assertFalse(HttpStatusCodeIdentifier.isClientErrorCode(code));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {500, 550, 599})
+    void shouldIdentifyServerErrorCodes(int code) {
+        Assertions.assertTrue(HttpStatusCodeIdentifier.isServerErrorCode(code));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0, 499, 600})
+    void shouldIdentifyNonServerErrorCodes(int code) {
+        Assertions.assertFalse(HttpStatusCodeIdentifier.isServerErrorCode(code));
+    }
+}


### PR DESCRIPTION
Fixes #218.

This PR adds a check to make sure that the HTTP response's status code is `200` and that its status message and body are not `null`. If the `200` requirement is too strict, we could also change it to `200 <= x < 300`.

In addition to fixing the NPE issue, because of the status code check, `upload-recording` now also correctly identifies many invalid uploads to existing but non-jfr-datasource servers, such as `http://google.com`, which previously would have just returned a standard `MapResponse`.

With the datasource URL pointing to the running CJFR instance, the response from an `upload-recording` call now looks like this:

`{"id":null,"commandName":"upload-recording","status":-2,"payload":"Invalid response from server; datasource URL may be incorrect, or server may not be functioning properly: status=\"405 Method Not Allowed\"; body=\"null\""}`

The test code is just copied from the `shouldDoPost()` tests. In the serialized `shoudDoPost()`, I moved the `urlCaptor` part to before the response checking part so it's a bit more chronological. The diff looks a little weird because of it.