### PR TITLE
Upload certificate

### DIFF
--- a/src/main/extras/app/entrypoint.sh
+++ b/src/main/extras/app/entrypoint.sh
@@ -155,6 +155,8 @@ fi
 
 KEYSTORE_PATH="$KEYSTORE_PATH" \
     KEYSTORE_PASS="$KEYSTORE_PASS" \
+    SSL_TRUSTSTORE="$SSL_TRUSTSTORE" \
+    SSL_TRUSTSTORE_PASS="$SSL_TRUSTSTORE_PASS" \
     java \
     "${FLAGS[@]}" \
     -cp /app/resources:/app/classes:/app/libs/* \

--- a/src/main/extras/app/entrypoint.sh
+++ b/src/main/extras/app/entrypoint.sh
@@ -35,6 +35,8 @@ SSL_KEY_PASS="$(genpass)"
 SSL_STORE_PASS="$SSL_KEY_PASS"
 SSL_TRUSTSTORE="/tmp/truststore.p12"
 SSL_TRUSTSTORE_PASS="$(genpass)"
+TRUSTSTORE_DIR="/truststore"
+
 function createSslStores() {
     pushd /tmp
 
@@ -50,16 +52,15 @@ function createSslStores() {
 }
 
 function importTrustStores() {
-    local DIR="/truststore"
-    if [ ! -d "$DIR" ]; then
-        banner "$DIR does not exist; no certificates to import"
+    if [ ! -d "$TRUSTSTORE_DIR" ]; then
+        banner "$TRUSTSTORE_DIR does not exist; no certificates to import"
         return 0
-    elif [ ! "$(ls -A $DIR)" ]; then
-        banner "$DIR is empty; no certificates to import"
+    elif [ ! "$(ls -A $TRUSTSTORE_DIR)" ]; then
+        banner "$TRUSTSTORE_DIR is empty; no certificates to import"
         return 0
     fi
 
-    for cert in $(find "$DIR" -type f); do
+    for cert in $(find "$TRUSTSTORE_DIR" -type f); do
         echo "Importing certificate $cert ..."
 
         keytool -importcert -v \
@@ -155,8 +156,7 @@ fi
 
 KEYSTORE_PATH="$KEYSTORE_PATH" \
     KEYSTORE_PASS="$KEYSTORE_PASS" \
-    SSL_TRUSTSTORE="$SSL_TRUSTSTORE" \
-    SSL_TRUSTSTORE_PASS="$SSL_TRUSTSTORE_PASS" \
+    TRUSTSTORE_DIR="$TRUSTSTORE_DIR" \
     java \
     "${FLAGS[@]}" \
     -cp /app/resources:/app/classes:/app/libs/* \

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/security/CertificateValidator.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/security/CertificateValidator.java
@@ -42,12 +42,13 @@
 package com.redhat.rhjmc.containerjfr.net.security;
 
 import java.io.InputStream;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.util.Collection;
 
 public class CertificateValidator {
 
-    public Collection parseCertificate(InputStream stream) throws Exception {
+    public Collection<Certificate> parseCertificates(InputStream stream) throws Exception {
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
         return cf.generateCertificates(stream);
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/security/CertificateValidator.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/security/CertificateValidator.java
@@ -48,7 +48,8 @@ import java.util.Collection;
 
 public class CertificateValidator {
 
-    public Collection<Certificate> parseCertificates(InputStream stream) throws Exception {
+    public Collection<? extends Certificate> parseCertificates(InputStream stream)
+            throws Exception {
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
         return cf.generateCertificates(stream);
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/security/CertificateValidator.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/security/CertificateValidator.java
@@ -47,7 +47,7 @@ import java.security.cert.CertificateFactory;
 
 public class CertificateValidator {
 
-    public Certificate verify(ByteArrayInputStream byteStream) throws Exception {
+    public Certificate parseCertificate(ByteArrayInputStream byteStream) throws Exception {
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
         return cf.generateCertificate(byteStream);
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/security/CertificateValidator.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/security/CertificateValidator.java
@@ -41,7 +41,6 @@
  */
 package com.redhat.rhjmc.containerjfr.net.security;
 
-
 import java.io.ByteArrayInputStream;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/security/CertificateValidator.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/security/CertificateValidator.java
@@ -41,14 +41,14 @@
  */
 package com.redhat.rhjmc.containerjfr.net.security;
 
-import java.io.ByteArrayInputStream;
-import java.security.cert.Certificate;
+import java.io.InputStream;
 import java.security.cert.CertificateFactory;
+import java.util.Collection;
 
 public class CertificateValidator {
 
-    public Certificate parseCertificate(ByteArrayInputStream byteStream) throws Exception {
+    public Collection parseCertificate(InputStream stream) throws Exception {
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        return cf.generateCertificate(byteStream);
+        return cf.generateCertificates(stream);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/security/CertificateValidator.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/security/CertificateValidator.java
@@ -39,54 +39,17 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
+package com.redhat.rhjmc.containerjfr.net.security;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.function.Function;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
+import java.io.ByteArrayInputStream;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
 
-import com.redhat.rhjmc.containerjfr.net.security.CertificateValidator;
-import com.redhat.rhjmc.containerjfr.net.web.http.RequestHandler;
+public class CertificateValidator {
 
-import dagger.Binds;
-import dagger.Module;
-import dagger.Provides;
-import dagger.multibindings.IntoSet;
-
-@Module
-public abstract class HttpApiV2Module {
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetSnapshotPostHandler(TargetSnapshotPostHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindCertificatePostHandler(CertificatePostHandler handler);
-
-    @Provides
-    @Singleton
-    @Named("OutputStreamFunction")
-    static Function<File, FileOutputStream> provideOutputStreamFunction() throws RuntimeException {
-        return (File file) -> {
-            try {
-                return new FileOutputStream(file);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        };
+    public Certificate verify(ByteArrayInputStream byteStream) throws Exception {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        return cf.generateCertificate(byteStream);
     }
-
-    @Provides
-    static CertificateValidator provideCertificateValidator() {
-        return new CertificateValidator();
-    }
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindCertificatePostBodyHandler(CertificatePostBodyHandler handler);
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostBodyHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostBodyHandler.java
@@ -41,24 +41,47 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
 
-import com.redhat.rhjmc.containerjfr.net.web.http.RequestHandler;
+import javax.inject.Inject;
 
-import dagger.Binds;
-import dagger.Module;
-import dagger.multibindings.IntoSet;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.web.http.AbstractAuthenticatedRequestHandler;
+import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiVersion;
 
-@Module
-public abstract class HttpApiV2Module {
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetSnapshotPostHandler(TargetSnapshotPostHandler handler);
+class CertificatePostBodyHandler extends AbstractAuthenticatedRequestHandler {
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindCertificatePostHandler(CertificatePostHandler handler);
+    static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindCertificatePostBodyHandler(CertificatePostBodyHandler handler);
+    @Inject
+    CertificatePostBodyHandler(AuthManager auth) {
+        super(auth);
+    }
+
+    @Override
+    public int getPriority() {
+        return DEFAULT_PRIORITY - 1;
+    }
+
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.V2;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public String path() {
+        return basePath() + CertificatePostHandler.PATH;
+    }
+
+    @Override
+    public void handleAuthenticated(RoutingContext ctx) throws Exception {
+        BODY_HANDLER.handle(ctx);
+    }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
@@ -156,11 +156,12 @@ class CertificatePostHandler extends AbstractAuthenticatedRequestHandler {
 
             byte[] bytes = new byte[dis.available()];
             dis.readFully(bytes);
-            ByteArrayInputStream bytestream = new ByteArrayInputStream(bytes);
-            Certificate certificate = certValidator.parseCertificate(bytestream);
-            byte[] buf = certificate.getEncoded();
 
-            out.write(buf);
+            try (ByteArrayInputStream bytestream = new ByteArrayInputStream(bytes)) {
+                Certificate certificate = certValidator.parseCertificate(bytestream);
+                byte[] buf = certificate.getEncoded();
+                out.write(buf);
+            }
         }
 
         ctx.response().end("Saved: " + filePath);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
@@ -1,0 +1,186 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.spec.*;
+
+import javax.inject.Inject;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.web.http.AbstractAuthenticatedRequestHandler;
+import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiVersion;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+class CertificatePostHandler extends AbstractAuthenticatedRequestHandler {
+
+    static final String PATH = "certificates";
+
+    private final Environment env;
+    private final FileSystem fs;
+    private final Logger logger;
+
+    private static final String SSL_TRUSTSTORE = "SSL_TRUSTSTORE";
+    private static final String SSL_TRUSTSTORE_PASS = "SSL_TRUSTSTORE_PASS";
+
+    @Inject
+    CertificatePostHandler(AuthManager auth, Environment env, FileSystem fs, Logger logger) {
+        super(auth);
+        this.env = env;
+        this.fs = fs;
+        this.logger = logger;
+    }
+
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.V2;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public String path() {
+        return basePath() + PATH;
+    }
+
+    @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
+    public boolean isOrdered() {
+        return true;
+    }
+
+    @Override
+    public void handleAuthenticated(RoutingContext ctx) throws Exception {
+        FileUpload cert = null;
+        for (FileUpload fu : ctx.fileUploads()) {
+            if ("cert".equals(fu.name())) {
+                cert = fu;
+                break;
+            }
+        }
+
+        if (cert == null) {
+            throw new HttpStatusException(400, "No certificate found");
+        }
+
+        String certPath = fs.pathOf(cert.uploadedFileName()).normalize().toString();
+        String trustStore;
+        String trustStorePass;
+
+        if (env.hasEnv(SSL_TRUSTSTORE) && env.hasEnv(SSL_TRUSTSTORE_PASS)) {
+            try {
+                trustStore = fs.pathOf(env.getEnv(SSL_TRUSTSTORE)).normalize().toString();
+                trustStorePass = env.getEnv(SSL_TRUSTSTORE_PASS, "");
+            } catch (Exception e) {
+                throw new HttpStatusException(500, e.getMessage());
+            }
+        } else {
+            throw new HttpStatusException(500, "Truststore environment variables not set");
+        }
+
+        try {
+            FileInputStream is = new FileInputStream(trustStore);
+            KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+            keystore.load(is, trustStorePass.toCharArray());
+
+            var temp = keystore.aliases();
+            while (temp.hasMoreElements()){
+                logger.warn(temp.nextElement());
+            }
+
+            Certificate selftrust = keystore.getCertificate("selftrust");
+            keystore.deleteEntry("selftrust");
+            
+            String alias = "imported-" + cert.fileName();
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            InputStream certstream = fullStream(certPath);
+            Certificate certs = cf.generateCertificate(certstream);
+            logger.warn("Ok, so we get here...");
+            keystore.setCertificateEntry(alias, certs);
+            keystore.setCertificateEntry("selftrust", selftrust);
+
+            File keystoreFile = new File(trustStore);
+            FileOutputStream out = new FileOutputStream(keystoreFile);
+            keystore.store(out, trustStorePass.toCharArray());
+            out.close();
+
+            logger.warn("does this work?");
+        } catch (Exception e) {
+            throw new HttpStatusException(500, e.getLocalizedMessage());
+        }
+
+        ctx.response().end();
+    }
+
+    private static InputStream fullStream(String fname) throws IOException {
+        FileInputStream fis = new FileInputStream(fname);
+        DataInputStream dis = new DataInputStream(fis);
+        byte[] bytes = new byte[dis.available()];
+        dis.readFully(bytes);
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        return bais;
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
@@ -61,6 +61,7 @@ import com.redhat.rhjmc.containerjfr.net.security.CertificateValidator;
 import com.redhat.rhjmc.containerjfr.net.web.http.AbstractAuthenticatedRequestHandler;
 import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiVersion;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
@@ -121,6 +122,7 @@ class CertificatePostHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         FileUpload cert = null;
         for (FileUpload fu : ctx.fileUploads()) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
@@ -161,8 +161,6 @@ class CertificatePostHandler extends AbstractAuthenticatedRequestHandler {
             byte[] buf = certificate.getEncoded();
 
             out.write(buf);
-        } catch (Exception e) {
-            throw new HttpStatusException(500, e.getMessage());
         }
 
         ctx.response().end("Saved: " + filePath);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
@@ -41,13 +41,13 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
 
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.security.cert.Certificate;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.function.Function;
 
 import javax.inject.Inject;
@@ -151,14 +151,12 @@ class CertificatePostHandler extends AbstractAuthenticatedRequestHandler {
         }
 
         try (InputStream fis = fs.newInputStream(certPath);
-                DataInputStream dis = new DataInputStream(fis);
                 FileOutputStream out = outputStreamFunction.apply(filePath.toFile())) {
 
-            byte[] bytes = new byte[dis.available()];
-            dis.readFully(bytes);
-
-            try (ByteArrayInputStream bytestream = new ByteArrayInputStream(bytes)) {
-                Certificate certificate = certValidator.parseCertificate(bytestream);
+            Collection certificates = certValidator.parseCertificate(fis);
+            Iterator it = certificates.iterator();
+            while (it.hasNext()) {
+                Certificate certificate = (Certificate) it.next();
                 byte[] buf = certificate.getEncoded();
                 out.write(buf);
             }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
@@ -153,8 +153,8 @@ class CertificatePostHandler extends AbstractAuthenticatedRequestHandler {
         try (InputStream fis = fs.newInputStream(certPath);
                 FileOutputStream out = outputStreamFunction.apply(filePath.toFile())) {
 
-            Collection certificates = certValidator.parseCertificate(fis);
-            Iterator it = certificates.iterator();
+            Collection<? extends Certificate> certificates = certValidator.parseCertificates(fis);
+            Iterator<? extends Certificate> it = certificates.iterator();
             while (it.hasNext()) {
                 Certificate certificate = (Certificate) it.next();
                 byte[] buf = certificate.getEncoded();

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -164,7 +164,7 @@ class CertificatePostHandlerTest {
 
         InputStream instream = new ByteArrayInputStream("not a certificate".getBytes());
         Mockito.when(fs.newInputStream(fileUploadPath)).thenReturn(instream);
-        Mockito.when(certValidator.parseCertificate(Mockito.any()))
+        Mockito.when(certValidator.parseCertificates(Mockito.any()))
                 .thenThrow(new CertificateException("parsing error"));
 
         CertificateException ex =
@@ -189,7 +189,7 @@ class CertificatePostHandlerTest {
 
         InputStream instream = new ByteArrayInputStream("certificate".getBytes());
         Mockito.when(fs.newInputStream(fileUploadPath)).thenReturn(instream);
-        Mockito.when(certValidator.parseCertificate(Mockito.any())).thenReturn(certificates);
+        Mockito.when(certValidator.parseCertificates(Mockito.any())).thenReturn(certificates);
         Mockito.when(certificates.iterator()).thenReturn(iterator);
         Mockito.when(iterator.hasNext()).thenReturn(true).thenReturn(false);
         Mockito.when(iterator.next()).thenReturn(cert);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -1,0 +1,201 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.util.Collections;
+import java.util.Set;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.security.CertificateValidator;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class CertificatePostHandlerTest {
+
+    CertificatePostHandler handler;
+    @Mock AuthManager auth;
+    @Mock Environment env;
+    @Mock FileSystem fs;
+    @Mock Logger logger;
+
+    @Mock RoutingContext ctx;
+    @Mock FileOutputStream outStream;
+    @Mock FileUpload fu;
+    @Mock Path truststorePath;
+    @Mock Path fileUploadPath;
+    @Mock CertificateValidator certValidator;
+    @Mock Certificate cert;
+
+    @BeforeEach
+    void setup() {
+        this.handler =
+                new CertificatePostHandler(
+                        auth, env, fs, logger, (file) -> outStream, certValidator);
+    }
+
+    @Test
+    void shouldHandlePOST() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v2/certificates"));
+    }
+
+    @Test
+    void shouldThrow400IfNoCertInRequest() {
+        Mockito.when(ctx.fileUploads()).thenReturn(Collections.<FileUpload>emptySet());
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+    }
+
+    @Test
+    void shouldThrow500IfNoTruststoreDirSet() {
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.<FileUpload>of(fu));
+        Mockito.when(fu.name()).thenReturn("cert");
+        Mockito.when(env.hasEnv(Mockito.any())).thenReturn(false);
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Test
+    void shouldThrow409IfCertAlreadyExists() {
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.<FileUpload>of(fu));
+        Mockito.when(fu.name()).thenReturn("cert");
+        Mockito.when(fu.fileName()).thenReturn("certificate.cer");
+        Mockito.when(fu.uploadedFileName()).thenReturn("/temp/temp.cer");
+        Mockito.when(fs.pathOf("/temp/temp.cer")).thenReturn(fileUploadPath);
+        Mockito.when(env.hasEnv(Mockito.any())).thenReturn(true);
+        Mockito.when(env.getEnv(Mockito.any())).thenReturn("/truststore");
+        Mockito.when(fs.pathOf("/truststore", "certificate.cer")).thenReturn(truststorePath);
+        Mockito.when(truststorePath.normalize()).thenReturn(truststorePath);
+        Mockito.when(truststorePath.toString()).thenReturn("/truststore/certificate.cer");
+        Mockito.when(fs.exists(Mockito.any())).thenReturn(true);
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(409));
+    }
+
+    @Test
+    void shouldThrow500ifCertIsMalformed() throws Exception {
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.<FileUpload>of(fu));
+        Mockito.when(fu.name()).thenReturn("cert");
+        Mockito.when(fu.fileName()).thenReturn("certificate.cer");
+        Mockito.when(fu.uploadedFileName()).thenReturn("/temp/temp.cer");
+        Mockito.when(fs.pathOf("/temp/temp.cer")).thenReturn(fileUploadPath);
+        Mockito.when(env.hasEnv(Mockito.any())).thenReturn(true);
+        Mockito.when(env.getEnv(Mockito.any())).thenReturn("/truststore");
+        Mockito.when(fs.pathOf("/truststore", "certificate.cer")).thenReturn(truststorePath);
+        Mockito.when(truststorePath.normalize()).thenReturn(truststorePath);
+        Mockito.when(truststorePath.toString()).thenReturn("/truststore/certificate.cer");
+        Mockito.when(fs.pathOf("/truststore/certificate.cer")).thenReturn(truststorePath);
+        Mockito.when(fs.exists(Mockito.any())).thenReturn(false);
+
+        InputStream instream = new ByteArrayInputStream("not a certificate".getBytes());
+        Mockito.when(fs.newInputStream(fileUploadPath)).thenReturn(instream);
+        Mockito.when(certValidator.verify(Mockito.any())).thenThrow(new CertificateException("parsing error"));
+
+        HttpStatusException ex =
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Test
+    void shouldAddCertToTruststore() throws Exception {
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.<FileUpload>of(fu));
+        Mockito.when(fu.name()).thenReturn("cert");
+        Mockito.when(fu.fileName()).thenReturn("certificate.cer");
+        Mockito.when(fu.uploadedFileName()).thenReturn("/temp/temp.cer");
+        Mockito.when(fs.pathOf("/temp/temp.cer")).thenReturn(fileUploadPath);
+        Mockito.when(env.hasEnv(Mockito.any())).thenReturn(true);
+        Mockito.when(env.getEnv(Mockito.any())).thenReturn("/truststore");
+        Mockito.when(fs.pathOf("/truststore", "certificate.cer")).thenReturn(truststorePath);
+        Mockito.when(truststorePath.normalize()).thenReturn(truststorePath);
+        Mockito.when(truststorePath.toString()).thenReturn("/truststore/certificate.cer");
+        Mockito.when(fs.pathOf("/truststore/certificate.cer")).thenReturn(truststorePath);
+        Mockito.when(fs.exists(Mockito.any())).thenReturn(false);
+
+        InputStream instream = new ByteArrayInputStream("not a certificate".getBytes());
+        Mockito.when(fs.newInputStream(fileUploadPath)).thenReturn(instream);
+        Mockito.when(certValidator.verify(Mockito.any())).thenReturn(cert);
+        Mockito.when(cert.getEncoded()).thenReturn("the cert".getBytes());
+
+        HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(ctx.response()).thenReturn(resp);
+
+        handler.handleAuthenticated(ctx);
+
+        Mockito.verify(outStream).write("the cert".getBytes());
+        Mockito.verify(resp).end("Saved: /truststore/certificate.cer");
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -146,7 +146,7 @@ class CertificatePostHandlerTest {
     }
 
     @Test
-    void shouldThrow500ifCertIsMalformed() throws Exception {
+    void shouldThrowExceptionIfCertIsMalformed() throws Exception {
         Mockito.when(ctx.fileUploads()).thenReturn(Set.<FileUpload>of(fu));
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(fu.fileName()).thenReturn("certificate.cer");
@@ -163,10 +163,10 @@ class CertificatePostHandlerTest {
         Mockito.when(certValidator.parseCertificate(Mockito.any()))
                 .thenThrow(new CertificateException("parsing error"));
 
-        HttpStatusException ex =
+        CertificateException ex =
                 Assertions.assertThrows(
-                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
-        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+                        CertificateException.class, () -> handler.handleAuthenticated(ctx));
+        MatcherAssert.assertThat(ex.getMessage(), Matchers.equalTo("parsing error"));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -162,7 +162,8 @@ class CertificatePostHandlerTest {
 
         InputStream instream = new ByteArrayInputStream("not a certificate".getBytes());
         Mockito.when(fs.newInputStream(fileUploadPath)).thenReturn(instream);
-        Mockito.when(certValidator.verify(Mockito.any())).thenThrow(new CertificateException("parsing error"));
+        Mockito.when(certValidator.verify(Mockito.any()))
+                .thenThrow(new CertificateException("parsing error"));
 
         HttpStatusException ex =
                 Assertions.assertThrows(

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -156,13 +156,11 @@ class CertificatePostHandlerTest {
         Mockito.when(env.getEnv(Mockito.any())).thenReturn("/truststore");
         Mockito.when(fs.pathOf("/truststore", "certificate.cer")).thenReturn(truststorePath);
         Mockito.when(truststorePath.normalize()).thenReturn(truststorePath);
-        Mockito.when(truststorePath.toString()).thenReturn("/truststore/certificate.cer");
-        Mockito.when(fs.pathOf("/truststore/certificate.cer")).thenReturn(truststorePath);
         Mockito.when(fs.exists(Mockito.any())).thenReturn(false);
 
         InputStream instream = new ByteArrayInputStream("not a certificate".getBytes());
         Mockito.when(fs.newInputStream(fileUploadPath)).thenReturn(instream);
-        Mockito.when(certValidator.verify(Mockito.any()))
+        Mockito.when(certValidator.parseCertificate(Mockito.any()))
                 .thenThrow(new CertificateException("parsing error"));
 
         HttpStatusException ex =
@@ -183,12 +181,11 @@ class CertificatePostHandlerTest {
         Mockito.when(fs.pathOf("/truststore", "certificate.cer")).thenReturn(truststorePath);
         Mockito.when(truststorePath.normalize()).thenReturn(truststorePath);
         Mockito.when(truststorePath.toString()).thenReturn("/truststore/certificate.cer");
-        Mockito.when(fs.pathOf("/truststore/certificate.cer")).thenReturn(truststorePath);
         Mockito.when(fs.exists(Mockito.any())).thenReturn(false);
 
         InputStream instream = new ByteArrayInputStream("not a certificate".getBytes());
         Mockito.when(fs.newInputStream(fileUploadPath)).thenReturn(instream);
-        Mockito.when(certValidator.verify(Mockito.any())).thenReturn(cert);
+        Mockito.when(certValidator.parseCertificate(Mockito.any())).thenReturn(cert);
         Mockito.when(cert.getEncoded()).thenReturn("the cert".getBytes());
 
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -47,7 +47,9 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Set;
 
 import org.hamcrest.MatcherAssert;
@@ -87,6 +89,8 @@ class CertificatePostHandlerTest {
     @Mock Path truststorePath;
     @Mock Path fileUploadPath;
     @Mock CertificateValidator certValidator;
+    @Mock Collection certificates;
+    @Mock Iterator iterator;
     @Mock Certificate cert;
 
     @BeforeEach
@@ -183,17 +187,20 @@ class CertificatePostHandlerTest {
         Mockito.when(truststorePath.toString()).thenReturn("/truststore/certificate.cer");
         Mockito.when(fs.exists(Mockito.any())).thenReturn(false);
 
-        InputStream instream = new ByteArrayInputStream("not a certificate".getBytes());
+        InputStream instream = new ByteArrayInputStream("certificate".getBytes());
         Mockito.when(fs.newInputStream(fileUploadPath)).thenReturn(instream);
-        Mockito.when(certValidator.parseCertificate(Mockito.any())).thenReturn(cert);
-        Mockito.when(cert.getEncoded()).thenReturn("the cert".getBytes());
+        Mockito.when(certValidator.parseCertificate(Mockito.any())).thenReturn(certificates);
+        Mockito.when(certificates.iterator()).thenReturn(iterator);
+        Mockito.when(iterator.hasNext()).thenReturn(true).thenReturn(false);
+        Mockito.when(iterator.next()).thenReturn(cert);
+        Mockito.when(cert.getEncoded()).thenReturn("certificate".getBytes());
 
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
         Mockito.when(ctx.response()).thenReturn(resp);
 
         handler.handleAuthenticated(ctx);
 
-        Mockito.verify(outStream).write("the cert".getBytes());
+        Mockito.verify(outStream).write("certificate".getBytes());
         Mockito.verify(resp).end("Saved: /truststore/certificate.cer");
     }
 }


### PR DESCRIPTION
Fixes #273 
A few things that may need attention:
* The status code 409 for certificate already exists (not sure if that is the most appropriate)
* I am not sure if the fact that a restart of the JVM is needed should be communicated anywhere (I guess it would be added to the docs and in the future web UI)
* When uploading the certificate, it is in a form with the name cert (it checks for this). This might not be the best name or even the most appropriate way to send it. (current curl command is `curl -X POST -F cert=@PATH/vertx-fib-demo.cer -vk https://localhost:8181/api/v2/certificates`)