### PR TITLE
Specify required podman version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Build:
 - Git
 - JDK11+
 - Maven 3+
-- Podman
+- Podman 2.0+
 
 Run:
 - Kubernetes/OpenShift/Minishift, Podman/Docker, or other container platform


### PR DESCRIPTION
Podman version 2.0+ seems to be needed for `run.sh` to work with its separate container creation and container run steps, which is useful for testing and development as it allows a nice and simple way to run other containers within the same pod, so that the container-jfr instance has other targets to connect to than itself (ex. andrewazores/vertx-fib-demo). For general image creation purposes (`mvn package`), older Podman versions should suffice, but I'm not sure it's worth explaining this distinction.