### PR TITLE
Respond 502 when target SSL untrusted

### DIFF
--- a/HTTP_API.md
+++ b/HTTP_API.md
@@ -475,10 +475,6 @@
     `501` - The Grafana datasource URL is malformed.
     The body is an error message.
 
-    `502` - Container JFR received an invalid response from the
-    Grafana datasource server after sending the upload request.
-    The body is an error message.
-
     ###### example
     ```
     $ curl -X POST localhost:8181/api/v1/recordings/localhost_foo_20200911T144545Z.jfr/upload
@@ -553,6 +549,10 @@
 
     `500` - There was an unexpected error. The body is an error message.
 
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
+
     ###### example
     ```
     $ curl localhost:8181/api/v1/targets/localhost/events --output events
@@ -595,6 +595,10 @@
 
     `500` - There was an unexpected error. The body is an error message.
 
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
+
     ###### example
     ```
     $ curl -X DELETE localhost:8181/api/v1/targets/localhost/recordings/foo
@@ -633,6 +637,10 @@
     `500` - The recording was found but it could not be written to the
     response. Or there was an unexpected error. The body is an error message.
 
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
+
     ###### example
     ```
     $ curl localhost:8181/api/v1/targets/localhost/recordings/foo --output foo.jfr
@@ -667,6 +675,10 @@
     the authentication scheme that is used.
 
     `500` - There was an unexpected error. The body is an error message.
+
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
 
     ###### example
     ```
@@ -718,6 +730,10 @@
     the authentication scheme that is used.
 
     `500` - There was an unexpected error. The body is an error message.
+
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
 
     ###### example
     ```
@@ -771,6 +787,10 @@
 
     `500` - There was an unexpected error. The body is an error message.
 
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
+
     **STOP**
 
     `200` - No body.
@@ -821,6 +841,10 @@
     the authentication scheme that is used.
 
     `500` - There was an unexpected error. The body is an error message.
+
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
 
     ###### example
     ```
@@ -889,6 +913,10 @@
 
     `500` - There was an unexpected error. The body is an error message.
 
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
+
     ###### example
     ```
     $ curl --data "recordingName=foo&duration=5&events=template=ALL" localhost:8181/api/v1/targets/localhost/recordings
@@ -937,6 +965,10 @@
     Grafana datasource after sending the upload request.
     The body is an error message.
 
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
+
     ###### example
     ```
     $ curl -X POST localhost:8181/api/v1/targets/localhost/recordings/foo/upload
@@ -976,6 +1008,10 @@
 
     `500` - There was an unexpected error. The body is an error message.
 
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
+
     ###### example
     ```
     $ curl localhost:8181/api/v1/targets/localhost/reports/foo --output report.html
@@ -1013,6 +1049,10 @@
     the authentication scheme that is used.
 
     `500` - There was an unexpected error. The body is an error message.
+
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
 
     ###### example
     ```
@@ -1053,6 +1093,10 @@
 
     `500` - There was an unexpected error. The body is an error message.
 
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
+
     ###### example
     ```
     $ curl localhost:8181/api/v1/targets/localhost/templates/Profiling/type/TARGET --output Continuous.jfc
@@ -1091,6 +1135,10 @@
     the authentication scheme that is used.
 
     `500` - There was an unexpected error. The body is an error message.
+
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
 
     ###### example
     ```
@@ -1211,6 +1259,10 @@
     the authentication scheme that is used.
 
     `500` - There was an unexpected error. The body is an error message.
+
+    `502` - JMX connection failed. This is generally because the target
+    application has SSL enabled over JMX, but ContainerJFR does not trust the
+    certificate.
 
     ###### example
     ```

--- a/HTTP_API.md
+++ b/HTTP_API.md
@@ -963,11 +963,9 @@
 
     `502` - Container JFR received an invalid response from the
     Grafana datasource after sending the upload request.
-    The body is an error message.
-
-    `502` - JMX connection failed. This is generally because the target
-    application has SSL enabled over JMX, but ContainerJFR does not trust the
-    certificate.
+    The body is an error message. Or, the JMX connection failed. This is
+    generally because the target application has SSL enabled over JMX, but
+    ContainerJFR does not trust the certificate.
 
     ###### example
     ```


### PR DESCRIPTION
Respond with status code 502 and message "Target SSL Untrusted" when attempting a target connection fails for what appears to be an SSL trust issue

Fixes #307

This can be tested by running `smoketest.sh`. Normally, the `truststore` directory should contain the `vertx-fib-demo.cer` copied from that project's repo, and this allows ContainerJFR to connect to the demo application when running in the smoketest. By removing the `.cer` from the truststore (ex. simply `mv truststore/vertx-fib-demo.cer .`) and re-running `sh smoketest.sh` an SSL trust failure can be easily triggered. Before this patch the response is a standard HTTP 404. After this patch the response is a 502 with the custom message "Target SSL Untrusted". This can be seen in the web-client notifications as well as with standard tooling such as curl.