### PR TITLE
Update frontend-plugin for yarn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -589,7 +589,9 @@
                 <goal>yarn</goal>
               </goals>
               <configuration>
-                <arguments>install</arguments>
+                  <arguments>
+                      install --frozen-lockfile
+                  </arguments>
               </configuration>
             </execution>
             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <baseImage>registry.access.redhat.com/ubi8/openjdk-11</baseImage>
   <baseImageTag>1.3-3.1593114401</baseImageTag>
   <node.version>v12.5.0</node.version>
-  <npm.version>6.13.4</npm.version>
+  <yarn.version>v1.22.10</yarn.version>
 
   <containerjfr.minimal>false</containerjfr.minimal>
   <containerjfr.imageStream>quay.io/rh-jmc-team/container-jfr</containerjfr.imageStream>
@@ -535,6 +535,15 @@
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
           <version>${org.apache.maven.plugins.clean.version}</version>
+          <executions>
+            <execution>
+              <id>clean web-client</id>
+              <phase>clean</phase>
+              <goals>
+                <goal>clean</goal>
+              </goals>
+            </execution>
+          </executions>
           <configuration>
             <filesets>
               <fileset>
@@ -566,28 +575,28 @@
               <id>install node and npm</id>
               <phase>initialize</phase>
               <goals>
-                <goal>install-node-and-npm</goal>
+                <goal>install-node-and-yarn</goal>
               </goals>
               <configuration>
                 <nodeVersion>${node.version}</nodeVersion>
-                <npmVersion>${npm.version}</npmVersion>
+                <yarnVersion>${yarn.version}</yarnVersion>
               </configuration>
             </execution>
             <execution>
-              <id>npm ci</id>
+              <id>yarn install</id>
               <phase>initialize</phase>
               <goals>
-                <goal>npm</goal>
+                <goal>yarn</goal>
               </goals>
               <configuration>
-                <arguments>ci</arguments>
+                <arguments>install</arguments>
               </configuration>
             </execution>
             <execution>
-              <id>npm run build</id>
+              <id>yarn run build</id>
               <phase>prepare-package</phase>
               <goals>
-                <goal>npm</goal>
+                <goal>yarn</goal>
               </goals>
               <configuration>
                 <arguments>run build</arguments>


### PR DESCRIPTION
See https://github.com/rh-jmc-team/container-jfr-web/pull/148 . With both patches applied, `mvn package` and `mvn clean package` should be notably faster and still result in a functional image due to a shorter time spent cleaning, checking, and rebuilding the frontend dependencies.