### PR TITLE
Fix itests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,22 @@
           </configuration>
         </execution>
         <execution>
+          <id>wait-for-container</id>
+          <phase>pre-integration-test</phase>
+          <goals>
+            <goal>exec</goal>
+          </goals>
+          <configuration>
+            <executable>timeout</executable>
+            <arguments>
+              <argument>5m</argument>
+              <argument>sh</argument>
+              <argument>-c</argument>
+              <argument>until curl -sSk http://0.0.0.0:${containerjfr.itest.webPort}/health; do sleep 10; done</argument>
+            </arguments>
+          </configuration>
+        </execution>
+        <execution>
           <id>stop-container</id>
           <phase>post-integration-test</phase>
           <goals>

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -5,7 +5,12 @@ set -e
 
 function runContainerJFR() {
     local DIR="$(dirname "$(readlink -f "$0")")"
-    GRAFANA_DATASOURCE_URL="http://0.0.0.0:8080" GRAFANA_DASHBOARD_URL="http://0.0.0.0:3000" sh "$DIR/run.sh"
+    GRAFANA_DATASOURCE_URL="http://0.0.0.0:8080" \
+        GRAFANA_DASHBOARD_URL="http://0.0.0.0:3000" \
+        CONTAINER_JFR_RJMX_AUTH=true \
+        CONTAINER_JFR_RJMX_USER=smoketest \
+        CONTAINER_JFR_RJMX_PASS=smoketest \
+        sh "$DIR/run.sh"
 }
 
 function runDemoApp() {


### PR DESCRIPTION
This fixes integration tests, which recently (in #243) broke. The cause of the failure is that the SSL portions of `entrypoint.sh` cause the real container start-up time to be increased, and without this PR, the integration test suite attempts to run tests immediately after starting the container. The container is in fact running, but the JVM has not yet started and begun listening for incoming connections, and so the integration test requests fail. The solution presented here is to simply add an exec-plugin configuration that does a slow loop waiting for the JVM to be ready before allowing the integration tests to proceed.

There are still rare instances where I observe the tests failing with `Connection Refused` errors, and in these cases I can see that the JVM is running and apparently ready using `podman logs -f`, but `curl` also shows requests failing due to `connection refused` without any corresponding request logs from ContainerJFR. I believe this is probably a separate issue and perhaps has to do with recent changes to `entrypoint.sh` since I haven't seen this failure before.