### PR TITLE
Create self-signed cert at image build time

### DIFF
--- a/base-image/Containerfile
+++ b/base-image/Containerfile
@@ -2,6 +2,8 @@ FROM registry.access.redhat.com/ubi8/openjdk-11:1.3-6
 
 ENV CONF_DIR=/opt/containerjfr.d
 
+ENV PATH=$CONF_DIR:$PATH
+
 RUN mkdir -p $CONF_DIR
 
 ENV SSL_TRUSTSTORE=$CONF_DIR/truststore.p12 \

--- a/base-image/Containerfile
+++ b/base-image/Containerfile
@@ -5,8 +5,10 @@ ENV CONF_DIR=/opt/containerjfr.d
 RUN mkdir -p $CONF_DIR
 
 ENV SSL_TRUSTSTORE=$CONF_DIR/truststore.p12 \
-    SSL_TRUSTSTORE_PASS_FILE=$CONF_DIR/truststore.pass
+    SSL_TRUSTSTORE_PASS_FILE=$CONF_DIR/truststore.pass \
+    SSL_KEYSTORE=$CONF_DIR/keystore.p12
 
 COPY include $CONF_DIR
 
-RUN $CONF_DIR/truststore-setup.sh
+RUN $CONF_DIR/truststore-setup.sh && \
+    $CONF_DIR/generate-cert.sh

--- a/base-image/build.sh
+++ b/base-image/build.sh
@@ -5,7 +5,7 @@ if [ -z "$IMAGE" ]; then
 fi
 
 if [ -z "$TAG" ]; then
-    TAG="0.2.0"
+    TAG="0.3.0"
 fi
 
 if [ -z "$BUILDER" ]; then

--- a/base-image/include/generate-cert.sh
+++ b/base-image/include/generate-cert.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e
+
+function genpass() {
+    echo "$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)"
+}
+
+SSL_TRUSTSTORE_PASS="$(cat $SSL_TRUSTSTORE_PASS_FILE)"
+
+trap popd EXIT
+pushd $CONF_DIR
+
+keytool -genkeypair -v \
+    -alias container-jfr \
+    -dname "cn=container-jfr, o=Red Hat, c=US" \
+    -storetype PKCS12 \
+    -validity 365 \
+    -keyalg RSA \
+    -storepass "$SSL_TRUSTSTORE_PASS" \
+    -keystore "$SSL_KEYSTORE"
+
+keytool -exportcert -v \
+    -alias container-jfr \
+    -keystore "$SSL_KEYSTORE" \
+    -storepass "$SSL_TRUSTSTORE_PASS" \
+    -file server.cer
+
+keytool -importcert -v \
+    -noprompt \
+    -trustcacerts \
+    -keystore "$SSL_TRUSTSTORE" \
+    -alias selftrust \
+    -file server.cer \
+    -storepass "$SSL_TRUSTSTORE_PASS"

--- a/base-image/include/generate-cert.sh
+++ b/base-image/include/generate-cert.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-function genpass() {
-    echo "$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)"
-}
-
 SSL_TRUSTSTORE_PASS="$(cat $SSL_TRUSTSTORE_PASS_FILE)"
 
 trap popd EXIT

--- a/base-image/include/genpass
+++ b/base-image/include/genpass
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-echo "$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)"
+< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32

--- a/base-image/include/genpass
+++ b/base-image/include/genpass
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)"

--- a/base-image/include/genpass.sh
+++ b/base-image/include/genpass.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-function genpass() {
-    echo "$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)"
-}

--- a/base-image/include/genpass.sh
+++ b/base-image/include/genpass.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+function genpass() {
+    echo "$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)"
+}

--- a/base-image/include/truststore-setup.sh
+++ b/base-image/include/truststore-setup.sh
@@ -2,9 +2,7 @@
 
 set -e
 
-function genpass() {
-    echo "$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)"
-}
+source genpass.sh
 
 SSL_TRUSTSTORE_PASS="$(genpass)"
 

--- a/base-image/include/truststore-setup.sh
+++ b/base-image/include/truststore-setup.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-source genpass.sh
-
 SSL_TRUSTSTORE_PASS="$(genpass)"
 
 echo "$SSL_TRUSTSTORE_PASS" > "$SSL_TRUSTSTORE_PASS_FILE"

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <imageBuilder>/usr/bin/podman</imageBuilder>
   <baseImage>quay.io/rh-jmc-team/container-jfr-base</baseImage>
-  <baseImageTag>0.2.0</baseImageTag>
+  <baseImageTag>0.3.0</baseImageTag>
   <node.version>v12.5.0</node.version>
   <yarn.version>v1.22.10</yarn.version>
 

--- a/src/main/extras/app/entrypoint.sh
+++ b/src/main/extras/app/entrypoint.sh
@@ -10,8 +10,6 @@ function banner() {
     echo   "+------------------------------------------+"
 }
 
-source /usr/local/bin/genpass.sh
-
 USRFILE="/tmp/jmxremote.access"
 PWFILE="/tmp/jmxremote.password"
 function createJmxCredentials() {

--- a/src/main/extras/app/entrypoint.sh
+++ b/src/main/extras/app/entrypoint.sh
@@ -10,9 +10,7 @@ function banner() {
     echo   "+------------------------------------------+"
 }
 
-function genpass() {
-    echo "$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)"
-}
+source /usr/local/bin/genpass.sh
 
 USRFILE="/tmp/jmxremote.access"
 PWFILE="/tmp/jmxremote.password"

--- a/src/main/extras/app/entrypoint.sh
+++ b/src/main/extras/app/entrypoint.sh
@@ -33,7 +33,7 @@ if [ -z "$SSL_TRUSTSTORE_DIR" ]; then
 fi
 export SSL_TRUSTSTORE_DIR
 
-function importTrustStores() {
+function importCertificatesToTrustStore() {
     if [ ! -d "$SSL_TRUSTSTORE_DIR" ]; then
         banner "$SSL_TRUSTSTORE_DIR does not exist; no certificates to import"
         return 0
@@ -72,7 +72,7 @@ FLAGS=(
     "-Djavax.net.ssl.trustStorePassword=$SSL_TRUSTSTORE_PASS"
 )
 
-importTrustStores
+importCertificatesToTrustStore
 
 if [ "$CONTAINER_JFR_DISABLE_JMX_AUTH" = "true" ]; then
     banner "JMX Auth Disabled"


### PR DESCRIPTION
Based on top of #337

Creates the self-signed SSL certificate at image build time. At runtime, `entrypoint.sh` determines whether this certificate should be used as a fallback, or if the user-supplied certificate can be used instead.

Fixes #335