### PR TITLE
fix difference in truststore env var name

### DIFF
--- a/HTTP_API.md
+++ b/HTTP_API.md
@@ -1271,7 +1271,7 @@
 
     `409` - A certificate with the same filename already exists in the truststore directory. The body includes the path where the file already exists.
 
-    `500` - The `TRUSTSTORE_DIR` environment variable is not set, or there is an unexpected error. The body is an error message.
+    `500` - The `SSL_TRUSTSTORE_DIR` environment variable is not set, or there is an unexpected error. The body is an error message.
 
     ###### example
     ```

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
@@ -75,7 +75,7 @@ class CertificatePostHandler extends AbstractAuthenticatedRequestHandler {
     private final FileSystem fs;
     private final Logger logger;
 
-    private static final String TRUSTSTORE_DIR = "TRUSTSTORE_DIR";
+    private static final String TRUSTSTORE_DIR = "SSL_TRUSTSTORE_DIR";
 
     private Function<File, FileOutputStream> outputStreamFunction;
     private CertificateValidator certValidator;


### PR DESCRIPTION
Not sure when it was changed, but the name of the env var for the ssl truststore was changed in entrypoint, and was not updated in the certificatePostHandler.