### PR TITLE
Use Endpoints watch for async target discovery

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/PlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/PlatformClient.java
@@ -41,12 +41,13 @@
  */
 package com.redhat.rhjmc.containerjfr.platform;
 
+import java.io.IOException;
 import java.util.List;
 
 public interface PlatformClient {
     static final String NOTIFICATION_CATEGORY = "TargetJvmDiscovery";
 
-    void start();
+    void start() throws IOException;
 
     List<ServiceRef> listDiscoverableServices();
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/PlatformModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/PlatformModule.java
@@ -41,6 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.platform;
 
+import java.io.IOException;
 import java.util.Objects;
 import java.util.Set;
 
@@ -129,7 +130,12 @@ public abstract class PlatformModule {
                             .findFirst()
                             .orElseThrow();
         }
-        strat.getPlatformClient().start();
+        try {
+            strat.getPlatformClient().start();
+        } catch (IOException ioe) {
+            logger.error(ioe);
+            throw new RuntimeException(ioe);
+        }
         return strat;
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/AbstractPlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/AbstractPlatformClient.java
@@ -39,13 +39,39 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr.platform;
+package com.redhat.rhjmc.containerjfr.platform.internal;
 
-import java.io.IOException;
-import java.util.List;
+import java.util.Map;
 
-public interface PlatformClient {
-    void start() throws IOException;
+import com.redhat.rhjmc.containerjfr.core.net.discovery.JvmDiscoveryClient.EventKind;
+import com.redhat.rhjmc.containerjfr.messaging.notifications.NotificationFactory;
+import com.redhat.rhjmc.containerjfr.platform.PlatformClient;
+import com.redhat.rhjmc.containerjfr.platform.ServiceRef;
 
-    List<ServiceRef> listDiscoverableServices();
+public abstract class AbstractPlatformClient implements PlatformClient {
+
+    public static final String NOTIFICATION_CATEGORY = "TargetJvmDiscovery";
+
+    protected final NotificationFactory notificationFactory;
+
+    protected AbstractPlatformClient(NotificationFactory notificationFactory) {
+        this.notificationFactory = notificationFactory;
+    }
+
+    protected void notifyAsyncTargetDiscovery(EventKind eventKind, ServiceRef serviceRef) {
+        notificationFactory
+            .createBuilder()
+            .metaCategory(NOTIFICATION_CATEGORY)
+            .message(
+                    Map.of(
+                        "event",
+                        Map.of(
+                            "kind",
+                            eventKind,
+                            "serviceRef",
+                            serviceRef)))
+            .build()
+            .send();
+    }
+
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/AbstractPlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/AbstractPlatformClient.java
@@ -60,18 +60,10 @@ public abstract class AbstractPlatformClient implements PlatformClient {
 
     protected void notifyAsyncTargetDiscovery(EventKind eventKind, ServiceRef serviceRef) {
         notificationFactory
-            .createBuilder()
-            .metaCategory(NOTIFICATION_CATEGORY)
-            .message(
-                    Map.of(
-                        "event",
-                        Map.of(
-                            "kind",
-                            eventKind,
-                            "serviceRef",
-                            serviceRef)))
-            .build()
-            .send();
+                .createBuilder()
+                .metaCategory(NOTIFICATION_CATEGORY)
+                .message(Map.of("event", Map.of("kind", eventKind, "serviceRef", serviceRef)))
+                .build()
+                .send();
     }
-
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/DefaultPlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/DefaultPlatformClient.java
@@ -71,13 +71,9 @@ class DefaultPlatformClient implements PlatformClient, Consumer<JvmDiscoveryEven
     }
 
     @Override
-    public void start() {
+    public void start() throws IOException {
         discoveryClient.addListener(this);
-        try {
-            discoveryClient.start();
-        } catch (IOException e) {
-            logger.error(e);
-        }
+        discoveryClient.start();
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeApiPlatformClient.java
@@ -41,6 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.platform.internal;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -77,7 +78,7 @@ class KubeApiPlatformClient implements PlatformClient {
     }
 
     @Override
-    public void start() {}
+    public void start() throws IOException {}
 
     @Override
     public List<ServiceRef> listDiscoverableServices() {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeEnvPlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/KubeEnvPlatformClient.java
@@ -41,6 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.platform.internal;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -71,7 +72,7 @@ class KubeEnvPlatformClient implements PlatformClient {
     }
 
     @Override
-    public void start() {}
+    public void start() throws IOException {}
 
     @Override
     public List<ServiceRef> listDiscoverableServices() {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/PlatformStrategyModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/internal/PlatformStrategyModule.java
@@ -76,7 +76,12 @@ public abstract class PlatformStrategyModule {
             NotificationFactory notificationFactory) {
         return Set.of(
                 new OpenShiftPlatformStrategy(
-                        logger, openShiftAuthManager, connectionToolkit, env, fs),
+                        logger,
+                        openShiftAuthManager,
+                        connectionToolkit,
+                        env,
+                        fs,
+                        notificationFactory),
                 new KubeApiPlatformStrategy(logger, noopAuthManager, connectionToolkit),
                 new KubeEnvPlatformStrategy(logger, noopAuthManager, connectionToolkit, env),
                 new DefaultPlatformStrategy(

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformClient.java
@@ -49,6 +49,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnectionToolkit;
 import com.redhat.rhjmc.containerjfr.core.net.discovery.JvmDiscoveryClient.EventKind;
@@ -56,8 +58,6 @@ import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.messaging.notifications.NotificationFactory;
 import com.redhat.rhjmc.containerjfr.platform.ServiceRef;
 import com.redhat.rhjmc.containerjfr.platform.internal.AbstractPlatformClient;
-
-import org.apache.commons.lang3.StringUtils;
 
 import dagger.Lazy;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -90,15 +90,16 @@ class OpenShiftPlatformClient extends AbstractPlatformClient {
     }
 
     @Override
-    @SuppressFBWarnings(
-            value = "SF_SWITCH_FALLTHROUGH",
-            justification = "The MODIFIED -> ADDED fallthrough is intentional")
     public void start() throws IOException {
         osClient.endpoints()
                 .inNamespace(getNamespace())
                 .watch(
                         new Watcher<Endpoints>() {
                             @Override
+                            @SuppressFBWarnings(
+                                    value = "SF_SWITCH_FALLTHROUGH",
+                                    justification =
+                                            "The MODIFIED -> ADDED fallthrough is intentional")
                             public void eventReceived(Action action, Endpoints endpoints) {
                                 EventKind kind = null;
                                 switch (action) {
@@ -122,17 +123,15 @@ class OpenShiftPlatformClient extends AbstractPlatformClient {
                                     default:
                                         logger.warn(
                                                 new IllegalArgumentException(action.toString()));
+                                        return;
                                 }
-                                if (kind == null) {
-                                    return;
-                                }
-                                final EventKind fKind = kind;
 
+                                final EventKind fKind = kind;
                                 getServiceRefs(endpoints)
                                         .forEach(
                                                 serviceRef ->
-                                                    notifyAsyncTargetDiscovery(fKind, serviceRef)
-                                                );
+                                                        notifyAsyncTargetDiscovery(
+                                                                fKind, serviceRef));
                             }
 
                             @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformStrategy.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformStrategy.java
@@ -40,7 +40,7 @@
  * #L%
  */
 
-//FIXME move the openshift package under the internal package
+// FIXME move the openshift package under the internal package
 package com.redhat.rhjmc.containerjfr.platform.openshift;
 
 import java.nio.file.Files;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformStrategy.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformStrategy.java
@@ -48,6 +48,7 @@ import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnectionToolkit;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.messaging.notifications.NotificationFactory;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.platform.internal.PlatformDetectionStrategy;
 
@@ -65,13 +66,15 @@ public class OpenShiftPlatformStrategy
     private final FileSystem fs;
     private OpenShiftClient osClient;
     private final Lazy<JFRConnectionToolkit> connectionToolkit;
+    private final NotificationFactory notificationFactory;
 
     public OpenShiftPlatformStrategy(
             Logger logger,
             OpenShiftAuthManager authMgr,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Environment env,
-            FileSystem fs) {
+            FileSystem fs,
+            NotificationFactory notificationFactory) {
         this.logger = logger;
         this.authMgr = authMgr;
         this.fs = fs;
@@ -82,6 +85,7 @@ public class OpenShiftPlatformStrategy
             this.osClient = null;
         }
         this.connectionToolkit = connectionToolkit;
+        this.notificationFactory = notificationFactory;
     }
 
     @Override
@@ -116,7 +120,8 @@ public class OpenShiftPlatformStrategy
     @Override
     public OpenShiftPlatformClient getPlatformClient() {
         logger.info("Selected OpenShift Platform Strategy");
-        return new OpenShiftPlatformClient(osClient, connectionToolkit, fs, logger);
+        return new OpenShiftPlatformClient(
+                osClient, connectionToolkit, fs, notificationFactory, logger);
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformStrategy.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformStrategy.java
@@ -39,6 +39,8 @@
  * SOFTWARE.
  * #L%
  */
+
+//FIXME move the openshift package under the internal package
 package com.redhat.rhjmc.containerjfr.platform.openshift;
 
 import java.nio.file.Files;

--- a/src/test/java/com/redhat/rhjmc/containerjfr/platform/internal/AbstractPlatformClientTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/platform/internal/AbstractPlatformClientTest.java
@@ -1,0 +1,123 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.platform.internal;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.management.remote.JMXServiceURL;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.core.net.discovery.JvmDiscoveryClient.EventKind;
+import com.redhat.rhjmc.containerjfr.messaging.notifications.Notification;
+import com.redhat.rhjmc.containerjfr.messaging.notifications.Notification.MetaType;
+import com.redhat.rhjmc.containerjfr.messaging.notifications.NotificationFactory;
+import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
+import com.redhat.rhjmc.containerjfr.platform.ServiceRef;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractPlatformClientTest {
+
+    @Mock NotificationFactory notificationFactory;
+    @Mock Notification.Builder builder;
+    @Mock Notification notification;
+    TestPlatformClient platformClient;
+
+    @BeforeEach
+    void setup() {
+        Mockito.lenient().when(notificationFactory.createBuilder()).thenReturn(builder);
+        Mockito.lenient().when(builder.meta(Mockito.any())).thenReturn(builder);
+        Mockito.lenient().when(builder.message(Mockito.any())).thenReturn(builder);
+        Mockito.lenient().when(builder.metaType(Mockito.any(MetaType.class))).thenReturn(builder);
+        Mockito.lenient()
+                .when(builder.metaType(Mockito.any(HttpMimeType.class)))
+                .thenReturn(builder);
+        Mockito.lenient().when(builder.metaCategory(Mockito.anyString())).thenReturn(builder);
+        Mockito.lenient().when(builder.build()).thenReturn(notification);
+
+        this.platformClient = new TestPlatformClient(notificationFactory);
+    }
+
+    @Test
+    void shouldEmitNotification() throws Exception {
+        Mockito.verifyNoInteractions(notificationFactory);
+
+        JMXServiceURL serviceUrl = Mockito.mock(JMXServiceURL.class);
+        String alias = "com.example.Foo";
+        ServiceRef serviceRef = new ServiceRef(serviceUrl, alias);
+        EventKind kind = EventKind.FOUND;
+
+        this.platformClient.notifyAsyncTargetDiscovery(kind, serviceRef);
+
+        InOrder inOrder = Mockito.inOrder(notificationFactory, builder, notification);
+        inOrder.verify(notificationFactory).createBuilder();
+        inOrder.verify(builder).build();
+        inOrder.verify(notification).send();
+
+        Mockito.verify(builder).metaCategory("TargetJvmDiscovery");
+        Mockito.verify(builder)
+                .message(Map.of("event", Map.of("kind", kind, "serviceRef", serviceRef)));
+    }
+
+    static class TestPlatformClient extends AbstractPlatformClient {
+        TestPlatformClient(NotificationFactory notificationFactory) {
+            super(notificationFactory);
+        }
+
+        @Override
+        public void start() throws IOException {}
+
+        @Override
+        public List<ServiceRef> listDiscoverableServices() {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformClientTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/platform/openshift/OpenShiftPlatformClientTest.java
@@ -65,6 +65,7 @@ import org.mockito.stubbing.Answer;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnectionToolkit;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.messaging.notifications.NotificationFactory;
 import com.redhat.rhjmc.containerjfr.platform.ServiceRef;
 
 import io.fabric8.kubernetes.api.model.EndpointAddress;
@@ -84,12 +85,14 @@ class OpenShiftPlatformClientTest {
     @Mock OpenShiftClient osClient;
     @Mock JFRConnectionToolkit connectionToolkit;
     @Mock FileSystem fs;
+    @Mock NotificationFactory notificationFactory;
     @Mock Logger logger;
 
     @BeforeEach
     void setup() {
         this.platformClient =
-                new OpenShiftPlatformClient(osClient, () -> connectionToolkit, fs, logger);
+                new OpenShiftPlatformClient(
+                        osClient, () -> connectionToolkit, fs, notificationFactory, logger);
     }
 
     @Test


### PR DESCRIPTION
Fixes #346

This uses an Endpoints resource watch in the OpenShiftPlatformClient to enable async target discovery, similar to how the DefaultPlatformClient implements async target discovery using JDP.

For ease of testing in OpenShift/CRC, I have published an image built from this PR as `quay.io/andrewazores/container-jfr:2.0.0-SNAPSHOT-endpoint-watch`.

During my testing in CRC I found that the `MODIFIED` event is emitted in many more scenarios than I expected - for example, using our Operator's Makefile, doing `make sample_app` and then `make undeploy_sample_app` produces an `ADDED` event and a `DELETED` event. But re-running `make sample_app` resulted in a `MODIFIED` event, and subsequent deploy/undeploy continues to generate `DELETED`/`MODIFIED` events, without any `FOUND`. But also, directly editing the application's service and making some change (`oc edit svc vertx-fib-demo`) results in another `MODIFIED` event. So I have implemented the event handling to consider a `MODIFIED` event as equivalent to a `DELETED`/`ADDED`, so that a listening notification client should end up with the same net state change in the end.

