### PR TITLE
Async JDP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
   <com.google.dagger.version>2.26</com.google.dagger.version>
 
-  <com.redhat.rhjmc.containerjfr.core.version>0.16.0</com.redhat.rhjmc.containerjfr.core.version>
+  <com.redhat.rhjmc.containerjfr.core.version>0.17.0</com.redhat.rhjmc.containerjfr.core.version>
 
   <org.apache.commons.lang3.version>3.9</org.apache.commons.lang3.version>
   <org.apache.commons.codec.version>1.13</org.apache.commons.codec.version>

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/PlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/PlatformClient.java
@@ -44,5 +44,9 @@ package com.redhat.rhjmc.containerjfr.platform;
 import java.util.List;
 
 public interface PlatformClient {
+    static final String NOTIFICATION_CATEGORY = "TargetJvmDiscovery";
+
+    void start();
+
     List<ServiceRef> listDiscoverableServices();
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/PlatformModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/PlatformModule.java
@@ -119,12 +119,15 @@ public abstract class PlatformModule {
             throw new RuntimeException(
                     String.format("Selected PlatformDetectionStrategy \"%s\" not found", platform));
         }
-        return strategies.stream()
-                // reverse sort, higher priorities should be earlier in the stream
-                .sorted((a, b) -> Integer.compare(b.getPriority(), a.getPriority()))
-                .filter(PlatformDetectionStrategy::isAvailable)
-                .findFirst()
-                .orElseThrow();
+        PlatformDetectionStrategy<?> strat =
+                strategies.stream()
+                        // reverse sort, higher priorities should be earlier in the stream
+                        .sorted((a, b) -> Integer.compare(b.getPriority(), a.getPriority()))
+                        .filter(PlatformDetectionStrategy::isAvailable)
+                        .findFirst()
+                        .orElseThrow();
+        strat.getPlatformClient().start();
+        return strat;
     }
 
     @Provides

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/DefaultPlatformStrategy.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/DefaultPlatformStrategy.java
@@ -41,10 +41,9 @@
  */
 package com.redhat.rhjmc.containerjfr.platform.internal;
 
-import java.io.IOException;
-
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.discovery.JvmDiscoveryClient;
+import com.redhat.rhjmc.containerjfr.messaging.notifications.NotificationFactory;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.NoopAuthManager;
 
@@ -53,12 +52,17 @@ class DefaultPlatformStrategy implements PlatformDetectionStrategy<DefaultPlatfo
     private final Logger logger;
     private final NoopAuthManager authMgr;
     private final JvmDiscoveryClient discoveryClient;
+    private final NotificationFactory notificationFactory;
 
     DefaultPlatformStrategy(
-            Logger logger, NoopAuthManager authMgr, JvmDiscoveryClient discoveryClient) {
+            Logger logger,
+            NoopAuthManager authMgr,
+            JvmDiscoveryClient discoveryClient,
+            NotificationFactory notificationFactory) {
         this.logger = logger;
         this.authMgr = authMgr;
         this.discoveryClient = discoveryClient;
+        this.notificationFactory = notificationFactory;
     }
 
     @Override
@@ -74,12 +78,7 @@ class DefaultPlatformStrategy implements PlatformDetectionStrategy<DefaultPlatfo
     @Override
     public DefaultPlatformClient getPlatformClient() {
         logger.info("Selected Default Platform Strategy");
-        try {
-            discoveryClient.start();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return new DefaultPlatformClient(logger, discoveryClient);
+        return new DefaultPlatformClient(logger, discoveryClient, notificationFactory);
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeApiPlatformClient.java
@@ -77,6 +77,9 @@ class KubeApiPlatformClient implements PlatformClient {
     }
 
     @Override
+    public void start() {}
+
+    @Override
     public List<ServiceRef> listDiscoverableServices() {
         try {
             List<ServiceRef> refs = new ArrayList<>();

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeEnvPlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeEnvPlatformClient.java
@@ -71,6 +71,9 @@ class KubeEnvPlatformClient implements PlatformClient {
     }
 
     @Override
+    public void start() {}
+
+    @Override
     public List<ServiceRef> listDiscoverableServices() {
         return env.getEnv().entrySet().stream()
                 .map(this::envToServiceRef)

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/PlatformStrategyModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/PlatformStrategyModule.java
@@ -48,6 +48,7 @@ import com.redhat.rhjmc.containerjfr.core.net.JFRConnectionToolkit;
 import com.redhat.rhjmc.containerjfr.core.net.discovery.JvmDiscoveryClient;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.messaging.notifications.NotificationFactory;
 import com.redhat.rhjmc.containerjfr.net.NetworkResolver;
 import com.redhat.rhjmc.containerjfr.net.NoopAuthManager;
 import com.redhat.rhjmc.containerjfr.platform.openshift.OpenShiftAuthManager;
@@ -71,12 +72,14 @@ public abstract class PlatformStrategyModule {
             NetworkResolver resolver,
             Environment env,
             FileSystem fs,
-            JvmDiscoveryClient discoveryClient) {
+            JvmDiscoveryClient discoveryClient,
+            NotificationFactory notificationFactory) {
         return Set.of(
                 new OpenShiftPlatformStrategy(
                         logger, openShiftAuthManager, connectionToolkit, env, fs),
                 new KubeApiPlatformStrategy(logger, noopAuthManager, connectionToolkit),
                 new KubeEnvPlatformStrategy(logger, noopAuthManager, connectionToolkit, env),
-                new DefaultPlatformStrategy(logger, noopAuthManager, discoveryClient));
+                new DefaultPlatformStrategy(
+                        logger, noopAuthManager, discoveryClient, notificationFactory));
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformClient.java
@@ -83,6 +83,9 @@ class OpenShiftPlatformClient implements PlatformClient {
     }
 
     @Override
+    public void start() {}
+
+    @Override
     public List<ServiceRef> listDiscoverableServices() {
         try {
             List<ServiceRef> refs = new ArrayList<>();

--- a/src/test/java/com/redhat/rhjmc/containerjfr/platform/internal/DefaultPlatformClientTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/platform/internal/DefaultPlatformClientTest.java
@@ -55,6 +55,14 @@ import java.util.Map;
 
 import javax.management.remote.JMXServiceURL;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.discovery.DiscoveredJvmDescriptor;
 import com.redhat.rhjmc.containerjfr.core.net.discovery.JvmDiscoveryClient;
@@ -64,14 +72,6 @@ import com.redhat.rhjmc.containerjfr.messaging.notifications.Notification;
 import com.redhat.rhjmc.containerjfr.messaging.notifications.NotificationFactory;
 import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
 import com.redhat.rhjmc.containerjfr.platform.ServiceRef;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultPlatformClientTest {
@@ -113,7 +113,8 @@ class DefaultPlatformClientTest {
         when(desc3.getMainClass()).thenReturn("com.redhat.containerjfr.ContainerJFR");
         when(desc3.getJmxServiceUrl()).thenReturn(url3);
 
-        when(discoveryClient.getDiscoveredJvmDescriptors()).thenReturn(List.of(desc1, desc2, desc3));
+        when(discoveryClient.getDiscoveredJvmDescriptors())
+                .thenReturn(List.of(desc1, desc2, desc3));
 
         List<ServiceRef> results = client.listDiscoverableServices();
 
@@ -139,7 +140,9 @@ class DefaultPlatformClientTest {
         Notification.Builder builder = mock(Notification.Builder.class);
         lenient().when(builder.meta(Mockito.any())).thenReturn(builder);
         lenient().when(builder.metaCategory(Mockito.any())).thenReturn(builder);
-        lenient().when(builder.metaType(Mockito.any(Notification.MetaType.class))).thenReturn(builder);
+        lenient()
+                .when(builder.metaType(Mockito.any(Notification.MetaType.class)))
+                .thenReturn(builder);
         lenient().when(builder.metaType(Mockito.any(HttpMimeType.class))).thenReturn(builder);
         lenient().when(builder.message(Mockito.any())).thenReturn(builder);
         lenient().when(builder.build()).thenReturn(notification);
@@ -158,10 +161,16 @@ class DefaultPlatformClientTest {
 
         verify(notificationFactory).createBuilder();
         verify(builder).metaCategory("TargetJvmDiscovery");
-        verify(builder).message(Map.of("event", Map.of("kind", EventKind.FOUND, "serviceRef", new
-                        ServiceRef(url, mainClass))));
+        verify(builder)
+                .message(
+                        Map.of(
+                                "event",
+                                Map.of(
+                                        "kind",
+                                        EventKind.FOUND,
+                                        "serviceRef",
+                                        new ServiceRef(url, mainClass))));
         verify(builder).build();
         verify(notification).send();
     }
-
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/platform/internal/DefaultPlatformClientTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/platform/internal/DefaultPlatformClientTest.java
@@ -1,0 +1,167 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.platform.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.Map;
+
+import javax.management.remote.JMXServiceURL;
+
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.net.discovery.DiscoveredJvmDescriptor;
+import com.redhat.rhjmc.containerjfr.core.net.discovery.JvmDiscoveryClient;
+import com.redhat.rhjmc.containerjfr.core.net.discovery.JvmDiscoveryClient.EventKind;
+import com.redhat.rhjmc.containerjfr.core.net.discovery.JvmDiscoveryClient.JvmDiscoveryEvent;
+import com.redhat.rhjmc.containerjfr.messaging.notifications.Notification;
+import com.redhat.rhjmc.containerjfr.messaging.notifications.NotificationFactory;
+import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
+import com.redhat.rhjmc.containerjfr.platform.ServiceRef;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultPlatformClientTest {
+
+    @Mock Logger logger;
+    @Mock JvmDiscoveryClient discoveryClient;
+    @Mock NotificationFactory notificationFactory;
+    DefaultPlatformClient client;
+
+    @BeforeEach
+    void setup() {
+        this.client = new DefaultPlatformClient(logger, discoveryClient, notificationFactory);
+    }
+
+    @Test
+    void testShouldAddListenerAndStartDiscovery() throws Exception {
+        verifyNoInteractions(discoveryClient);
+        verifyNoInteractions(notificationFactory);
+
+        client.start();
+
+        InOrder inOrder = Mockito.inOrder(discoveryClient);
+        inOrder.verify(discoveryClient).addListener(client);
+        inOrder.verify(discoveryClient).start();
+    }
+
+    @Test
+    void testDiscoverableServiceMapping() throws Exception {
+        DiscoveredJvmDescriptor desc1 = mock(DiscoveredJvmDescriptor.class);
+        JMXServiceURL url1 = mock(JMXServiceURL.class);
+        when(desc1.getMainClass()).thenReturn("com.example.Main");
+        when(desc1.getJmxServiceUrl()).thenReturn(url1);
+
+        DiscoveredJvmDescriptor desc2 = mock(DiscoveredJvmDescriptor.class);
+        when(desc2.getJmxServiceUrl()).thenThrow(MalformedURLException.class);
+
+        DiscoveredJvmDescriptor desc3 = mock(DiscoveredJvmDescriptor.class);
+        JMXServiceURL url3 = mock(JMXServiceURL.class);
+        when(desc3.getMainClass()).thenReturn("com.redhat.containerjfr.ContainerJFR");
+        when(desc3.getJmxServiceUrl()).thenReturn(url3);
+
+        when(discoveryClient.getDiscoveredJvmDescriptors()).thenReturn(List.of(desc1, desc2, desc3));
+
+        List<ServiceRef> results = client.listDiscoverableServices();
+
+        ServiceRef exp1 = new ServiceRef(desc1.getJmxServiceUrl(), desc1.getMainClass());
+        ServiceRef exp2 = new ServiceRef(desc3.getJmxServiceUrl(), desc3.getMainClass());
+
+        assertThat(results, equalTo(List.of(exp1, exp2)));
+    }
+
+    @Test
+    void testAcceptDiscoveryEvent() throws Exception {
+        JMXServiceURL url = mock(JMXServiceURL.class);
+        String mainClass = "com.example.Main";
+        DiscoveredJvmDescriptor desc = mock(DiscoveredJvmDescriptor.class);
+        when(desc.getMainClass()).thenReturn(mainClass);
+        when(desc.getJmxServiceUrl()).thenReturn(url);
+        JvmDiscoveryEvent evt = mock(JvmDiscoveryEvent.class);
+        when(evt.getEventKind()).thenReturn(EventKind.FOUND);
+        when(evt.getJvmDescriptor()).thenReturn(desc);
+
+        Notification notification = mock(Notification.class);
+
+        Notification.Builder builder = mock(Notification.Builder.class);
+        lenient().when(builder.meta(Mockito.any())).thenReturn(builder);
+        lenient().when(builder.metaCategory(Mockito.any())).thenReturn(builder);
+        lenient().when(builder.metaType(Mockito.any(Notification.MetaType.class))).thenReturn(builder);
+        lenient().when(builder.metaType(Mockito.any(HttpMimeType.class))).thenReturn(builder);
+        lenient().when(builder.message(Mockito.any())).thenReturn(builder);
+        lenient().when(builder.build()).thenReturn(notification);
+
+        when(notificationFactory.createBuilder()).thenReturn(builder);
+
+        verifyNoInteractions(notificationFactory);
+
+        try {
+            client.accept(evt);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        verifyNoInteractions(discoveryClient);
+
+        verify(notificationFactory).createBuilder();
+        verify(builder).metaCategory("TargetJvmDiscovery");
+        verify(builder).message(Map.of("event", Map.of("kind", EventKind.FOUND, "serviceRef", new
+                        ServiceRef(url, mainClass))));
+        verify(builder).build();
+        verify(notification).send();
+    }
+
+}


### PR DESCRIPTION
Related to #158

This enables async JDP (rh-jmc-team/container-jfr-core#50) in the `DefaultPlatformClient`, sending a message on the Notification channel whenever a change in the known targets is observed. This also adds a `start` method to the `PlatformClient` interface so that other implementations can be extended with similar async discovery logic (ex. the `OpenShiftPlatformClient` can use "watch" functionality to observe changes to endpoints and notify based on these) or other async behaviours.