### PR TITLE
Fix username problem for RJMX credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,10 +348,6 @@
               <file>${containerjfr.entrypoint}</file>
               <mode>755</mode>
             </permission>
-            <permission>
-              <file>/app/resources/jmxremote.access</file>
-              <mode>644</mode>
-            </permission>
           </permissions>
         </extraDirectories>
       </configuration>

--- a/src/main/extras/app/entrypoint.sh
+++ b/src/main/extras/app/entrypoint.sh
@@ -3,6 +3,7 @@
 set -x
 set -e
 
+USRFILE="/tmp/jmxremote.access"
 PWFILE="/tmp/jmxremote.password"
 function createJmxPassword() {
     if [ -z "$CONTAINER_JFR_RJMX_USER" ]; then
@@ -14,6 +15,8 @@ function createJmxPassword() {
 
     echo "$CONTAINER_JFR_RJMX_USER $CONTAINER_JFR_RJMX_PASS" > "$PWFILE"
     chmod 400 "$PWFILE"
+    echo "$CONTAINER_JFR_RJMX_USER readwrite" > "$USRFILE"
+    chmod 400 "$USRFILE"
 }
 
 if [ -z "$CONTAINER_JFR_RJMX_PORT" ]; then
@@ -39,7 +42,7 @@ if [ "$CONTAINER_JFR_RJMX_AUTH" = "true" ] || [ -n "$CONTAINER_JFR_RJMX_USER" ] 
 
     FLAGS+=("-Dcom.sun.management.jmxremote.authenticate=true")
     FLAGS+=("-Dcom.sun.management.jmxremote.password.file=$PWFILE")
-    FLAGS+=("-Dcom.sun.management.jmxremote.access.file=/app/resources/jmxremote.access")
+    FLAGS+=("-Dcom.sun.management.jmxremote.access.file=$USRFILE")
 else
     FLAGS+=("-Dcom.sun.management.jmxremote.authenticate=false")
 fi

--- a/src/main/extras/app/entrypoint.sh
+++ b/src/main/extras/app/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 
 USRFILE="/tmp/jmxremote.access"
 PWFILE="/tmp/jmxremote.password"
-function createJmxPassword() {
+function createJmxCredentials() {
     if [ -z "$CONTAINER_JFR_RJMX_USER" ]; then
         CONTAINER_JFR_RJMX_USER="containerjfr"
     fi
@@ -38,7 +38,7 @@ fi
 
 if [ "$CONTAINER_JFR_RJMX_AUTH" = "true" ] || [ -n "$CONTAINER_JFR_RJMX_USER" ] || 
     [ -n "$CONTAINER_JFR_RJMX_PASS" ]; then
-    createJmxPassword
+    createJmxCredentials
 
     FLAGS+=("-Dcom.sun.management.jmxremote.authenticate=true")
     FLAGS+=("-Dcom.sun.management.jmxremote.password.file=$PWFILE")

--- a/src/main/extras/app/resources/jmxremote.access
+++ b/src/main/extras/app/resources/jmxremote.access
@@ -1,1 +1,0 @@
-containerjfr readwrite


### PR DESCRIPTION
Fixes #221 
Remove jmxremote.access, and generate it with the correct username in entrypoint.sh