### PR TITLE
Add timeouthandler

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/generic/CorsEnablingHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/generic/CorsEnablingHandler.java
@@ -84,7 +84,7 @@ class CorsEnablingHandler implements RequestHandler {
 
     @Override
     public int getPriority() {
-        return 0;
+        return 1;
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/generic/TimeoutHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/generic/TimeoutHandler.java
@@ -83,5 +83,4 @@ class TimeoutHandler implements RequestHandler {
     public void handle(RoutingContext ctx) {
         handler.handle(ctx);
     }
-
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/generic/TimeoutHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/generic/TimeoutHandler.java
@@ -51,7 +51,7 @@ import io.vertx.ext.web.RoutingContext;
 
 class TimeoutHandler implements RequestHandler {
 
-    static final long TIMEOUT_MS = 15_000;
+    static final long TIMEOUT_MS = 15_000L;
     final io.vertx.ext.web.handler.TimeoutHandler handler;
 
     @Inject

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/generic/TimeoutHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/generic/TimeoutHandler.java
@@ -41,36 +41,47 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.http.generic;
 
+import javax.inject.Inject;
+
 import com.redhat.rhjmc.containerjfr.net.web.http.RequestHandler;
+import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiVersion;
 
-import dagger.Binds;
-import dagger.Module;
-import dagger.multibindings.IntoSet;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
 
-@Module
-public abstract class HttpGenericModule {
+class TimeoutHandler implements RequestHandler {
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTimeoutHandler(TimeoutHandler handler);
+    static final long TIMEOUT_MS = 15_000;
+    final io.vertx.ext.web.handler.TimeoutHandler handler;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindCorsEnablingHandler(CorsEnablingHandler handler);
+    @Inject
+    TimeoutHandler() {
+        this.handler = io.vertx.ext.web.handler.TimeoutHandler.create(TIMEOUT_MS);
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindCorsOptionsHandler(CorsOptionsHandler handler);
+    @Override
+    public int getPriority() {
+        return 0;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindHealthGetHandler(HealthGetHandler handler);
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.GENERIC;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindStaticAssetsGetHandler(StaticAssetsGetHandler handler);
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.OTHER;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindWebClientAssetsGetHandler(WebClientAssetsGetHandler handler);
+    @Override
+    public String path() {
+        return ALL_PATHS;
+    }
+
+    @Override
+    public void handle(RoutingContext ctx) {
+        handler.handle(ctx);
+    }
+
 }


### PR DESCRIPTION
Wraps around Vert.x TimeoutHandler implementation to write a 500 response if a request is not completed by another handler within 15 seconds

Fixes #288

Easy ways to test: modify the `15_000` constant in the patch to a shorter period, like `500`, and then do some operation like generating a report. Or, build a minimal image and try to request a web-client asset.