### PR TITLE
Change JMX auth header name

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandler.java
@@ -62,6 +62,7 @@ class CorsEnablingHandler implements RequestHandler {
         this.corsHandler =
                 CorsHandler.create(getOrigin())
                         .allowedHeader("Authorization")
+                        .allowedHeader(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER)
                         .allowedMethod(HttpMethod.GET)
                         .allowedMethod(HttpMethod.POST)
                         .allowedMethod(HttpMethod.PATCH)
@@ -69,7 +70,8 @@ class CorsEnablingHandler implements RequestHandler {
                         .allowedMethod(HttpMethod.HEAD)
                         .allowedMethod(HttpMethod.DELETE)
                         .allowCredentials(true)
-                        .exposedHeader(WebServer.AUTH_SCHEME_HEADER);
+                        .exposedHeader(WebServer.AUTH_SCHEME_HEADER)
+                        .exposedHeader(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER);
     }
 
     @Override

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandlerTest.java
@@ -138,7 +138,9 @@ class CorsEnablingHandlerTest {
             Mockito.verify(res)
                     .putHeader(
                             HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
-                            WebServer.AUTH_SCHEME_HEADER);
+                            WebServer.AUTH_SCHEME_HEADER
+                                    + ","
+                                    + AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER);
             Mockito.verifyNoMoreInteractions(res);
             Mockito.verify(ctx).next();
         }
@@ -163,7 +165,9 @@ class CorsEnablingHandlerTest {
                             HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
                             "GET,POST,PATCH,OPTIONS,HEAD,DELETE");
             Mockito.verify(res)
-                    .putHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "Authorization");
+                    .putHeader(
+                            HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                            "Authorization,X-JMX-Authorization");
             Mockito.verify(res).setStatusCode(200);
             Mockito.verify(res).end();
             Mockito.verifyNoMoreInteractions(res);


### PR DESCRIPTION
Browsers do not send Proxy-Authorization header as expected, so rename
the header to X-JMX-Authorization to allow browser clients to provide
JMX auth credentials