### PR TITLE
Change call/response JMX auth header

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
@@ -62,7 +62,8 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
 
     static final Pattern AUTH_HEADER_PATTERN =
             Pattern.compile("(?<type>[\\w]+)[\\s]+(?<credentials>[\\S]+)");
-    static final String JMX_AUTH_HEADER = "X-JMX-Authorization";
+    static final String JMX_AUTHENTICATE_HEADER = "X-JMX-Authenticate";
+    static final String JMX_AUTHORIZATION_HEADER = "X-JMX-Authorization";
 
     private final AuthManager auth;
 
@@ -84,7 +85,7 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
         } catch (ConnectionException e) {
             Throwable cause = e.getCause();
             if (cause instanceof SecurityException) {
-                ctx.response().putHeader(JMX_AUTH_HEADER, "Basic");
+                ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
                 throw new HttpStatusException(407, e);
             }
             throw new HttpStatusException(404, e);
@@ -100,15 +101,15 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
     protected ConnectionDescriptor getConnectionDescriptorFromContext(RoutingContext ctx) {
         String targetId = ctx.pathParam("targetId");
         Credentials credentials = null;
-        if (ctx.request().headers().contains(JMX_AUTH_HEADER)) {
-            String proxyAuth = ctx.request().getHeader(JMX_AUTH_HEADER);
+        if (ctx.request().headers().contains(JMX_AUTHORIZATION_HEADER)) {
+            String proxyAuth = ctx.request().getHeader(JMX_AUTHORIZATION_HEADER);
             Matcher m = AUTH_HEADER_PATTERN.matcher(proxyAuth);
             if (!m.find()) {
-                throw new HttpStatusException(400, "Invalid " + JMX_AUTH_HEADER + " format");
+                throw new HttpStatusException(400, "Invalid " + JMX_AUTHORIZATION_HEADER + " format");
             } else {
                 String t = m.group("type");
                 if (!"basic".equals(t.toLowerCase())) {
-                    throw new HttpStatusException(400, "Unacceptable " + JMX_AUTH_HEADER + " type");
+                    throw new HttpStatusException(400, "Unacceptable " + JMX_AUTHORIZATION_HEADER + " type");
                 } else {
                     String c;
                     try {
@@ -119,13 +120,13 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
                     } catch (IllegalArgumentException iae) {
                         throw new HttpStatusException(
                                 400,
-                                JMX_AUTH_HEADER + " credentials do not appear to be Base64-encoded",
+                                JMX_AUTHORIZATION_HEADER + " credentials do not appear to be Base64-encoded",
                                 iae);
                     }
                     String[] parts = c.split(":");
                     if (parts.length != 2) {
                         throw new HttpStatusException(
-                                400, "Unrecognized " + JMX_AUTH_HEADER + " credential format");
+                                400, "Unrecognized " + JMX_AUTHORIZATION_HEADER + " credential format");
                     }
                     credentials = new Credentials(parts[0], parts[1]);
                 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
@@ -105,10 +105,12 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
             String proxyAuth = ctx.request().getHeader(JMX_AUTHORIZATION_HEADER);
             Matcher m = AUTH_HEADER_PATTERN.matcher(proxyAuth);
             if (!m.find()) {
+                ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
                 throw new HttpStatusException(407, "Invalid " + JMX_AUTHORIZATION_HEADER + " format");
             } else {
                 String t = m.group("type");
                 if (!"basic".equals(t.toLowerCase())) {
+                    ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
                     throw new HttpStatusException(407, "Unacceptable " + JMX_AUTHORIZATION_HEADER + " type");
                 } else {
                     String c;
@@ -118,6 +120,7 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
                                         Base64.getDecoder().decode(m.group("credentials")),
                                         StandardCharsets.UTF_8);
                     } catch (IllegalArgumentException iae) {
+                        ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
                         throw new HttpStatusException(
                                 407,
                                 JMX_AUTHORIZATION_HEADER + " credentials do not appear to be Base64-encoded",
@@ -125,6 +128,7 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
                     }
                     String[] parts = c.split(":");
                     if (parts.length != 2) {
+                        ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
                         throw new HttpStatusException(
                                 407, "Unrecognized " + JMX_AUTHORIZATION_HEADER + " credential format");
                     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
@@ -105,11 +105,11 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
             String proxyAuth = ctx.request().getHeader(JMX_AUTHORIZATION_HEADER);
             Matcher m = AUTH_HEADER_PATTERN.matcher(proxyAuth);
             if (!m.find()) {
-                throw new HttpStatusException(400, "Invalid " + JMX_AUTHORIZATION_HEADER + " format");
+                throw new HttpStatusException(407, "Invalid " + JMX_AUTHORIZATION_HEADER + " format");
             } else {
                 String t = m.group("type");
                 if (!"basic".equals(t.toLowerCase())) {
-                    throw new HttpStatusException(400, "Unacceptable " + JMX_AUTHORIZATION_HEADER + " type");
+                    throw new HttpStatusException(407, "Unacceptable " + JMX_AUTHORIZATION_HEADER + " type");
                 } else {
                     String c;
                     try {
@@ -119,14 +119,14 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
                                         StandardCharsets.UTF_8);
                     } catch (IllegalArgumentException iae) {
                         throw new HttpStatusException(
-                                400,
+                                407,
                                 JMX_AUTHORIZATION_HEADER + " credentials do not appear to be Base64-encoded",
                                 iae);
                     }
                     String[] parts = c.split(":");
                     if (parts.length != 2) {
                         throw new HttpStatusException(
-                                400, "Unrecognized " + JMX_AUTHORIZATION_HEADER + " credential format");
+                                407, "Unrecognized " + JMX_AUTHORIZATION_HEADER + " credential format");
                     }
                     credentials = new Credentials(parts[0], parts[1]);
                 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandler.java
@@ -106,12 +106,14 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
             Matcher m = AUTH_HEADER_PATTERN.matcher(proxyAuth);
             if (!m.find()) {
                 ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
-                throw new HttpStatusException(407, "Invalid " + JMX_AUTHORIZATION_HEADER + " format");
+                throw new HttpStatusException(
+                        407, "Invalid " + JMX_AUTHORIZATION_HEADER + " format");
             } else {
                 String t = m.group("type");
                 if (!"basic".equals(t.toLowerCase())) {
                     ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
-                    throw new HttpStatusException(407, "Unacceptable " + JMX_AUTHORIZATION_HEADER + " type");
+                    throw new HttpStatusException(
+                            407, "Unacceptable " + JMX_AUTHORIZATION_HEADER + " type");
                 } else {
                     String c;
                     try {
@@ -123,14 +125,16 @@ abstract class AbstractAuthenticatedRequestHandler implements RequestHandler {
                         ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
                         throw new HttpStatusException(
                                 407,
-                                JMX_AUTHORIZATION_HEADER + " credentials do not appear to be Base64-encoded",
+                                JMX_AUTHORIZATION_HEADER
+                                        + " credentials do not appear to be Base64-encoded",
                                 iae);
                     }
                     String[] parts = c.split(":");
                     if (parts.length != 2) {
                         ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
                         throw new HttpStatusException(
-                                407, "Unrecognized " + JMX_AUTHORIZATION_HEADER + " credential format");
+                                407,
+                                "Unrecognized " + JMX_AUTHORIZATION_HEADER + " credential format");
                     }
                     credentials = new Credentials(parts[0], parts[1]);
                 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandler.java
@@ -62,7 +62,7 @@ class CorsEnablingHandler implements RequestHandler {
         this.corsHandler =
                 CorsHandler.create(getOrigin())
                         .allowedHeader("Authorization")
-                        .allowedHeader(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER)
+                        .allowedHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER)
                         .allowedMethod(HttpMethod.GET)
                         .allowedMethod(HttpMethod.POST)
                         .allowedMethod(HttpMethod.PATCH)
@@ -71,7 +71,7 @@ class CorsEnablingHandler implements RequestHandler {
                         .allowedMethod(HttpMethod.DELETE)
                         .allowCredentials(true)
                         .exposedHeader(WebServer.AUTH_SCHEME_HEADER)
-                        .exposedHeader(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER);
+                        .exposedHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHENTICATE_HEADER);
     }
 
     @Override

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandlerTest.java
@@ -76,6 +76,7 @@ class AbstractAuthenticatedRequestHandlerTest {
     RequestHandler handler;
     @Mock RoutingContext ctx;
     @Mock AuthManager auth;
+    @Mock HttpServerResponse resp;
 
     @BeforeEach
     void setup() {
@@ -138,7 +139,6 @@ class AbstractAuthenticatedRequestHandlerTest {
             expectedException.initCause(cause);
             handler = new ThrowingAuthenticatedHandler(auth, expectedException);
 
-            HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
             Mockito.when(ctx.response()).thenReturn(resp);
 
             HttpStatusException ex =
@@ -193,9 +193,10 @@ class AbstractAuthenticatedRequestHandlerTest {
                     "",
                     "credentialsWithoutAuthType",
                 })
-        void shouldThrow400WithMalformedAuthorizationHeader(String authHeader) {
+        void shouldThrow407WithMalformedAuthorizationHeader(String authHeader) {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
+            Mockito.when(ctx.response()).thenReturn(resp);
             Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
             Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
@@ -203,7 +204,7 @@ class AbstractAuthenticatedRequestHandlerTest {
 
             HttpStatusException ex =
                     Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
-            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(407));
             MatcherAssert.assertThat(
                     ex.getPayload(), Matchers.equalTo("Invalid X-JMX-Authorization format"));
         }
@@ -214,9 +215,10 @@ class AbstractAuthenticatedRequestHandlerTest {
                     "Type credentials",
                     "Bearer credentials",
                 })
-        void shouldThrow400WithBadAuthorizationType(String authHeader) {
+        void shouldThrow407WithBadAuthorizationType(String authHeader) {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
+            Mockito.when(ctx.response()).thenReturn(resp);
             Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
             Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
@@ -224,7 +226,7 @@ class AbstractAuthenticatedRequestHandlerTest {
 
             HttpStatusException ex =
                     Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
-            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(407));
             MatcherAssert.assertThat(
                     ex.getPayload(), Matchers.equalTo("Unacceptable X-JMX-Authorization type"));
         }
@@ -235,9 +237,10 @@ class AbstractAuthenticatedRequestHandlerTest {
                     "Basic bm9zZXBhcmF0b3I=", // credential value of "noseparator"
                     "Basic b25lOnR3bzp0aHJlZQ==", // credential value of "one:two:three"
                 })
-        void shouldThrow400WithBadCredentialFormat(String authHeader) {
+        void shouldThrow407WithBadCredentialFormat(String authHeader) {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
+            Mockito.when(ctx.response()).thenReturn(resp);
             Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
             Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
@@ -245,7 +248,7 @@ class AbstractAuthenticatedRequestHandlerTest {
 
             HttpStatusException ex =
                     Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
-            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(407));
             MatcherAssert.assertThat(
                     ex.getPayload(),
                     Matchers.equalTo("Unrecognized X-JMX-Authorization credential format"));
@@ -256,9 +259,10 @@ class AbstractAuthenticatedRequestHandlerTest {
                 strings = {
                     "Basic foo:bar",
                 })
-        void shouldThrow400WithUnencodedCredentials(String authHeader) {
+        void shouldThrow407WithUnencodedCredentials(String authHeader) {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
+            Mockito.when(ctx.response()).thenReturn(resp);
             Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
             Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
@@ -266,7 +270,7 @@ class AbstractAuthenticatedRequestHandlerTest {
 
             HttpStatusException ex =
                     Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
-            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(407));
             MatcherAssert.assertThat(
                     ex.getPayload(),
                     Matchers.equalTo(

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandlerTest.java
@@ -144,8 +144,7 @@ class AbstractAuthenticatedRequestHandlerTest {
             HttpStatusException ex =
                     Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(407));
-            Mockito.verify(resp)
-                    .putHeader(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER, "Basic");
+            Mockito.verify(resp).putHeader("X-JMX-Authenticate", "Basic");
         }
 
         @Test
@@ -197,9 +196,9 @@ class AbstractAuthenticatedRequestHandlerTest {
         void shouldThrow400WithMalformedAuthorizationHeader(String authHeader) {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
-            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER))
+            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER))
+            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
             HttpStatusException ex =
@@ -218,9 +217,9 @@ class AbstractAuthenticatedRequestHandlerTest {
         void shouldThrow400WithBadAuthorizationType(String authHeader) {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
-            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER))
+            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER))
+            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
             HttpStatusException ex =
@@ -239,9 +238,9 @@ class AbstractAuthenticatedRequestHandlerTest {
         void shouldThrow400WithBadCredentialFormat(String authHeader) {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
-            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER))
+            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER))
+            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
             HttpStatusException ex =
@@ -260,9 +259,9 @@ class AbstractAuthenticatedRequestHandlerTest {
         void shouldThrow400WithUnencodedCredentials(String authHeader) {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
-            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER))
+            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER))
+            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
             HttpStatusException ex =
@@ -278,9 +277,9 @@ class AbstractAuthenticatedRequestHandlerTest {
         void shouldIncludeCredentialsFromAppropriateHeader() {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
-            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER))
+            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER))
+            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn("Basic Zm9vOmJhcg==");
 
             Assertions.assertDoesNotThrow(() -> handler.handle(ctx));

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/AbstractAuthenticatedRequestHandlerTest.java
@@ -197,9 +197,13 @@ class AbstractAuthenticatedRequestHandlerTest {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
             Mockito.when(ctx.response()).thenReturn(resp);
-            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(
+                            headers.contains(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(
+                            req.getHeader(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
             HttpStatusException ex =
@@ -219,9 +223,13 @@ class AbstractAuthenticatedRequestHandlerTest {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
             Mockito.when(ctx.response()).thenReturn(resp);
-            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(
+                            headers.contains(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(
+                            req.getHeader(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
             HttpStatusException ex =
@@ -241,9 +249,13 @@ class AbstractAuthenticatedRequestHandlerTest {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
             Mockito.when(ctx.response()).thenReturn(resp);
-            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(
+                            headers.contains(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(
+                            req.getHeader(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
             HttpStatusException ex =
@@ -263,9 +275,13 @@ class AbstractAuthenticatedRequestHandlerTest {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
             Mockito.when(ctx.response()).thenReturn(resp);
-            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(
+                            headers.contains(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(
+                            req.getHeader(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
             HttpStatusException ex =
@@ -281,9 +297,13 @@ class AbstractAuthenticatedRequestHandlerTest {
         void shouldIncludeCredentialsFromAppropriateHeader() {
             String targetId = "fooTarget";
             Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
-            Mockito.when(headers.contains(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(
+                            headers.contains(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(req.getHeader(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(
+                            req.getHeader(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn("Basic Zm9vOmJhcg==");
 
             Assertions.assertDoesNotThrow(() -> handler.handle(ctx));

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/handlers/CorsEnablingHandlerTest.java
@@ -140,7 +140,7 @@ class CorsEnablingHandlerTest {
                             HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
                             WebServer.AUTH_SCHEME_HEADER
                                     + ","
-                                    + AbstractAuthenticatedRequestHandler.JMX_AUTH_HEADER);
+                                    + AbstractAuthenticatedRequestHandler.JMX_AUTHENTICATE_HEADER);
             Mockito.verifyNoMoreInteractions(res);
             Mockito.verify(ctx).next();
         }


### PR DESCRIPTION
Related to #5

Server's "call" is changed to X-JMX-Authenticate, while corresponding
client response is left as "X-JMX-Authorization". This matches the HTTP
WWW-Authenticate/Authorization headers.

This header will be used by clients to discover the authentication scheme expected by the ContainerJFR instance. The only supported scheme at this time is `Basic`.