### PR TITLE
Do not exit early from platform detection

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -75,6 +75,7 @@ podman run \
     --mount type=tmpfs,target=/templates \
     --mount type=bind,source="$(dirname $0)/truststore",destination=/truststore,relabel=shared,bind-propagation=shared \
     --mount type=bind,source="$(dirname $0)/certs",destination=/certs,relabel=shared,bind-propagation=shared \
+    -e CONTAINER_JFR_PLATFORM=$CONTAINER_JFR_PLATFORM \
     -e CONTAINER_JFR_DISABLE_SSL=$CONTAINER_JFR_DISABLE_SSL \
     -e CONTAINER_JFR_DISABLE_JMX_AUTH=$CONTAINER_JFR_DISABLE_JMX_AUTH \
     -e CONTAINER_JFR_RJMX_USER=$CONTAINER_JFR_RJMX_USER \


### PR DESCRIPTION
Use single method exit point to ensure post-selection logic (currently, client starting) is performed for both automatic and manual platform selection

Fixes #344