### PR TITLE
Use custom base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,20 @@ To re-run integration tests without a rebuild, do
 `mvn exec:exec@start-container failsafe:integration-test
 exec:exec@stop-container`.
 
-An OCI image can be built to your local `podman` image registry using
-`mvn package`. This will normally be a full-fledged image including built
+The application OCI image is built on top of a custom base image, built in the
+`base-image` directory. To produce a new base image simply run
+`sh base-image/build.sh`. This will default to using `podman` to build, which
+can be overriden by setting the environment variable `BUILDER` to another
+OCI-compliant image builder. The tag and version of the base image can also be
+overriden using the `TAG` and `VERSION` environment variables.
+
+An application OCI image can be built to your local `podman` image registry
+using `mvn package`. This will normally be a full-fledged image including built
 web-client assets. To skip building the web-client and not include its assets
 in the OCI image, use `mvn -Dcontainerjfr.minimal=true clean package`. The
 `clean` phase should always be specified here, or else previously-generated
-client assets will still be included into the built image.
-
-To use other OCI builders, use the `imageBuilder` Maven property, ex.
+client assets will still be included into the built image. To use other OCI
+builders, use the `imageBuilder` Maven property, ex.
 `mvn -DimageBuilder=$(which docker) clean verify` to build to Docker instead of
 Podman.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The application OCI image is built on top of a custom base image, built in the
 `sh base-image/build.sh`. This will default to using `podman` to build, which
 can be overriden by setting the environment variable `BUILDER` to another
 OCI-compliant image builder. The tag and version of the base image can also be
-overriden using the `TAG` and `VERSION` environment variables.
+overriden using the `IMAGE` and `TAG` environment variables.
 
 An application OCI image can be built to your local `podman` image registry
 using `mvn package`. This will normally be a full-fledged image including built

--- a/base-image/Containerfile
+++ b/base-image/Containerfile
@@ -1,0 +1,1 @@
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.3-6

--- a/base-image/build.sh
+++ b/base-image/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ -z "$TAG" ]; then
+    TAG="0.1.0"
+fi
+
+if [ -z "$BUILDER" ]; then
+    BUILDER="podman"
+fi
+
+IMAGE="quay.io/rh-jmc-team/container-jfr-base"
+
+$BUILDER build -t $IMAGE:$TAG -f "$(dirname $0)"/Containerfile
+$BUILDER tag $IMAGE:$TAG $IMAGE:latest

--- a/base-image/build.sh
+++ b/base-image/build.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ -z "$IMAGE" ]; then
+    IMAGE="quay.io/rh-jmc-team/container-jfr-base"
+fi
+
 if [ -z "$TAG" ]; then
     TAG="0.1.0"
 fi
@@ -7,8 +11,6 @@ fi
 if [ -z "$BUILDER" ]; then
     BUILDER="podman"
 fi
-
-IMAGE="quay.io/rh-jmc-team/container-jfr-base"
 
 $BUILDER build -t $IMAGE:$TAG -f "$(dirname $0)"/Containerfile
 $BUILDER tag $IMAGE:$TAG $IMAGE:latest

--- a/build-images.sh
+++ b/build-images.sh
@@ -3,6 +3,8 @@
 set -x
 set -e
 
+sh "$(dirname $0)/baseImage/build.sh"
+
 mvn -Dcontainerjfr.minimal=true clean verify
 
 mvn verify

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <maven.compiler.source>${java.version}</maven.compiler.source>
 
   <imageBuilder>/usr/bin/podman</imageBuilder>
-  <baseImage>registry.access.redhat.com/ubi8/openjdk-11</baseImage>
-  <baseImageTag>1.3-6</baseImageTag>
+  <baseImage>quay.io/rh-jmc-team/container-jfr-base</baseImage>
+  <baseImageTag>0.1.0</baseImageTag>
   <node.version>v12.5.0</node.version>
   <yarn.version>v1.22.10</yarn.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -346,9 +346,6 @@
           <format>OCI</format>
           <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
           <entrypoint>${containerjfr.entrypoint}</entrypoint>
-          <args>
-            <arg>-w</arg>
-          </args>
           <ports>
             <port>${containerjfr.webPort}</port>
             <port>${containerjfr.listenPort}</port>


### PR DESCRIPTION
Create a custom base image Containerfile and build script (currently just extends the previous ubi8 base image with no changes) and set pom.xml to use this new image for container builds

Fixes #333