### PR TITLE
Add Check for Upload Handler POST Response

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingUploadPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/RecordingUploadPostHandler.java
@@ -41,6 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
+import static com.redhat.rhjmc.containerjfr.util.HttpStatusCodeIdentifier.isSuccessCode;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.InvalidPathException;
@@ -108,6 +110,15 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
             URL uploadUrl = new URL(env.getEnv("GRAFANA_DATASOURCE_URL"));
             // TODO validate URL before POST attempt
             ResponseMessage response = doPost(recordingName, uploadUrl);
+            if (!isSuccessCode(response.statusCode)
+                    || response.statusMessage == null
+                    || response.body == null) {
+                throw new HttpStatusException(
+                        502,
+                        String.format(
+                                "Invalid response from datasource server; datasource URL may be incorrect, or server may not be functioning properly: %d %s",
+                                response.statusCode, response.statusMessage));
+            }
             ctx.response().setStatusCode(response.statusCode);
             ctx.response().setStatusMessage(response.statusMessage);
             ctx.response().end(response.body);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingUploadPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/handlers/TargetRecordingUploadPostHandler.java
@@ -41,6 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.handlers;
 
+import static com.redhat.rhjmc.containerjfr.util.HttpStatusCodeIdentifier.isSuccessCode;
+
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -110,6 +112,15 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
         try {
             URL uploadUrl = new URL(env.getEnv("GRAFANA_DATASOURCE_URL"));
             ResponseMessage response = doPost(ctx, uploadUrl);
+            if (!isSuccessCode(response.statusCode)
+                    || response.statusMessage == null
+                    || response.body == null) {
+                throw new HttpStatusException(
+                        502,
+                        String.format(
+                                "Invalid response from datasource server; datasource URL may be incorrect, or server may not be functioning properly: %d %s",
+                                response.statusCode, response.statusMessage));
+            }
             ctx.response().setStatusCode(response.statusCode);
             ctx.response().setStatusMessage(response.statusMessage);
             ctx.response().end(response.body);


### PR DESCRIPTION
Fixes #237.

Mostly just the same implementation as #224. I had to remove the response body from the exception message though, since it could contain newlines or other characters not allowed in a status message.

Tests are again just the `shouldDoPost()` test with a modification to the `Answer` and verifications at the end.