### PR TITLE
RJMX authorization via HTTP header

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/HttpServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/HttpServer.java
@@ -78,7 +78,7 @@ public class HttpServer {
                         sslConf.applyToHttpServerOptions(
                                 new HttpServerOptions()
                                         .setPort(netConf.getInternalWebServerPort())
-                                        .setWebsocketSubProtocols("*")
+                                        .addWebSocketSubProtocol("*")
                                         .setCompressionSupported(true)
                                         .setLogActivity(true)));
 
@@ -95,7 +95,7 @@ public class HttpServer {
         CompletableFuture<Void> future = new CompletableFuture<>();
         this.server
                 .requestHandler(requestHandlerDelegate)
-                .websocketHandler(websocketHandlerDelegate)
+                .webSocketHandler(websocketHandlerDelegate)
                 .listen(
                         res -> {
                             if (res.failed()) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
@@ -109,10 +109,14 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
                 if (!"basic".equals(t.toLowerCase())) {
                     throw new HttpStatusException(400, "Unacceptable PROXY_AUTHORIZATION type");
                 } else {
-                    String c =
-                            new String(
-                                    Base64.getDecoder().decode(m.group("credentials")),
-                                    StandardCharsets.UTF_8);
+                    String c;
+                    try {
+                        c = new String(
+                                Base64.getDecoder().decode(m.group("credentials")),
+                                StandardCharsets.UTF_8);
+                    } catch (IllegalArgumentException iae) {
+                        throw new HttpStatusException(400, "PROXY_AUTHORIZATION credentials do not appear to be Base64-encoded", iae);
+                    }
                     if (!c.contains(":")) {
                         throw new HttpStatusException(
                                 400, "Unrecognized PROXY_AUTHORIZATION credential format");

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
@@ -111,11 +111,15 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
                 } else {
                     String c;
                     try {
-                        c = new String(
-                                Base64.getDecoder().decode(m.group("credentials")),
-                                StandardCharsets.UTF_8);
+                        c =
+                                new String(
+                                        Base64.getDecoder().decode(m.group("credentials")),
+                                        StandardCharsets.UTF_8);
                     } catch (IllegalArgumentException iae) {
-                        throw new HttpStatusException(400, "PROXY_AUTHORIZATION credentials do not appear to be Base64-encoded", iae);
+                        throw new HttpStatusException(
+                                400,
+                                "PROXY_AUTHORIZATION credentials do not appear to be Base64-encoded",
+                                iae);
                     }
                     String[] parts = c.split(":");
                     if (parts.length != 2) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
@@ -117,17 +117,12 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
                     } catch (IllegalArgumentException iae) {
                         throw new HttpStatusException(400, "PROXY_AUTHORIZATION credentials do not appear to be Base64-encoded", iae);
                     }
-                    if (!c.contains(":")) {
+                    String[] parts = c.split(":");
+                    if (parts.length != 2) {
                         throw new HttpStatusException(
                                 400, "Unrecognized PROXY_AUTHORIZATION credential format");
-                    } else {
-                        String[] parts = c.split(":");
-                        if (parts.length != 2) {
-                            throw new HttpStatusException(
-                                    400, "Unrecognized PROXY_AUTHORIZATION credential format");
-                        }
-                        credentials = new Credentials(parts[0], parts[1]);
                     }
+                    credentials = new Credentials(parts[0], parts[1]);
                 }
             }
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
@@ -118,6 +118,10 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
                                 400, "Unrecognized PROXY_AUTHORIZATION credential format");
                     } else {
                         String[] parts = c.split(":");
+                        if (parts.length != 2) {
+                            throw new HttpStatusException(
+                                    400, "Unrecognized PROXY_AUTHORIZATION credential format");
+                        }
                         credentials = new Credentials(parts[0], parts[1]);
                     }
                 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandlerTest.java
@@ -41,7 +41,6 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.CompletableFuture;
@@ -54,14 +53,13 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 import org.openjdk.jmc.rjmx.ConnectionException;
 
-import com.redhat.rhjmc.containerjfr.core.net.Credentials;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 
@@ -191,70 +189,81 @@ class AbstractAuthenticatedRequestHandlerTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = {
-            "",
-            "credentialsWithoutAuthType",
-        })
+        @ValueSource(
+                strings = {
+                    "",
+                    "credentialsWithoutAuthType",
+                })
         void shouldThrow400WithMalformedAuthorizationHeader(String authHeader) {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
             Mockito.when(headers.contains(HttpHeaders.PROXY_AUTHORIZATION)).thenReturn(true);
             Mockito.when(req.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).thenReturn(authHeader);
 
-            HttpStatusException ex = Assertions.assertThrows(HttpStatusException.class, () ->
-                    handler.handle(ctx));
+            HttpStatusException ex =
+                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
-            MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("Invalid PROXY_AUTHORIZATION format"));
+            MatcherAssert.assertThat(
+                    ex.getPayload(), Matchers.equalTo("Invalid PROXY_AUTHORIZATION format"));
         }
 
         @ParameterizedTest
-        @ValueSource(strings = {
-            "Type credentials",
-            "Bearer credentials",
-        })
+        @ValueSource(
+                strings = {
+                    "Type credentials",
+                    "Bearer credentials",
+                })
         void shouldThrow400WithBadAuthorizationType(String authHeader) {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
             Mockito.when(headers.contains(HttpHeaders.PROXY_AUTHORIZATION)).thenReturn(true);
             Mockito.when(req.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).thenReturn(authHeader);
 
-            HttpStatusException ex = Assertions.assertThrows(HttpStatusException.class, () ->
-                    handler.handle(ctx));
+            HttpStatusException ex =
+                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
-            MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("Unacceptable PROXY_AUTHORIZATION type"));
+            MatcherAssert.assertThat(
+                    ex.getPayload(), Matchers.equalTo("Unacceptable PROXY_AUTHORIZATION type"));
         }
 
         @ParameterizedTest
-        @ValueSource(strings = {
-            "Basic bm9zZXBhcmF0b3I=", // credential value of "noseparator"
-            "Basic b25lOnR3bzp0aHJlZQ==", // credential value of "one:two:three"
-        })
+        @ValueSource(
+                strings = {
+                    "Basic bm9zZXBhcmF0b3I=", // credential value of "noseparator"
+                    "Basic b25lOnR3bzp0aHJlZQ==", // credential value of "one:two:three"
+                })
         void shouldThrow400WithBadCredentialFormat(String authHeader) {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
             Mockito.when(headers.contains(HttpHeaders.PROXY_AUTHORIZATION)).thenReturn(true);
             Mockito.when(req.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).thenReturn(authHeader);
 
-            HttpStatusException ex = Assertions.assertThrows(HttpStatusException.class, () ->
-                    handler.handle(ctx));
+            HttpStatusException ex =
+                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
-            MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("Unrecognized PROXY_AUTHORIZATION credential format"));
+            MatcherAssert.assertThat(
+                    ex.getPayload(),
+                    Matchers.equalTo("Unrecognized PROXY_AUTHORIZATION credential format"));
         }
 
         @ParameterizedTest
-        @ValueSource(strings = {
-            "Basic foo:bar",
-        })
+        @ValueSource(
+                strings = {
+                    "Basic foo:bar",
+                })
         void shouldThrow400WithUnencodedCredentials(String authHeader) {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
             Mockito.when(headers.contains(HttpHeaders.PROXY_AUTHORIZATION)).thenReturn(true);
             Mockito.when(req.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).thenReturn(authHeader);
 
-            HttpStatusException ex = Assertions.assertThrows(HttpStatusException.class, () ->
-                    handler.handle(ctx));
+            HttpStatusException ex =
+                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
-            MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("PROXY_AUTHORIZATION credentials do not appear to be Base64-encoded"));
+            MatcherAssert.assertThat(
+                    ex.getPayload(),
+                    Matchers.equalTo(
+                            "PROXY_AUTHORIZATION credentials do not appear to be Base64-encoded"));
         }
 
         @Test
@@ -262,7 +271,8 @@ class AbstractAuthenticatedRequestHandlerTest {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
             Mockito.when(headers.contains(HttpHeaders.PROXY_AUTHORIZATION)).thenReturn(true);
-            Mockito.when(req.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).thenReturn("Basic Zm9vOmJhcg==");
+            Mockito.when(req.getHeader(HttpHeaders.PROXY_AUTHORIZATION))
+                    .thenReturn("Basic Zm9vOmJhcg==");
 
             Assertions.assertDoesNotThrow(() -> handler.handle(ctx));
             ConnectionDescriptor desc = handler.desc;
@@ -270,7 +280,6 @@ class AbstractAuthenticatedRequestHandlerTest {
             MatcherAssert.assertThat(desc.getTargetId(), Matchers.equalTo(targetId));
             Assertions.assertTrue(desc.getCredentials().isPresent());
         }
-
     }
 
     static class AuthenticatedHandler extends AbstractAuthenticatedRequestHandler {

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetEventsGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetEventsGetHandlerTest.java
@@ -73,7 +73,9 @@ import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 
+import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 
@@ -106,11 +108,15 @@ class TargetEventsGetHandlerTest {
     void shouldRespondWithErrorIfExceptionThrown() throws Exception {
         Mockito.when(
                         connectionManager.executeConnectedTask(
-                                Mockito.any(ConnectionDescriptor.class), Mockito.any()))
+                                Mockito.any(ConnectionDescriptor.class),
+                                Mockito.any(ConnectedTask.class)))
                 .thenThrow(new Exception("dummy exception"));
 
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
         Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
 
         Assertions.assertThrows(Exception.class, () -> handler.handleAuthenticated(ctx));
     }
@@ -152,6 +158,9 @@ class TargetEventsGetHandlerTest {
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
         Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
 
         handler.handleAuthenticated(ctx);
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetEventsGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetEventsGetHandlerTest.java
@@ -73,7 +73,7 @@ import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 
-import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -116,7 +116,7 @@ class TargetEventsGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.when(ctx.request()).thenReturn(req);
-        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         Assertions.assertThrows(Exception.class, () -> handler.handleAuthenticated(ctx));
     }
@@ -160,7 +160,7 @@ class TargetEventsGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.when(ctx.request()).thenReturn(req);
-        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         handler.handleAuthenticated(ctx);
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingDeleteHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingDeleteHandlerTest.java
@@ -68,7 +68,9 @@ import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService;
 
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
@@ -82,6 +84,7 @@ class TargetRecordingDeleteHandlerTest {
     @Mock ReportService reportService;
 
     @Mock RoutingContext ctx;
+    @Mock HttpServerRequest req;
     @Mock HttpServerResponse resp;
     @Mock JFRConnection connection;
     @Mock IFlightRecorderService service;
@@ -108,7 +111,9 @@ class TargetRecordingDeleteHandlerTest {
     void shouldDeleteRecording() throws Exception {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("fooTarget");
         Mockito.when(ctx.pathParam("recordingName")).thenReturn("someRecording");
+        Mockito.when(ctx.request()).thenReturn(req);
         Mockito.when(ctx.response()).thenReturn(resp);
+        Mockito.when(ctx.request().headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
                 .thenAnswer(
                         new Answer() {
@@ -141,6 +146,8 @@ class TargetRecordingDeleteHandlerTest {
 
     @Test
     void shouldHandleRecordingNotFound() throws Exception {
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(ctx.request().headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(ctx.pathParam("targetId")).thenReturn("fooTarget");
         Mockito.when(ctx.pathParam("recordingName")).thenReturn("someRecording");
         Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandlerTest.java
@@ -74,6 +74,7 @@ import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
@@ -130,6 +131,7 @@ class TargetRecordingGetHandlerTest {
         when(ctx.response()).thenReturn(resp);
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
+        when(ctx.request().headers()).thenReturn(new CaseInsensitiveHeaders());
 
         byte[] src = new byte[1024 * 1024];
         new Random(123456).nextBytes(src);
@@ -175,6 +177,7 @@ class TargetRecordingGetHandlerTest {
         when(ctx.response()).thenReturn(resp);
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
+        when(ctx.request().headers()).thenReturn(new CaseInsensitiveHeaders());
 
         byte[] src = new byte[1024 * 1024];
         new Random(123456).nextBytes(src);
@@ -212,6 +215,7 @@ class TargetRecordingGetHandlerTest {
         RoutingContext ctx = mock(RoutingContext.class);
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
+        when(ctx.request().headers()).thenReturn(new CaseInsensitiveHeaders());
 
         when(targetConnectionManager.connect(Mockito.any(ConnectionDescriptor.class)))
                 .thenReturn(connection);
@@ -227,13 +231,14 @@ class TargetRecordingGetHandlerTest {
     }
 
     @Test
-    void shouldResponse500IfUnexpectedExceptionThrown() throws Exception {
+    void shouldRespond500IfUnexpectedExceptionThrown() throws Exception {
         when(authManager.validateHttpHeader(Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
 
         RoutingContext ctx = mock(RoutingContext.class);
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
+        when(ctx.request().headers()).thenReturn(new CaseInsensitiveHeaders());
 
         when(targetConnectionManager.connect(Mockito.any(ConnectionDescriptor.class)))
                 .thenReturn(connection);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingGetHandlerTest.java
@@ -73,8 +73,8 @@ import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
@@ -131,7 +131,7 @@ class TargetRecordingGetHandlerTest {
         when(ctx.response()).thenReturn(resp);
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
-        when(ctx.request().headers()).thenReturn(new CaseInsensitiveHeaders());
+        when(ctx.request().headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         byte[] src = new byte[1024 * 1024];
         new Random(123456).nextBytes(src);
@@ -177,7 +177,7 @@ class TargetRecordingGetHandlerTest {
         when(ctx.response()).thenReturn(resp);
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
-        when(ctx.request().headers()).thenReturn(new CaseInsensitiveHeaders());
+        when(ctx.request().headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         byte[] src = new byte[1024 * 1024];
         new Random(123456).nextBytes(src);
@@ -215,7 +215,7 @@ class TargetRecordingGetHandlerTest {
         RoutingContext ctx = mock(RoutingContext.class);
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
-        when(ctx.request().headers()).thenReturn(new CaseInsensitiveHeaders());
+        when(ctx.request().headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         when(targetConnectionManager.connect(Mockito.any(ConnectionDescriptor.class)))
                 .thenReturn(connection);
@@ -238,7 +238,7 @@ class TargetRecordingGetHandlerTest {
         RoutingContext ctx = mock(RoutingContext.class);
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
-        when(ctx.request().headers()).thenReturn(new CaseInsensitiveHeaders());
+        when(ctx.request().headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         when(targetConnectionManager.connect(Mockito.any(ConnectionDescriptor.class)))
                 .thenReturn(connection);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingPatchHandlerTest.java
@@ -59,7 +59,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 
@@ -71,6 +73,7 @@ class TargetRecordingPatchHandlerTest {
     @Mock TargetRecordingPatchSave patchSave;
     @Mock TargetRecordingPatchStop patchStop;
     @Mock RoutingContext ctx;
+    @Mock HttpServerRequest req;
     @Mock ConnectionDescriptor connectionDescriptor;
 
     @BeforeEach
@@ -124,6 +127,8 @@ class TargetRecordingPatchHandlerTest {
     void shouldDelegateSupportedOperations(String mtd) throws Exception {
         Mockito.when(authManager.validateHttpHeader(Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(ctx.getBodyAsString()).thenReturn(mtd);
 
         handler.handle(ctx);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingUploadPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingUploadPostHandlerTest.java
@@ -76,8 +76,10 @@ import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService.Recordin
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpRequest;
@@ -96,6 +98,8 @@ class TargetRecordingUploadPostHandlerTest {
     @Mock FileSystem fs;
 
     @Mock RoutingContext ctx;
+    @Mock HttpServerRequest req;
+    @Mock HttpServerResponse resp;
     @Mock JFRConnection conn;
 
     static final String DATASOURCE_URL = "http://localhost:8080";
@@ -134,6 +138,8 @@ class TargetRecordingUploadPostHandlerTest {
 
     @Test
     void shouldThrowExceptionIfRecordingNotFound() throws Exception {
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(auth.validateHttpHeader(Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
         Mockito.when(
@@ -198,7 +204,8 @@ class TargetRecordingUploadPostHandlerTest {
                 .when(httpReq)
                 .sendMultipartForm(Mockito.any(), Mockito.any());
 
-        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(ctx.response()).thenReturn(resp);
 
         handler.handle(ctx);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsGetHandlerTest.java
@@ -75,7 +75,7 @@ import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 import com.redhat.rhjmc.containerjfr.net.web.WebServer;
 
-import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -119,7 +119,7 @@ class TargetRecordingsGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.when(ctx.request()).thenReturn(req);
-        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         Assertions.assertThrows(Exception.class, () -> handler.handleAuthenticated(ctx));
     }
@@ -173,7 +173,7 @@ class TargetRecordingsGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.when(ctx.request()).thenReturn(req);
-        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         handler.handleAuthenticated(ctx);
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsGetHandlerTest.java
@@ -75,7 +75,9 @@ import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 import com.redhat.rhjmc.containerjfr.net.web.WebServer;
 
+import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 
@@ -115,6 +117,9 @@ class TargetRecordingsGetHandlerTest {
 
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
         Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
 
         Assertions.assertThrows(Exception.class, () -> handler.handleAuthenticated(ctx));
     }
@@ -166,6 +171,9 @@ class TargetRecordingsGetHandlerTest {
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
         Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
 
         handler.handleAuthenticated(ctx);
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingsPostHandlerTest.java
@@ -165,6 +165,7 @@ class TargetRecordingsPostHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("fooHost:9091");
         MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
         Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(req.formAttributes()).thenReturn(attrs);
         attrs.add("recordingName", "someRecording");
         attrs.add("events", "foo.Bar:enabled=true");
@@ -223,6 +224,7 @@ class TargetRecordingsPostHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("fooHost:9091");
         MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
         Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(req.formAttributes()).thenReturn(attrs);
         attrs.add("recordingName", "someRecording");
         attrs.add("events", "foo.Bar:enabled=true");

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetReportGetHandlerTest.java
@@ -63,6 +63,7 @@ import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService;
 import com.redhat.rhjmc.containerjfr.net.internal.reports.ReportService.RecordingNotFoundException;
 import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
@@ -103,6 +104,7 @@ class TargetReportGetHandlerTest {
         RoutingContext ctx = mock(RoutingContext.class);
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
+        when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         HttpServerResponse resp = mock(HttpServerResponse.class);
         when(ctx.response()).thenReturn(resp);
 
@@ -128,6 +130,7 @@ class TargetReportGetHandlerTest {
         RoutingContext ctx = mock(RoutingContext.class);
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
+        when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         HttpServerResponse resp = mock(HttpServerResponse.class);
         when(ctx.response()).thenReturn(resp);
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetSnapshotPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetSnapshotPostHandlerTest.java
@@ -64,6 +64,8 @@ import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 
@@ -88,6 +90,9 @@ class TargetSnapshotPostHandlerTest {
                 .thenReturn(CompletableFuture.completedFuture(true));
 
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
         Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(ctx.pathParam("targetId")).thenReturn("someHost");

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandlerTest.java
@@ -66,8 +66,10 @@ import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
+import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
@@ -105,6 +107,9 @@ class TargetTemplateGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("localhost");
         Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
         Mockito.when(ctx.pathParam("templateType")).thenReturn("CUSTOM");
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
 
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
@@ -121,6 +126,9 @@ class TargetTemplateGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("localhost");
         Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
         Mockito.when(ctx.pathParam("templateType")).thenReturn("TARGET");
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
 
         Mockito.when(conn.getTemplateService()).thenReturn(templateService);
         Mockito.when(templateService.getXml("FooTemplate", TemplateType.TARGET))
@@ -151,6 +159,9 @@ class TargetTemplateGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("localhost");
         Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
         Mockito.when(ctx.pathParam("templateType")).thenReturn("CUSTOM");
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
 
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
         Mockito.when(ctx.response()).thenReturn(resp);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplateGetHandlerTest.java
@@ -66,7 +66,7 @@ import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 import com.redhat.rhjmc.containerjfr.net.web.HttpMimeType;
 
-import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
@@ -109,7 +109,7 @@ class TargetTemplateGetHandlerTest {
         Mockito.when(ctx.pathParam("templateType")).thenReturn("CUSTOM");
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.when(ctx.request()).thenReturn(req);
-        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
@@ -128,7 +128,7 @@ class TargetTemplateGetHandlerTest {
         Mockito.when(ctx.pathParam("templateType")).thenReturn("TARGET");
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.when(ctx.request()).thenReturn(req);
-        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         Mockito.when(conn.getTemplateService()).thenReturn(templateService);
         Mockito.when(templateService.getXml("FooTemplate", TemplateType.TARGET))
@@ -161,7 +161,7 @@ class TargetTemplateGetHandlerTest {
         Mockito.when(ctx.pathParam("templateType")).thenReturn("CUSTOM");
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.when(ctx.request()).thenReturn(req);
-        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
         Mockito.when(ctx.response()).thenReturn(resp);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplatesGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplatesGetHandlerTest.java
@@ -69,7 +69,9 @@ import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 
+import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 
@@ -107,6 +109,9 @@ class TargetTemplatesGetHandlerTest {
 
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
         Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
 
         Assertions.assertThrows(Exception.class, () -> handler.handleAuthenticated(ctx));
     }
@@ -134,6 +139,9 @@ class TargetTemplatesGetHandlerTest {
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
         Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
 
         handler.handleAuthenticated(ctx);
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplatesGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetTemplatesGetHandlerTest.java
@@ -69,7 +69,7 @@ import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 
-import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -111,7 +111,7 @@ class TargetTemplatesGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.when(ctx.request()).thenReturn(req);
-        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         Assertions.assertThrows(Exception.class, () -> handler.handleAuthenticated(ctx));
     }
@@ -141,7 +141,7 @@ class TargetTemplatesGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("foo:9091");
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.when(ctx.request()).thenReturn(req);
-        Mockito.when(req.headers()).thenReturn(new CaseInsensitiveHeaders());
+        Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         handler.handleAuthenticated(ctx);
 


### PR DESCRIPTION
This adds a bit of logic to the `AbstractAuthenticatedRequestHandler` to fill in the implementation of retrieving target RJMX credentials from HTTP headers. This was previously added as a stub which always used null credentials in an earlier PR. Now, if credentials are provided using the `Proxy-Authorization` header (maybe this isn't the most appropriate header to use), they are checked for validity and passed along down the line when establishing the connection to the target JVM.