### PR TITLE
Discover Kube targets by Endpoints, not Services

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeApiPlatformClient.java
@@ -41,6 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.platform.internal;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -48,68 +49,51 @@ import java.util.stream.Collectors;
 
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnectionToolkit;
-import com.redhat.rhjmc.containerjfr.net.NetworkResolver;
 import com.redhat.rhjmc.containerjfr.platform.PlatformClient;
 import com.redhat.rhjmc.containerjfr.platform.ServiceRef;
 
 import dagger.Lazy;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.apis.CoreV1Api;
-import io.kubernetes.client.models.V1Service;
+import io.kubernetes.client.models.V1EndpointPort;
+import io.kubernetes.client.models.V1EndpointSubset;
 
 class KubeApiPlatformClient implements PlatformClient {
 
     private final CoreV1Api api;
     private final String namespace;
     private final Lazy<JFRConnectionToolkit> connectionToolkit;
-    private final NetworkResolver resolver;
     private final Logger logger;
 
     KubeApiPlatformClient(
             CoreV1Api api,
             String namespace,
             Lazy<JFRConnectionToolkit> connectionToolkit,
-            NetworkResolver resolver,
             Logger logger) {
         this.api = api;
         this.namespace = namespace;
         this.connectionToolkit = connectionToolkit;
-        this.resolver = resolver;
         this.logger = logger;
     }
 
     @Override
     public List<ServiceRef> listDiscoverableServices() {
         try {
-            return api
-                    .listNamespacedService(
+            List<ServiceRef> refs = new ArrayList<>();
+            api
+                    .listNamespacedEndpoints(
                             namespace, null, null, null, null, null, null, null, null, null)
                     .getItems().stream()
-                    .map(V1Service::getSpec)
-                    .peek(spec -> logger.trace("Service spec: " + spec.toString()))
-                    .filter(s -> s.getPorts() != null)
-                    .flatMap(
+                    .flatMap(l -> l.getSubsets().stream())
+                    .forEach(
                             s ->
                                     s.getPorts().stream()
-                                            .map(
-                                                    p -> {
-                                                        try {
-                                                            return new ServiceRef(
-                                                                    connectionToolkit.get(),
-                                                                    s.getClusterIP(),
-                                                                    p.getPort(),
-                                                                    resolver
-                                                                            .resolveCanonicalHostName(
-                                                                                    s
-                                                                                            .getClusterIP()));
-                                                        } catch (Exception e) {
-                                                            logger.warn(e);
-                                                            return null;
-                                                        }
-                                                    }))
-                    .parallel()
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
+                                            .filter(this::isCompatiblePort)
+                                            .forEach(
+                                                    port -> {
+                                                        refs.addAll(createServiceRefs(s, port));
+                                                    }));
+            return refs;
         } catch (ApiException e) {
             logger.warn(e.getMessage());
             logger.warn(e.getResponseBody());
@@ -118,5 +102,28 @@ class KubeApiPlatformClient implements PlatformClient {
             logger.warn(e);
             return Collections.emptyList();
         }
+    }
+
+    private boolean isCompatiblePort(V1EndpointPort port) {
+        return "jfr-jmx".equals(port.getName()) || 9091 == port.getPort();
+    }
+
+    private List<ServiceRef> createServiceRefs(V1EndpointSubset subset, V1EndpointPort port) {
+        return subset.getAddresses().stream()
+                .map(
+                        addr -> {
+                            try {
+                                return new ServiceRef(
+                                        connectionToolkit.get(),
+                                        addr.getIp(),
+                                        port.getPort(),
+                                        addr.getTargetRef().getName());
+                            } catch (Exception e) {
+                                logger.warn(e);
+                                return null;
+                            }
+                        })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeApiPlatformStrategy.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeApiPlatformStrategy.java
@@ -48,7 +48,6 @@ import java.nio.file.Paths;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnectionToolkit;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
-import com.redhat.rhjmc.containerjfr.net.NetworkResolver;
 import com.redhat.rhjmc.containerjfr.net.NoopAuthManager;
 
 import dagger.Lazy;
@@ -65,13 +64,9 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
     private CoreV1Api api;
     private final String namespace;
     private final Lazy<JFRConnectionToolkit> connectionToolkit;
-    private final NetworkResolver resolver;
 
     KubeApiPlatformStrategy(
-            Logger logger,
-            NoopAuthManager authMgr,
-            Lazy<JFRConnectionToolkit> connectionToolkit,
-            NetworkResolver resolver) {
+            Logger logger, NoopAuthManager authMgr, Lazy<JFRConnectionToolkit> connectionToolkit) {
         this.logger = logger;
         this.authMgr = authMgr;
         try {
@@ -82,7 +77,6 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
         }
         this.connectionToolkit = connectionToolkit;
         this.namespace = getNamespace();
-        this.resolver = resolver;
     }
 
     @Override
@@ -109,7 +103,7 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
     @Override
     public KubeApiPlatformClient getPlatformClient() {
         logger.info("Selected KubeApi Platform Strategy");
-        return new KubeApiPlatformClient(api, namespace, connectionToolkit, resolver, logger);
+        return new KubeApiPlatformClient(api, namespace, connectionToolkit, logger);
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/PlatformStrategyModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/PlatformStrategyModule.java
@@ -75,7 +75,7 @@ public abstract class PlatformStrategyModule {
         return Set.of(
                 new OpenShiftPlatformStrategy(
                         logger, openShiftAuthManager, connectionToolkit, env, fs),
-                new KubeApiPlatformStrategy(logger, noopAuthManager, connectionToolkit, resolver),
+                new KubeApiPlatformStrategy(logger, noopAuthManager, connectionToolkit),
                 new KubeEnvPlatformStrategy(logger, noopAuthManager, connectionToolkit, env),
                 new DefaultPlatformStrategy(logger, noopAuthManager, discoveryClient));
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformClient.java
@@ -99,7 +99,7 @@ class OpenShiftPlatformClient implements PlatformClient {
                                                                             subset, port))));
             return refs;
         } catch (Exception e) {
-            logger.error(e);
+            logger.warn(e);
             return Collections.emptyList();
         }
     }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeApiPlatformClientTest.java
@@ -45,7 +45,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.net.MalformedURLException;
@@ -53,26 +52,30 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.management.remote.JMXServiceURL;
+
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnectionToolkit;
-import com.redhat.rhjmc.containerjfr.net.NetworkResolver;
 import com.redhat.rhjmc.containerjfr.platform.ServiceRef;
 
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.apis.CoreV1Api;
-import io.kubernetes.client.models.V1Service;
-import io.kubernetes.client.models.V1ServiceList;
-import io.kubernetes.client.models.V1ServicePort;
-import io.kubernetes.client.models.V1ServiceSpec;
+import io.kubernetes.client.models.V1EndpointAddress;
+import io.kubernetes.client.models.V1EndpointPort;
+import io.kubernetes.client.models.V1EndpointSubset;
+import io.kubernetes.client.models.V1Endpoints;
+import io.kubernetes.client.models.V1EndpointsList;
+import io.kubernetes.client.models.V1ObjectReference;
 
 @ExtendWith(MockitoExtension.class)
 class KubeApiPlatformClientTest {
@@ -81,161 +84,111 @@ class KubeApiPlatformClientTest {
     @Mock CoreV1Api api;
     String namespace = "someNamespace";
     @Mock JFRConnectionToolkit connectionToolkit;
-    @Mock NetworkResolver resolver;
     @Mock Logger logger;
 
     @BeforeEach
     void setup() {
-        client =
-                new KubeApiPlatformClient(
-                        api, namespace, () -> connectionToolkit, resolver, logger);
+        client = new KubeApiPlatformClient(api, namespace, () -> connectionToolkit, logger);
     }
 
-    @Nested
-    class DiscoverableServicesTests {
+    @Test
+    void discoversNoServicesIfApiThrows() throws ApiException {
+        when(api.listNamespacedEndpoints(
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any()))
+                .thenThrow(ApiException.class);
 
-        @Test
-        void discoversNoServicesIfApiThrows() throws ApiException {
-            when(api.listNamespacedService(
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any()))
-                    .thenThrow(ApiException.class);
+        assertThat(client.listDiscoverableServices(), Matchers.empty());
 
-            assertThat(client.listDiscoverableServices(), Matchers.empty());
+        verify(api)
+                .listNamespacedEndpoints(
+                        namespace, null, null, null, null, null, null, null, null, null);
+        verifyNoMoreInteractions(api);
+    }
 
-            verify(api)
-                    .listNamespacedService(
-                            namespace, null, null, null, null, null, null, null, null, null);
-            verifyNoMoreInteractions(api);
-            verifyZeroInteractions(resolver);
-        }
+    @Test
+    void discoversServices() throws ApiException, UnknownHostException, MalformedURLException {
+        V1EndpointsList mockServiceList = mock(V1EndpointsList.class);
 
-        @Test
-        void discoversAndResolvesServices()
-                throws ApiException, UnknownHostException, MalformedURLException {
-            V1ServiceList mockServiceList = mock(V1ServiceList.class);
+        V1Endpoints mockServiceA = mock(V1Endpoints.class);
+        V1EndpointAddress aAddr = mock(V1EndpointAddress.class);
+        when(aAddr.getIp()).thenReturn("127.0.0.1");
+        V1ObjectReference aRef = mock(V1ObjectReference.class);
+        when(aRef.getName()).thenReturn("ServiceA.local");
+        when(aAddr.getTargetRef()).thenReturn(aRef);
+        V1EndpointSubset aSubset = mock(V1EndpointSubset.class);
+        when(aSubset.getAddresses()).thenReturn(List.of(aAddr));
+        when(mockServiceA.getSubsets()).thenReturn(List.of(aSubset));
+        V1EndpointPort aPort1 = mock(V1EndpointPort.class);
+        when(aPort1.getName()).thenReturn("jfr-jmx");
+        when(aPort1.getPort()).thenReturn(123);
+        V1EndpointPort aPort2 = mock(V1EndpointPort.class);
+        when(aPort2.getName()).thenReturn("port-name");
+        when(aPort2.getPort()).thenReturn(456);
+        when(aSubset.getPorts()).thenReturn(List.of(aPort1, aPort2));
 
-            V1Service mockServiceA = mock(V1Service.class);
-            V1ServiceSpec aSpec = mock(V1ServiceSpec.class);
-            when(aSpec.getClusterIP()).thenReturn("127.0.0.1");
-            when(mockServiceA.getSpec()).thenReturn(aSpec);
-            V1ServicePort aPort1 = mock(V1ServicePort.class);
-            when(aPort1.getPort()).thenReturn(123);
-            V1ServicePort aPort2 = mock(V1ServicePort.class);
-            when(aPort2.getPort()).thenReturn(456);
-            when(aSpec.getPorts()).thenReturn(Arrays.asList(aPort1, aPort2));
+        V1Endpoints mockServiceB = mock(V1Endpoints.class);
+        V1EndpointAddress bAddr = mock(V1EndpointAddress.class);
+        when(bAddr.getIp()).thenReturn("10.0.0.1");
+        V1ObjectReference bRef = mock(V1ObjectReference.class);
+        when(bRef.getName()).thenReturn("b-service.example.com");
+        when(bAddr.getTargetRef()).thenReturn(bRef);
+        V1EndpointSubset bSubset = mock(V1EndpointSubset.class);
+        when(bSubset.getAddresses()).thenReturn(List.of(bAddr));
+        when(mockServiceB.getSubsets()).thenReturn(List.of(bSubset));
+        V1EndpointPort bPort1 = mock(V1EndpointPort.class);
+        when(bPort1.getName()).thenReturn("jfr-jmx");
+        when(bPort1.getPort()).thenReturn(7899);
+        when(bSubset.getPorts()).thenReturn(List.of(bPort1));
 
-            V1Service mockServiceB = mock(V1Service.class);
-            V1ServiceSpec bSpec = mock(V1ServiceSpec.class);
-            when(bSpec.getClusterIP()).thenReturn("10.0.0.1");
-            when(mockServiceB.getSpec()).thenReturn(bSpec);
-            V1ServicePort bPort = mock(V1ServicePort.class);
-            when(bPort.getPort()).thenReturn(7899);
-            when(bSpec.getPorts()).thenReturn(Arrays.asList(bPort));
+        when(mockServiceList.getItems()).thenReturn(Arrays.asList(mockServiceA, mockServiceB));
+        when(api.listNamespacedEndpoints(
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any()))
+                .thenReturn(mockServiceList);
 
-            when(mockServiceList.getItems()).thenReturn(Arrays.asList(mockServiceA, mockServiceB));
-            when(api.listNamespacedService(
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any()))
-                    .thenReturn(mockServiceList);
-            when(resolver.resolveCanonicalHostName("127.0.0.1")).thenReturn("ServiceA.local");
-            when(resolver.resolveCanonicalHostName("10.0.0.1")).thenReturn("b-service.example.com");
+        when(connectionToolkit.createServiceURL(Mockito.anyString(), Mockito.anyInt()))
+                .thenAnswer(
+                        new Answer<>() {
+                            @Override
+                            public JMXServiceURL answer(InvocationOnMock args) throws Throwable {
+                                String host = args.getArgument(0);
+                                int port = args.getArgument(1);
+                                return new JMXServiceURL(
+                                        "rmi",
+                                        "",
+                                        0,
+                                        "/jndi/rmi://" + host + ":" + port + "/jmxrmi");
+                            }
+                        });
 
-            List<ServiceRef> result = client.listDiscoverableServices();
+        List<ServiceRef> result = client.listDiscoverableServices();
 
-            ServiceRef serv1 =
-                    new ServiceRef(connectionToolkit, "127.0.0.1", 123, "ServiceA.local");
-            ServiceRef serv2 =
-                    new ServiceRef(connectionToolkit, "127.0.0.1", 456, "ServiceA.local");
-            ServiceRef serv3 =
-                    new ServiceRef(connectionToolkit, "10.0.0.1", 7899, "b-service.example.com");
+        ServiceRef serv1 = new ServiceRef(connectionToolkit, "127.0.0.1", 123, "ServiceA.local");
+        ServiceRef serv2 =
+                new ServiceRef(connectionToolkit, "10.0.0.1", 7899, "b-service.example.com");
 
-            assertThat(result, Matchers.contains(serv1, serv2, serv3));
+        assertThat(result, Matchers.equalTo(List.of(serv1, serv2)));
 
-            assertThat(result, Matchers.hasSize(3));
-
-            verify(resolver, Mockito.times(2)).resolveCanonicalHostName("127.0.0.1");
-            verify(resolver).resolveCanonicalHostName("10.0.0.1");
-            verifyNoMoreInteractions(resolver);
-            verify(api)
-                    .listNamespacedService(
-                            namespace, null, null, null, null, null, null, null, null, null);
-            verifyNoMoreInteractions(api);
-        }
-
-        @Test
-        void ignoresUnresolveableServices()
-                throws ApiException, UnknownHostException, MalformedURLException {
-            V1ServiceList mockServiceList = mock(V1ServiceList.class);
-
-            V1Service mockServiceA = mock(V1Service.class);
-            V1ServiceSpec aSpec = mock(V1ServiceSpec.class);
-            when(aSpec.getClusterIP()).thenReturn("127.0.0.1");
-            when(mockServiceA.getSpec()).thenReturn(aSpec);
-            V1ServicePort aPort1 = mock(V1ServicePort.class);
-            when(aPort1.getPort()).thenReturn(123);
-            V1ServicePort aPort2 = mock(V1ServicePort.class);
-            when(aPort2.getPort()).thenReturn(456);
-            when(aSpec.getPorts()).thenReturn(Arrays.asList(aPort1, aPort2));
-
-            V1Service mockServiceB = mock(V1Service.class);
-            V1ServiceSpec bSpec = mock(V1ServiceSpec.class);
-            when(bSpec.getClusterIP()).thenReturn("10.0.0.1");
-            when(mockServiceB.getSpec()).thenReturn(bSpec);
-            V1ServicePort bPort = mock(V1ServicePort.class);
-            when(bPort.getPort()).thenReturn(7899);
-            when(bSpec.getPorts()).thenReturn(Arrays.asList(bPort));
-
-            when(mockServiceList.getItems()).thenReturn(Arrays.asList(mockServiceA, mockServiceB));
-            when(api.listNamespacedService(
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any(),
-                            Mockito.any()))
-                    .thenReturn(mockServiceList);
-            when(resolver.resolveCanonicalHostName("127.0.0.1")).thenReturn("ServiceA.local");
-            when(resolver.resolveCanonicalHostName("10.0.0.1"))
-                    .thenThrow(UnknownHostException.class);
-
-            List<ServiceRef> result = client.listDiscoverableServices();
-
-            ServiceRef serv1 =
-                    new ServiceRef(connectionToolkit, "127.0.0.1", 123, "ServiceA.local");
-            ServiceRef serv2 =
-                    new ServiceRef(connectionToolkit, "127.0.0.1", 456, "ServiceA.local");
-
-            assertThat(result, Matchers.contains(serv1, serv2));
-            assertThat(result, Matchers.hasSize(2));
-
-            verify(resolver, Mockito.times(2)).resolveCanonicalHostName("127.0.0.1");
-            verify(resolver).resolveCanonicalHostName("10.0.0.1");
-            verifyNoMoreInteractions(resolver);
-            verify(api)
-                    .listNamespacedService(
-                            namespace, null, null, null, null, null, null, null, null, null);
-            verifyNoMoreInteractions(api);
-        }
+        verify(api)
+                .listNamespacedEndpoints(
+                        namespace, null, null, null, null, null, null, null, null, null);
+        verifyNoMoreInteractions(api);
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformClientTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformClientTest.java
@@ -48,6 +48,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import javax.management.remote.JMXServiceURL;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,7 +58,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnectionToolkit;
@@ -174,6 +178,21 @@ class OpenShiftPlatformClientTest {
         Mockito.when(endpoint.getSubsets()).thenReturn(Arrays.asList(subset1, subset2, subset3));
 
         Mockito.when(mockListable.getItems()).thenReturn(Collections.singletonList(endpoint));
+
+        Mockito.when(connectionToolkit.createServiceURL(Mockito.anyString(), Mockito.anyInt()))
+                .thenAnswer(
+                        new Answer<>() {
+                            @Override
+                            public JMXServiceURL answer(InvocationOnMock args) throws Throwable {
+                                String host = args.getArgument(0);
+                                int port = args.getArgument(1);
+                                return new JMXServiceURL(
+                                        "rmi",
+                                        "",
+                                        0,
+                                        "/jndi/rmi://" + host + ":" + port + "/jmxrmi");
+                            }
+                        });
 
         List<ServiceRef> result = platformClient.listDiscoverableServices();
         ServiceRef serv1 =


### PR DESCRIPTION
Fixes #282

This basically duplicates the existing `OpenShiftPlatformClient` implementation for reuse as the `KubeApiPlatformClient`. These use two different client libraries for the internal API clients, which also means different library implementations for the various Kubernetes types (Endpoints, Subsets, Ports, etc.). So although these types model the same Kubernetes datatypes, the types themselves are distinct hierarchies, and so the final concrete `PlatformClient` implementations are also distinct and do not inherit from each other (unfortunately).

This can be tested by setting the `CONTAINER_JFR_PLATFORM` env var to force the `KubeApiPlatformClient` into use and then running as usual in CRC. This should result in essentially no noticeable difference from running with the standard `OpenShiftPlatformClient`. Compared to the previous `KubeApiPlatformClient` implementation, only ports named `jfr-jmx` or numbered `9091` should cause `ServiceRef`s to be listed in the targets list. If a single `Service` has more than one such port, or if there are multiple `Pod`s (each distinguished by cluster-internal IP address) behind the `Service`, then there should be near-duplicate `ServiceRef`s for each of these, differentiated by port number or by IP address.