### PR TITLE
V2 Response API Format

### DIFF
--- a/HTTP_API.md
+++ b/HTTP_API.md
@@ -1347,21 +1347,21 @@ The handler-specific descriptions below describe how each handler populates the
     Should use percent-encoding.
 
     ###### response
-    `201` - The body is a descriptor of the newly started recording, in the form
+    `201` - The response is a descriptor of the newly created recording, in the form
     `{"downloadUrl":"$DOWNLOAD_URL","reportUrl":"$REPORT_URL","id":$ID,"name":"$NAME","state":"$STATE","startTime":$START_TIME,"duration":$DURATION,"continuous":$CONTINUOUS,"toDisk":$TO_DISK,"maxSize":$MAX_SIZE,"maxAge":$MAX_AGE}`. The `Location` header will also be set
     to the same URL as in the `downloadUrl` field.
 
-    `401` - User authentication failed. The body is an error message.
+    `401` - User authentication failed. The reason is an error message.
     There will be an `X-WWW-Authenticate: $SCHEME` header that indicates
     the authentication scheme that is used.
 
-    `404` - The target could not be found. The body is an error message.
+    `404` - The target could not be found. The reason is an error message.
 
-    `427` - JMX authentication failed. The body is an error message.
+    `427` - JMX authentication failed. The reason is an error message.
     There will be an `X-JMX-Authenticate: $SCHEME` header that indicates
     the authentication scheme that is used.
 
-    `500` - There was an unexpected error. The body is an error message.
+    `500` - There was an unexpected error. The reason is an error message.
 
     `502` - JMX connection failed. This is generally because the target
     application has SSL enabled over JMX, but ContainerJFR does not trust the
@@ -1370,7 +1370,7 @@ The handler-specific descriptions below describe how each handler populates the
     ###### example
     ```
     $ curl -X POST localhost:8181/api/v2/targets/localhost/snapshot
-    {"downloadUrl":"http://192.168.0.109:8181/api/v1/targets/service:jmx:rmi:%2F%2F%2Fjndi%2Frmi:%2F%2Flocalhost:9091%2Fjmxrmi/recordings/snapshot-1","reportUrl":"http://192.168.0.109:8181/api/v1/targets/service:jmx:rmi:%2F%2F%2Fjndi%2Frmi:%2F%2Flocalhost:9091%2Fjmxrmi/reports/snapshot-1","id":1,"name":"snapshot-1","state":"STOPPED","startTime":1601998841300,"duration":0,"continuous":true,"toDisk":true,"maxSize":0,"maxAge":0}
+{"meta":{"status":"OK","type":"application/json"},"data":{"result":{"downloadUrl":"http://192.168.0.109:8181/api/v1/targets/service:jmx:rmi:%2F%2F%2Fjndi%2Frmi:%2F%2Flocalhost:9091%2Fjmxrmi/recordings/snapshot-1","reportUrl":"http://192.168.0.109:8181/api/v1/targets/service:jmx:rmi:%2F%2F%2Fjndi%2Frmi:%2F%2Flocalhost:9091%2Fjmxrmi/reports/snapshot-1","id":1,"name":"snapshot-1","state":"STOPPED","startTime":1601998841300,"duration":0,"continuous":true,"toDisk":true,"maxSize":0,"maxAge":0}}}
     ```
 
 ### Security

--- a/HTTP_API.md
+++ b/HTTP_API.md
@@ -1305,22 +1305,22 @@ The handler-specific descriptions below describe how each handler populates the
     Should use percent-encoding.
 
     ###### response
-    `200` - The body is a JSON array of recording option objects.
+    `200` - The result is a JSON array of recording option objects.
 
     The format of a recording option is
     `{"name":"$NAME","description":"$DESCRIPTION","defaultValue":"$DEFAULT"}`.
 
-    `401` - User authentication failed. The body is an error message.
+    `401` - User authentication failed. The reason is an error message.
     There will be an `X-WWW-Authenticate: $SCHEME` header that indicates
     the authentication scheme that is used.
 
-    `404` - The target could not be found. The body is an error message.
+    `404` - The target could not be found. The reason is an error message.
 
-    `427` - JMX authentication failed. The body is an error message.
+    `427` - JMX authentication failed. The reason is an error message.
     There will be an `X-JMX-Authenticate: $SCHEME` header that indicates
     the authentication scheme that is used.
 
-    `500` - There was an unexpected error. The body is an error message.
+    `500` - There was an unexpected error. The reason is an error message.
 
     `502` - JMX connection failed. This is generally because the target
     application has SSL enabled over JMX, but ContainerJFR does not trust the
@@ -1329,7 +1329,7 @@ The handler-specific descriptions below describe how each handler populates the
     ###### example
     ```
     $ curl localhost:8181/api/v2/targets/localhost/recordingOptionsList
-    [{"name":"Name","description":"Recording name","defaultValue":"Recording"},{"name":"Duration","description":"Duration of recording","defaultValue":"30s[s]"},{"name":"Max Size","description":"Maximum size of recording","defaultValue":"0B[B]"},{"name":"Max Age","description":"Maximum age of the events in the recording","defaultValue":"0s[s]"},{"name":"To disk","description":"Record to disk","defaultValue":"false"},{"name":"Dump on Exit","description":"Dump recording data to disk on JVM exit","defaultValue":"false"}]
+    {"meta":{"status":"OK","type":"application/json"},"data":{result:[{"name":"Name","description":"Recording name","defaultValue":"Recording"},{"name":"Duration","description":"Duration of recording","defaultValue":"30s[s]"},{"name":"Max Size","description":"Maximum size of recording","defaultValue":"0B[B]"},{"name":"Max Age","description":"Maximum age of the events in the recording","defaultValue":"0s[s]"},{"name":"To disk","description":"Record to disk","defaultValue":"false"},{"name":"Dump on Exit","description":"Dump recording data to disk on JVM exit","defaultValue":"false"}]}}
     ```
 
 * #### `TargetSnapshotPostHandler`

--- a/HTTP_API.md
+++ b/HTTP_API.md
@@ -1370,7 +1370,7 @@ The handler-specific descriptions below describe how each handler populates the
     ###### example
     ```
     $ curl -X POST localhost:8181/api/v2/targets/localhost/snapshot
-{"meta":{"status":"OK","type":"application/json"},"data":{"result":{"downloadUrl":"http://192.168.0.109:8181/api/v1/targets/service:jmx:rmi:%2F%2F%2Fjndi%2Frmi:%2F%2Flocalhost:9091%2Fjmxrmi/recordings/snapshot-1","reportUrl":"http://192.168.0.109:8181/api/v1/targets/service:jmx:rmi:%2F%2F%2Fjndi%2Frmi:%2F%2Flocalhost:9091%2Fjmxrmi/reports/snapshot-1","id":1,"name":"snapshot-1","state":"STOPPED","startTime":1601998841300,"duration":0,"continuous":true,"toDisk":true,"maxSize":0,"maxAge":0}}}
+    {"meta":{"status":"Created","type":"application/json"},"data":{"result":{"downloadUrl":"http://192.168.0.109:8181/api/v1/targets/service:jmx:rmi:%2F%2F%2Fjndi%2Frmi:%2F%2Flocalhost:9091%2Fjmxrmi/recordings/snapshot-1","reportUrl":"http://192.168.0.109:8181/api/v1/targets/service:jmx:rmi:%2F%2F%2Fjndi%2Frmi:%2F%2Flocalhost:9091%2Fjmxrmi/reports/snapshot-1","id":1,"name":"snapshot-1","state":"STOPPED","startTime":1601998841300,"duration":0,"continuous":true,"toDisk":true,"maxSize":0,"maxAge":0}}}
     ```
 
 ### Security

--- a/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
@@ -57,10 +57,12 @@ import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 import com.redhat.rhjmc.containerjfr.messaging.MessagingModule;
 import com.redhat.rhjmc.containerjfr.net.NetworkModule;
+import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
 import com.redhat.rhjmc.containerjfr.platform.PlatformModule;
 import com.redhat.rhjmc.containerjfr.sys.SystemModule;
 import com.redhat.rhjmc.containerjfr.templates.TemplatesModule;
 import com.redhat.rhjmc.containerjfr.util.GsonJmxServiceUrlAdapter;
+import com.redhat.rhjmc.containerjfr.util.HttpMimeTypeAdapter;
 
 import dagger.Module;
 import dagger.Provides;
@@ -110,6 +112,7 @@ public abstract class MainModule {
                 .serializeNulls()
                 .disableHtmlEscaping()
                 .registerTypeAdapter(JMXServiceURL.class, new GsonJmxServiceUrlAdapter(logger))
+                .registerTypeAdapter(HttpMimeType.class, new HttpMimeTypeAdapter())
                 .create();
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
@@ -63,6 +63,7 @@ import com.redhat.rhjmc.containerjfr.sys.SystemModule;
 import com.redhat.rhjmc.containerjfr.templates.TemplatesModule;
 import com.redhat.rhjmc.containerjfr.util.GsonJmxServiceUrlAdapter;
 import com.redhat.rhjmc.containerjfr.util.HttpMimeTypeAdapter;
+import com.redhat.rhjmc.containerjfr.util.PathTypeAdapter;
 
 import dagger.Module;
 import dagger.Provides;
@@ -113,6 +114,7 @@ public abstract class MainModule {
                 .disableHtmlEscaping()
                 .registerTypeAdapter(JMXServiceURL.class, new GsonJmxServiceUrlAdapter(logger))
                 .registerTypeAdapter(HttpMimeType.class, new HttpMimeTypeAdapter())
+                .registerTypeHierarchyAdapter(Path.class, new PathTypeAdapter())
                 .create();
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -58,7 +58,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.EnglishReasonPhraseCatalog;
+
+import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
+
 import com.google.gson.Gson;
+
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
@@ -70,10 +76,6 @@ import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiData;
 import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiMeta;
 import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiResponse;
 import com.redhat.rhjmc.containerjfr.net.web.http.api.v2.ApiException;
-
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.EnglishReasonPhraseCatalog;
-import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
 
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpHeaders;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -58,13 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.EnglishReasonPhraseCatalog;
-
-import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
-
 import com.google.gson.Gson;
-
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
@@ -72,7 +66,14 @@ import com.redhat.rhjmc.containerjfr.net.HttpServer;
 import com.redhat.rhjmc.containerjfr.net.NetworkConfiguration;
 import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
 import com.redhat.rhjmc.containerjfr.net.web.http.RequestHandler;
+import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiData;
+import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiMeta;
+import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiResponse;
 import com.redhat.rhjmc.containerjfr.net.web.http.api.v2.ApiException;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.EnglishReasonPhraseCatalog;
+import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
 
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpHeaders;
@@ -144,7 +145,7 @@ public class WebServer {
                                                 ex.getStatusCode(), null);
                         ApiErrorResponse resp =
                                 new ApiErrorResponse(
-                                        new ApiErrorMeta(HttpMimeType.PLAINTEXT, apiStatus),
+                                        new ApiMeta(HttpMimeType.PLAINTEXT, apiStatus),
                                         new ApiErrorData(ex.getFailureReason()));
                         ctx.response()
                                 .putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime())
@@ -290,27 +291,13 @@ public class WebServer {
         return conn.getJMXURL().toString();
     }
 
-    static class ApiErrorResponse {
-        private final ApiErrorMeta meta;
-        private final ApiErrorData data;
-
-        ApiErrorResponse(ApiErrorMeta meta, ApiErrorData data) {
-            this.meta = meta;
-            this.data = data;
+    static class ApiErrorResponse extends ApiResponse<ApiErrorData> {
+        ApiErrorResponse(ApiMeta meta, ApiErrorData data) {
+            super(meta, data);
         }
     }
 
-    static class ApiErrorMeta {
-        private final HttpMimeType type;
-        private final String status;
-
-        ApiErrorMeta(HttpMimeType type, String status) {
-            this.type = type;
-            this.status = status;
-        }
-    }
-
-    static class ApiErrorData {
+    static class ApiErrorData extends ApiData {
         private final String reason;
 
         ApiErrorData(String reason) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -142,12 +142,13 @@ public class WebServer {
                                         ? ex.getApiStatus()
                                         : EnglishReasonPhraseCatalog.INSTANCE.getReason(
                                                 ex.getStatusCode(), null);
-                        Map meta = Map.of("status", apiStatus, "type", HttpMimeType.PLAINTEXT);
-                        Map data = Map.of("reason", ex.getFailureReason());
-                        Map body = Map.of("meta", meta, "data", data);
+                        ApiErrorResponse resp =
+                                new ApiErrorResponse(
+                                        new ApiErrorMeta(HttpMimeType.PLAINTEXT, apiStatus),
+                                        new ApiErrorData(ex.getFailureReason()));
                         ctx.response()
                                 .putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime())
-                                .end(gson.toJson(body));
+                                .end(gson.toJson(resp));
                     } else {
                         // kept for V1 API handler compatibility
                         String payload =
@@ -287,5 +288,33 @@ public class WebServer {
 
     private String getTargetId(JFRConnection conn) throws IOException {
         return conn.getJMXURL().toString();
+    }
+
+    static class ApiErrorResponse {
+        private final ApiErrorMeta meta;
+        private final ApiErrorData data;
+
+        ApiErrorResponse(ApiErrorMeta meta, ApiErrorData data) {
+            this.meta = meta;
+            this.data = data;
+        }
+    }
+
+    static class ApiErrorMeta {
+        private final HttpMimeType type;
+        private final String status;
+
+        ApiErrorMeta(HttpMimeType type, String status) {
+            this.type = type;
+            this.status = status;
+        }
+    }
+
+    static class ApiErrorData {
+        private final String reason;
+
+        ApiErrorData(String reason) {
+            this.reason = reason;
+        }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiData.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiData.java
@@ -1,0 +1,44 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.http.api;
+
+public class ApiData { }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiData.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiData.java
@@ -41,4 +41,4 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.http.api;
 
-public class ApiData { }
+public class ApiData {}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiMeta.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiMeta.java
@@ -42,17 +42,16 @@
 package com.redhat.rhjmc.containerjfr.net.web.http.api;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
 
 public class ApiMeta {
     protected final HttpMimeType type;
-    protected final Optional<String> status;
+    protected final String status;
 
     public ApiMeta(HttpMimeType type, String status) {
         this.type = Objects.requireNonNull(type);
-        this.status = Optional.ofNullable(status);
+        this.status = status;
     }
 
     public ApiMeta(HttpMimeType type) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiMeta.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiMeta.java
@@ -1,0 +1,54 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.http.api;
+
+import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
+
+public class ApiMeta {
+    protected final HttpMimeType type;
+    protected final String status;
+
+    public ApiMeta(HttpMimeType type, String status) {
+        this.type = type;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiMeta.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiMeta.java
@@ -46,15 +46,23 @@ import java.util.Objects;
 import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
 
 public class ApiMeta {
-    protected final HttpMimeType type;
-    protected final String status;
+    protected HttpMimeType type;
+    protected String status;
 
     public ApiMeta(HttpMimeType type, String status) {
         this.type = Objects.requireNonNull(type);
-        this.status = status;
+        this.status = status == null ? "OK" : status;
     }
 
     public ApiMeta(HttpMimeType type) {
         this(type, null);
+    }
+
+    public HttpMimeType getMimeType() {
+        return this.type;
+    }
+
+    public String getStatus() {
+        return this.status;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiResponse.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiResponse.java
@@ -1,0 +1,52 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.http.api;
+
+public class ApiResponse<T extends ApiData> {
+    protected final ApiMeta meta;
+    protected final T data;
+
+    public ApiResponse(ApiMeta meta, T data) {
+        this.meta = meta;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiResultData.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiResultData.java
@@ -42,9 +42,13 @@
 package com.redhat.rhjmc.containerjfr.net.web.http.api;
 
 public class ApiResultData<T> extends ApiData {
-    protected final T result;
+    protected T result;
 
     public ApiResultData(T result) {
         this.result = result;
+    }
+
+    public T getResult() {
+        return this.result;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiResultData.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/ApiResultData.java
@@ -41,21 +41,10 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.http.api;
 
-import java.util.Objects;
-import java.util.Optional;
+public class ApiResultData<T> extends ApiData {
+    protected final T result;
 
-import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
-
-public class ApiMeta {
-    protected final HttpMimeType type;
-    protected final Optional<String> status;
-
-    public ApiMeta(HttpMimeType type, String status) {
-        this.type = Objects.requireNonNull(type);
-        this.status = Optional.ofNullable(status);
-    }
-
-    public ApiMeta(HttpMimeType type) {
-        this(type, null);
+    public ApiResultData(T result) {
+        this.result = result;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
@@ -106,11 +106,12 @@ abstract class AbstractV2RequestHandler<T> implements RequestHandler {
             if (cause instanceof SecurityException) {
                 ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
                 // FIXME should be 401, needs web-client to be adapted for V2 format
-                throw new ApiException(427, "JMX Authentication Failure", e);
+                throw new ApiException(
+                        427, "Authentication Failure", "JMX Authentication Failure", e);
             }
             Throwable rootCause = ExceptionUtils.getRootCause(e);
             if (rootCause instanceof ConnectIOException) {
-                throw new ApiException(502, "Target SSL Untrusted", e);
+                throw new ApiException(502, "Connection Failure", "Target SSL Untrusted", e);
             }
             throw new ApiException(500, e.getMessage(), e);
         } catch (Exception e) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
@@ -1,0 +1,170 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
+
+import java.nio.charset.StandardCharsets;
+import java.rmi.ConnectIOException;
+import java.util.Base64;
+import java.util.concurrent.Future;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.gson.Gson;
+import com.redhat.rhjmc.containerjfr.core.net.Credentials;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
+import com.redhat.rhjmc.containerjfr.net.web.http.RequestHandler;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.openjdk.jmc.rjmx.ConnectionException;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+abstract class AbstractV2RequestHandler implements RequestHandler {
+
+    abstract boolean requiresAuthentication();
+
+    static final Pattern AUTH_HEADER_PATTERN =
+            Pattern.compile("(?<type>[\\w]+)[\\s]+(?<credentials>[\\S]+)");
+    static final String JMX_AUTHENTICATE_HEADER = "X-JMX-Authenticate";
+    static final String JMX_AUTHORIZATION_HEADER = "X-JMX-Authorization";
+
+    protected final AuthManager auth;
+    protected final Gson gson;
+
+    protected AbstractV2RequestHandler(AuthManager auth, Gson gson) {
+        this.auth = auth;
+        this.gson = gson;
+    }
+
+    abstract <T> IntermediateResponse<T> handle(RequestParams requestParams) throws Exception;
+
+    @Override
+    public void handle(RoutingContext ctx) {
+        RequestParams requestParams = RequestParams.from(ctx);
+            try {
+                if (requiresAuthentication() && !validateRequestAuthorization(ctx.request()).get()) {
+                    throw new HttpStatusException(401);
+                }
+                writeResponse(ctx, handle(requestParams));
+            } catch (HttpStatusException e) {
+                throw e;
+            } catch (ConnectionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof SecurityException) {
+                    ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
+                    throw new HttpStatusException(427, "JMX Authentication Failure", e);
+                }
+                Throwable rootCause = ExceptionUtils.getRootCause(e);
+                if (rootCause instanceof ConnectIOException) {
+                    throw new HttpStatusException(502, "Target SSL Untrusted", e);
+                }
+                throw new HttpStatusException(500, e);
+            } catch (Exception e) {
+                throw new HttpStatusException(500, e.getMessage(), e);
+            }
+    }
+
+    protected Future<Boolean> validateRequestAuthorization(HttpServerRequest req) throws Exception {
+        return auth.validateHttpHeader(() -> req.getHeader(HttpHeaders.AUTHORIZATION));
+    }
+
+    protected ConnectionDescriptor getConnectionDescriptorFromContext(RoutingContext ctx) {
+        String targetId = ctx.pathParam("targetId");
+        Credentials credentials = null;
+        if (ctx.request().headers().contains(JMX_AUTHORIZATION_HEADER)) {
+            String proxyAuth = ctx.request().getHeader(JMX_AUTHORIZATION_HEADER);
+            Matcher m = AUTH_HEADER_PATTERN.matcher(proxyAuth);
+            if (!m.find()) {
+                ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
+                throw new HttpStatusException(
+                        427, "Invalid " + JMX_AUTHORIZATION_HEADER + " format");
+            } else {
+                String t = m.group("type");
+                if (!"basic".equals(t.toLowerCase())) {
+                    ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
+                    throw new HttpStatusException(
+                            427, "Unacceptable " + JMX_AUTHORIZATION_HEADER + " type");
+                } else {
+                    String c;
+                    try {
+                        c =
+                                new String(
+                                        Base64.getDecoder().decode(m.group("credentials")),
+                                        StandardCharsets.UTF_8);
+                    } catch (IllegalArgumentException iae) {
+                        ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
+                        throw new HttpStatusException(
+                                427,
+                                JMX_AUTHORIZATION_HEADER
+                                        + " credentials do not appear to be Base64-encoded",
+                                iae);
+                    }
+                    String[] parts = c.split(":");
+                    if (parts.length != 2) {
+                        ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
+                        throw new HttpStatusException(
+                                427,
+                                "Unrecognized " + JMX_AUTHORIZATION_HEADER + " credential format");
+                    }
+                    credentials = new Credentials(parts[0], parts[1]);
+                }
+            }
+        }
+        return new ConnectionDescriptor(targetId, credentials);
+    }
+
+    protected void writeResponse(RoutingContext ctx, IntermediateResponse<?> intermediateResponse) {
+        HttpServerResponse response = ctx.response();
+        response.setStatusCode(intermediateResponse.statusCode);
+        if (intermediateResponse.statusMessage != null) {
+            response.setStatusMessage(intermediateResponse.statusMessage);
+        }
+        intermediateResponse.headers.forEach(response::putHeader);
+        response.end(gson.toJson(intermediateResponse.body));
+    }
+
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
@@ -84,13 +84,13 @@ abstract class AbstractV2RequestHandler<T> implements RequestHandler {
         this.gson = gson;
     }
 
-    abstract IntermediateResponse<T> handle(RequestParams requestParams) throws Exception;
+    abstract IntermediateResponse<T> handle(RequestParameters requestParams) throws Exception;
 
     abstract HttpMimeType mimeType();
 
     @Override
     public final void handle(RoutingContext ctx) {
-        RequestParams requestParams = RequestParams.from(ctx);
+        RequestParameters requestParams = RequestParameters.from(ctx);
         try {
             if (requiresAuthentication()
                     && !validateRequestAuthorization(
@@ -123,7 +123,7 @@ abstract class AbstractV2RequestHandler<T> implements RequestHandler {
         return auth.validateHttpHeader(() -> authHeader);
     }
 
-    protected ConnectionDescriptor getConnectionDescriptorFromParams(RequestParams params) {
+    protected ConnectionDescriptor getConnectionDescriptorFromParams(RequestParameters params) {
         String targetId = params.getPathParams().get("targetId");
         Credentials credentials = null;
         if (params.getHeaders().contains(JMX_AUTHORIZATION_HEADER)) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
@@ -51,15 +51,17 @@ import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.exception.ExceptionUtils;
+
+import org.openjdk.jmc.rjmx.ConnectionException;
+
 import com.google.gson.Gson;
+
 import com.redhat.rhjmc.containerjfr.core.net.Credentials;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
 import com.redhat.rhjmc.containerjfr.net.web.http.RequestHandler;
-
-import org.apache.commons.lang.exception.ExceptionUtils;
-import org.openjdk.jmc.rjmx.ConnectionException;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
@@ -44,24 +44,22 @@ package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
 import java.nio.charset.StandardCharsets;
 import java.rmi.ConnectIOException;
 import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
-
-import org.openjdk.jmc.rjmx.ConnectionException;
-
 import com.google.gson.Gson;
-
 import com.redhat.rhjmc.containerjfr.core.net.Credentials;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
 import com.redhat.rhjmc.containerjfr.net.web.http.RequestHandler;
+import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiMeta;
+import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiResponse;
+import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiResultData;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.openjdk.jmc.rjmx.ConnectionException;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
@@ -172,20 +170,9 @@ abstract class AbstractV2RequestHandler<T> implements RequestHandler {
         }
         intermediateResponse.headers.forEach(response::putHeader);
 
-        Map<String, String> meta = new HashMap<>();
-        meta.put("type", Objects.requireNonNull(mimeType()).mime());
-        if (response.getStatusMessage() != null) {
-            meta.put("status", response.getStatusMessage());
-        }
-
-        Map<String, T> data = new HashMap<>();
-        if (intermediateResponse.body != null) {
-            data.put("data", intermediateResponse.body);
-        }
-
-        Map<String, Map<String, ?>> body = new HashMap<>();
-        body.put("meta", meta);
-        body.put("data", data);
+        ApiMeta meta = new ApiMeta(mimeType(), response.getStatusMessage());
+        ApiResultData<T> data = new ApiResultData<>(intermediateResponse.body);
+        ApiResponse<ApiResultData<T>> body = new ApiResponse<>(meta, data);
 
         response.end(gson.toJson(body));
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
@@ -48,7 +48,12 @@ import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.exception.ExceptionUtils;
+
+import org.openjdk.jmc.rjmx.ConnectionException;
+
 import com.google.gson.Gson;
+
 import com.redhat.rhjmc.containerjfr.core.net.Credentials;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
@@ -57,9 +62,6 @@ import com.redhat.rhjmc.containerjfr.net.web.http.RequestHandler;
 import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiMeta;
 import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiResponse;
 import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiResultData;
-
-import org.apache.commons.lang.exception.ExceptionUtils;
-import org.openjdk.jmc.rjmx.ConnectionException;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
@@ -164,14 +166,14 @@ abstract class AbstractV2RequestHandler<T> implements RequestHandler {
 
     protected void writeResponse(RoutingContext ctx, IntermediateResponse<T> intermediateResponse) {
         HttpServerResponse response = ctx.response();
-        response.setStatusCode(intermediateResponse.statusCode);
-        if (intermediateResponse.statusMessage != null) {
-            response.setStatusMessage(intermediateResponse.statusMessage);
+        response.setStatusCode(intermediateResponse.getStatusCode());
+        if (intermediateResponse.getStatusMessage() != null) {
+            response.setStatusMessage(intermediateResponse.getStatusMessage());
         }
-        intermediateResponse.headers.forEach(response::putHeader);
+        intermediateResponse.getHeaders().forEach(response::putHeader);
 
         ApiMeta meta = new ApiMeta(mimeType(), response.getStatusMessage());
-        ApiResultData<T> data = new ApiResultData<>(intermediateResponse.body);
+        ApiResultData<T> data = new ApiResultData<>(intermediateResponse.getBody());
         ApiResponse<ApiResultData<T>> body = new ApiResponse<>(meta, data);
 
         response.end(gson.toJson(body));

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/ApiException.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/ApiException.java
@@ -41,8 +41,6 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
 
-import java.util.Objects;
-
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 public class ApiException extends HttpStatusException {
@@ -53,7 +51,7 @@ public class ApiException extends HttpStatusException {
     ApiException(int statusCode, String apiStatus, String reason, Throwable cause) {
         super(statusCode, cause);
         this.apiStatus = apiStatus;
-        this.reason = Objects.requireNonNull(reason);
+        this.reason = reason;
     }
 
     ApiException(int statusCode, String apiStatus, String reason) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/ApiException.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/ApiException.java
@@ -1,0 +1,82 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
+
+import java.util.Objects;
+
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+public class ApiException extends HttpStatusException {
+
+    protected final String apiStatus;
+    protected final String reason;
+
+    ApiException(int statusCode, String apiStatus, String reason, Throwable cause) {
+        super(statusCode, cause);
+        this.apiStatus = apiStatus;
+        this.reason = Objects.requireNonNull(reason);
+    }
+
+    ApiException(int statusCode, String apiStatus, String reason) {
+        this(statusCode, apiStatus, reason, null);
+    }
+
+    ApiException(int statusCode, String reason, Throwable cause) {
+        this(statusCode, null, reason, cause);
+    }
+
+    ApiException(int statusCode, String reason) {
+        this(statusCode, null, reason, null);
+    }
+
+    ApiException(int statusCode) {
+        this(statusCode, null);
+    }
+
+    public String getApiStatus() {
+        return apiStatus;
+    }
+
+    public String getFailureReason() {
+        return reason;
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/CertificatePostHandler.java
@@ -130,7 +130,7 @@ class CertificatePostHandler extends AbstractV2RequestHandler<Path> {
     }
 
     @Override
-    public IntermediateResponse<Path> handle(RequestParams params) throws ApiException {
+    public IntermediateResponse<Path> handle(RequestParameters params) throws ApiException {
         FileUpload cert = null;
         for (FileUpload fu : params.getFileUploads()) {
             if ("cert".equals(fu.name())) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/IntermediateResponse.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/IntermediateResponse.java
@@ -51,4 +51,28 @@ class IntermediateResponse<T> {
     protected String statusMessage;
     protected T body;
 
+    IntermediateResponse<T> addHeader(String key, String value) {
+        this.headers.put(key, value);
+        return this;
+    }
+
+    IntermediateResponse<T> removeHeader(String key) {
+        this.headers.remove(key);
+        return this;
+    }
+
+    IntermediateResponse<T> statusCode(int statusCode) {
+        this.statusCode = statusCode;
+        return this;
+    }
+
+    IntermediateResponse<T> statusMessage(String statusMessage) {
+        this.statusMessage = statusMessage;
+        return this;
+    }
+
+    IntermediateResponse<T> body(T body) {
+        this.body = body;
+        return this;
+    }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/IntermediateResponse.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/IntermediateResponse.java
@@ -46,17 +46,17 @@ import java.util.Map;
 
 class IntermediateResponse<T> {
 
-    private final Map<String, String> headers = new HashMap<>();
+    private final Map<CharSequence, CharSequence> headers = new HashMap<>();
     private int statusCode = 200;
     private String statusMessage;
     private T body;
 
-    IntermediateResponse<T> addHeader(String key, String value) {
+    IntermediateResponse<T> addHeader(CharSequence key, CharSequence value) {
         this.headers.put(key, value);
         return this;
     }
 
-    IntermediateResponse<T> removeHeader(String key) {
+    IntermediateResponse<T> removeHeader(CharSequence key) {
         this.headers.remove(key);
         return this;
     }
@@ -80,7 +80,7 @@ class IntermediateResponse<T> {
         return this.statusCode;
     }
 
-    Map<String, String> getHeaders() {
+    Map<CharSequence, CharSequence> getHeaders() {
         return this.headers;
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/IntermediateResponse.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/IntermediateResponse.java
@@ -46,10 +46,10 @@ import java.util.Map;
 
 class IntermediateResponse<T> {
 
-    protected final Map<String, String> headers = new HashMap<>();
-    protected int statusCode = 200;
-    protected String statusMessage;
-    protected T body;
+    private final Map<String, String> headers = new HashMap<>();
+    private int statusCode = 200;
+    private String statusMessage;
+    private T body;
 
     IntermediateResponse<T> addHeader(String key, String value) {
         this.headers.put(key, value);
@@ -74,5 +74,21 @@ class IntermediateResponse<T> {
     IntermediateResponse<T> body(T body) {
         this.body = body;
         return this;
+    }
+
+    int getStatusCode() {
+        return this.statusCode;
+    }
+
+    Map<String, String> getHeaders() {
+        return this.headers;
+    }
+
+    String getStatusMessage() {
+        return this.statusMessage;
+    }
+
+    T getBody() {
+        return this.body;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/IntermediateResponse.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/IntermediateResponse.java
@@ -1,0 +1,54 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class IntermediateResponse<T> {
+
+    protected final Map<String, String> headers = new HashMap<>();
+    protected int statusCode = 200;
+    protected String statusMessage;
+    protected T body;
+
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/RequestParameters.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/RequestParameters.java
@@ -50,14 +50,14 @@ import io.vertx.core.MultiMap;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
 
-class RequestParams {
+class RequestParameters {
 
     private final Map<String, String> pathParams;
     private final MultiMap queryParams;
     private final MultiMap headers;
     private final Set<FileUpload> fileUploads;
 
-    RequestParams(
+    RequestParameters(
             Map<String, String> pathParams,
             MultiMap queryParams,
             MultiMap headers,
@@ -70,7 +70,7 @@ class RequestParams {
         this.fileUploads = new HashSet<>(fileUploads);
     }
 
-    static RequestParams from(RoutingContext ctx) {
+    static RequestParameters from(RoutingContext ctx) {
         Map<String, String> pathParams = new HashMap<>();
         if (ctx != null && ctx.pathParams() != null) {
             pathParams.putAll(ctx.pathParams());
@@ -91,7 +91,7 @@ class RequestParams {
             fileUploads.addAll(ctx.fileUploads());
         }
 
-        return new RequestParams(pathParams, queryParams, headers, fileUploads);
+        return new RequestParameters(pathParams, queryParams, headers, fileUploads);
     }
 
     Map<String, String> getPathParams() {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/RequestParams.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/RequestParams.java
@@ -1,0 +1,71 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
+
+import java.util.Map;
+import java.util.Set;
+
+import io.vertx.core.MultiMap;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.ParsedHeaderValues;
+import io.vertx.ext.web.RoutingContext;
+
+class RequestParams {
+
+    protected final Map<String, String> pathParams;
+    protected final MultiMap queryParams;
+    protected final ParsedHeaderValues headers;
+    protected final Set<FileUpload> fileUploads;
+
+    RequestParams(Map<String, String> pathParams, MultiMap queryParams, ParsedHeaderValues headers, Set<FileUpload> fileUploads) {
+        this.pathParams = pathParams;
+        this.queryParams = queryParams;
+        this.headers = headers;
+        this.fileUploads = fileUploads;
+    }
+
+    static RequestParams from(RoutingContext ctx) {
+        return new RequestParams(ctx.pathParams(), ctx.queryParams(), ctx.parsedHeaders(),
+                ctx.fileUploads());
+    }
+
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/RequestParams.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/RequestParams.java
@@ -41,6 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -50,24 +52,61 @@ import io.vertx.ext.web.RoutingContext;
 
 class RequestParams {
 
-    protected final Map<String, String> pathParams;
-    protected final MultiMap queryParams;
-    protected final MultiMap headers;
-    protected final Set<FileUpload> fileUploads;
+    private final Map<String, String> pathParams;
+    private final MultiMap queryParams;
+    private final MultiMap headers;
+    private final Set<FileUpload> fileUploads;
 
     RequestParams(
             Map<String, String> pathParams,
             MultiMap queryParams,
             MultiMap headers,
             Set<FileUpload> fileUploads) {
-        this.pathParams = pathParams;
-        this.queryParams = queryParams;
-        this.headers = headers;
-        this.fileUploads = fileUploads;
+        this.pathParams = new HashMap<>(pathParams);
+        this.queryParams = MultiMap.caseInsensitiveMultiMap();
+        this.queryParams.addAll(queryParams);
+        this.headers = MultiMap.caseInsensitiveMultiMap();
+        this.headers.addAll(headers);
+        this.fileUploads = new HashSet<>(fileUploads);
     }
 
     static RequestParams from(RoutingContext ctx) {
-        return new RequestParams(
-                ctx.pathParams(), ctx.queryParams(), ctx.request().headers(), ctx.fileUploads());
+        Map<String, String> pathParams = new HashMap<>();
+        if (ctx != null && ctx.pathParams() != null) {
+            pathParams.putAll(ctx.pathParams());
+        }
+
+        MultiMap queryParams = MultiMap.caseInsensitiveMultiMap();
+        if (ctx != null && ctx.queryParams() != null) {
+            queryParams.addAll(ctx.queryParams());
+        }
+
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+        if (ctx != null && ctx.request() != null && ctx.request().headers() != null) {
+            headers.addAll(ctx.request().headers());
+        }
+
+        Set<FileUpload> fileUploads = new HashSet<>();
+        if (ctx != null && ctx.fileUploads() != null) {
+            fileUploads.addAll(ctx.fileUploads());
+        }
+
+        return new RequestParams(pathParams, queryParams, headers, fileUploads);
+    }
+
+    Map<String, String> getPathParams() {
+        return this.pathParams;
+    }
+
+    MultiMap getQueryParams() {
+        return this.queryParams;
+    }
+
+    MultiMap getHeaders() {
+        return this.headers;
+    }
+
+    Set<FileUpload> getFileUploads() {
+        return this.fileUploads;
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetEventsSearchGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetEventsSearchGetHandler.java
@@ -103,7 +103,7 @@ class TargetEventsSearchGetHandler
     }
 
     @Override
-    public IntermediateResponse<List<SerializableEventTypeInfo>> handle(RequestParams params)
+    public IntermediateResponse<List<SerializableEventTypeInfo>> handle(RequestParameters params)
             throws Exception {
         return targetConnectionManager.executeConnectedTask(
                 getConnectionDescriptorFromParams(params),

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetEventsSearchGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetEventsSearchGetHandler.java
@@ -108,7 +108,7 @@ class TargetEventsSearchGetHandler
         return targetConnectionManager.executeConnectedTask(
                 getConnectionDescriptorFromParams(params),
                 connection -> {
-                    String query = params.pathParams.get("query");
+                    String query = params.getPathParams().get("query");
                     List<SerializableEventTypeInfo> matchingEvents =
                             connection.getService().getAvailableEventTypes().stream()
                                     .filter(

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetRecordingOptionsListGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetRecordingOptionsListGetHandler.java
@@ -47,18 +47,19 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.openjdk.jmc.common.unit.IOptionDescriptor;
+
 import com.google.gson.Gson;
+
 import com.redhat.rhjmc.containerjfr.jmc.serialization.SerializableOptionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
 import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiVersion;
-
-import org.openjdk.jmc.common.unit.IOptionDescriptor;
-
 import io.vertx.core.http.HttpMethod;
 
-class TargetRecordingOptionsListGetHandler extends AbstractV2RequestHandler<List<SerializableOptionDescriptor>> {
+class TargetRecordingOptionsListGetHandler
+        extends AbstractV2RequestHandler<List<SerializableOptionDescriptor>> {
 
     private final TargetConnectionManager connectionManager;
 
@@ -100,7 +101,8 @@ class TargetRecordingOptionsListGetHandler extends AbstractV2RequestHandler<List
     }
 
     @Override
-    IntermediateResponse<List<SerializableOptionDescriptor>> handle(RequestParams requestParams) throws Exception {
+    IntermediateResponse<List<SerializableOptionDescriptor>> handle(RequestParams requestParams)
+            throws Exception {
         List<SerializableOptionDescriptor> options =
                 connectionManager.executeConnectedTask(
                         getConnectionDescriptorFromParams(requestParams),

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetRecordingOptionsListGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetRecordingOptionsListGetHandler.java
@@ -101,7 +101,7 @@ class TargetRecordingOptionsListGetHandler
     }
 
     @Override
-    IntermediateResponse<List<SerializableOptionDescriptor>> handle(RequestParams requestParams)
+    IntermediateResponse<List<SerializableOptionDescriptor>> handle(RequestParameters requestParams)
             throws Exception {
         List<SerializableOptionDescriptor> options =
                 connectionManager.executeConnectedTask(

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetSnapshotPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetSnapshotPostHandler.java
@@ -108,7 +108,7 @@ class TargetSnapshotPostHandler
 
     @Override
     IntermediateResponse<HyperlinkedSerializableRecordingDescriptor> handle(
-            RequestParams requestParams) throws Exception {
+            RequestParameters requestParams) throws Exception {
         HyperlinkedSerializableRecordingDescriptor desc =
                 targetConnectionManager.executeConnectedTask(
                         getConnectionDescriptorFromParams(requestParams),

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetSnapshotPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetSnapshotPostHandler.java
@@ -43,7 +43,12 @@ package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
 
 import javax.inject.Inject;
 
+import org.openjdk.jmc.common.unit.QuantityConversionException;
+import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
 import com.google.gson.Gson;
+
 import com.redhat.rhjmc.containerjfr.commands.internal.RecordingOptionsBuilderFactory;
 import com.redhat.rhjmc.containerjfr.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
@@ -52,15 +57,12 @@ import com.redhat.rhjmc.containerjfr.net.web.WebServer;
 import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
 import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiVersion;
 
-import org.openjdk.jmc.common.unit.QuantityConversionException;
-import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
-import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
-
 import dagger.Lazy;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 
-class TargetSnapshotPostHandler extends AbstractV2RequestHandler<HyperlinkedSerializableRecordingDescriptor>{
+class TargetSnapshotPostHandler
+        extends AbstractV2RequestHandler<HyperlinkedSerializableRecordingDescriptor> {
 
     private final TargetConnectionManager targetConnectionManager;
     private final Lazy<WebServer> webServer;
@@ -105,8 +107,8 @@ class TargetSnapshotPostHandler extends AbstractV2RequestHandler<HyperlinkedSeri
     }
 
     @Override
-    IntermediateResponse<HyperlinkedSerializableRecordingDescriptor> handle(RequestParams requestParams)
-            throws Exception {
+    IntermediateResponse<HyperlinkedSerializableRecordingDescriptor> handle(
+            RequestParams requestParams) throws Exception {
         HyperlinkedSerializableRecordingDescriptor desc =
                 targetConnectionManager.executeConnectedTask(
                         getConnectionDescriptorFromParams(requestParams),
@@ -134,9 +136,10 @@ class TargetSnapshotPostHandler extends AbstractV2RequestHandler<HyperlinkedSeri
                                     webServer.get().getDownloadURL(connection, rename),
                                     webServer.get().getReportURL(connection, rename));
                         });
-        return new
-            IntermediateResponse<HyperlinkedSerializableRecordingDescriptor>().statusCode(201).addHeader(HttpHeaders.LOCATION,
-                    desc.getDownloadUrl()).body(desc);
+        return new IntermediateResponse<HyperlinkedSerializableRecordingDescriptor>()
+                .statusCode(201)
+                .addHeader(HttpHeaders.LOCATION, desc.getDownloadUrl())
+                .body(desc);
     }
 
     static class SnapshotDescriptor extends HyperlinkedSerializableRecordingDescriptor {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/util/HttpMimeTypeAdapter.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/util/HttpMimeTypeAdapter.java
@@ -39,35 +39,32 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
+package com.redhat.rhjmc.containerjfr.util;
 
-import java.util.Map;
-import java.util.Set;
+import java.io.IOException;
+import java.util.Objects;
 
-import io.vertx.core.MultiMap;
-import io.vertx.ext.web.FileUpload;
-import io.vertx.ext.web.RoutingContext;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 
-class RequestParams {
+import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
 
-    protected final Map<String, String> pathParams;
-    protected final MultiMap queryParams;
-    protected final MultiMap headers;
-    protected final Set<FileUpload> fileUploads;
+public class HttpMimeTypeAdapter extends TypeAdapter<HttpMimeType> {
 
-    RequestParams(
-            Map<String, String> pathParams,
-            MultiMap queryParams,
-            MultiMap headers,
-            Set<FileUpload> fileUploads) {
-        this.pathParams = pathParams;
-        this.queryParams = queryParams;
-        this.headers = headers;
-        this.fileUploads = fileUploads;
+    @Override
+    public HttpMimeType read(JsonReader reader) throws IOException {
+        String token = reader.nextString();
+        for (HttpMimeType mime : HttpMimeType.values()) {
+            if (Objects.equals(mime.mime(), token)) {
+                return mime;
+            }
+        }
+        return null;
     }
 
-    static RequestParams from(RoutingContext ctx) {
-        return new RequestParams(
-                ctx.pathParams(), ctx.queryParams(), ctx.request().headers(), ctx.fileUploads());
+    @Override
+    public void write(JsonWriter writer, HttpMimeType mime) throws IOException {
+        writer.value(mime.mime());
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/util/PathTypeAdapter.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/util/PathTypeAdapter.java
@@ -39,22 +39,25 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr.net.web.http.api;
+package com.redhat.rhjmc.containerjfr.util;
 
-public class ApiResponse<T extends ApiData> {
-    protected ApiMeta meta;
-    protected T data;
+import java.io.IOException;
+import java.nio.file.Path;
 
-    public ApiResponse(ApiMeta meta, T data) {
-        this.meta = meta;
-        this.data = data;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public class PathTypeAdapter extends TypeAdapter<Path> {
+
+    @Override
+    public Path read(JsonReader reader) throws IOException {
+        String token = reader.nextString();
+        return Path.of(token);
     }
 
-    public ApiMeta getMeta() {
-        return this.meta;
-    }
-
-    public ApiData getData() {
-        return this.data;
+    @Override
+    public void write(JsonWriter writer, Path path) throws IOException {
+        writer.value(path.toString());
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
@@ -1,0 +1,409 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
+
+import static org.mockito.Mockito.when;
+
+import java.rmi.ConnectIOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.gson.Gson;
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
+import com.redhat.rhjmc.containerjfr.net.web.http.AbstractAuthenticatedRequestHandler;
+import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
+import com.redhat.rhjmc.containerjfr.net.web.http.RequestHandler;
+import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiVersion;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openjdk.jmc.rjmx.ConnectionException;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractV2RequestHandlerTest {
+
+    RequestHandler handler;
+    @Mock RoutingContext ctx;
+    MultiMap headers;
+    @Mock Map<String, String> pathParams;
+    @Mock HttpServerRequest req;
+    @Mock HttpServerResponse resp;
+    @Mock AuthManager auth;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        Mockito.lenient().when(ctx.pathParams()).thenReturn(pathParams);
+        Mockito.lenient().when(ctx.queryParams()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        Mockito.lenient().when(ctx.fileUploads()).thenReturn(Collections.emptySet());
+
+        this.headers = Mockito.mock(MultiMap.class);
+
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.lenient().when(req.headers()).thenReturn(headers);
+        Mockito.lenient().when(ctx.request()).thenReturn(req);
+        Mockito.lenient().when(ctx.response()).thenReturn(resp);
+
+        this.handler = new AuthenticatedHandler(auth, gson);
+    }
+
+    @Test
+    void shouldThrow401IfAuthFails() {
+        when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(false));
+
+        ApiException ex =
+                Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
+    }
+
+    @Test
+    void shouldThrow500IfAuthThrows() {
+        when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.failedFuture(new NullPointerException()));
+
+        ApiException ex =
+                Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+
+    @Nested
+    class WithHandlerThrownException {
+
+        @BeforeEach
+        void setup2() {
+            when(auth.validateHttpHeader(Mockito.any()))
+                    .thenReturn(CompletableFuture.completedFuture(true));
+        }
+
+        @Test
+        void shouldPropagateIfHandlerThrowsApiException() {
+            Exception expectedException = new ApiException(200);
+            handler = new ThrowingAuthenticatedHandler(auth, gson, expectedException);
+
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+            MatcherAssert.assertThat(ex, Matchers.sameInstance(expectedException));
+        }
+
+        @Test
+        void shouldThrow500IfConnectionFails() {
+            Exception expectedException = new ConnectionException("");
+            handler = new ThrowingAuthenticatedHandler(auth, gson, expectedException);
+
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+        }
+
+        @Test
+        void shouldThrow427IfConnectionFailsDueToTargetAuth() {
+            Exception cause = new SecurityException();
+            Exception expectedException = new ConnectionException("");
+            expectedException.initCause(cause);
+            handler = new ThrowingAuthenticatedHandler(auth, gson, expectedException);
+
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
+            Mockito.verify(resp).putHeader("X-JMX-Authenticate", "Basic");
+        }
+
+        @Test
+        void shouldThrow502IfConnectionFailsDueToSslTrust() {
+            Exception cause = new ConnectIOException("SSL trust");
+            Exception expectedException = new ConnectionException("");
+            expectedException.initCause(cause);
+            handler = new ThrowingAuthenticatedHandler(auth, gson, expectedException);
+
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(502));
+            MatcherAssert.assertThat(ex.getFailureReason(), Matchers.equalTo("Target SSL Untrusted"));
+        }
+
+        @Test
+        void shouldThrow500IfHandlerThrowsUnexpectedly() {
+            Exception expectedException = new NullPointerException();
+            handler = new ThrowingAuthenticatedHandler(auth, gson, expectedException);
+
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+        }
+    }
+
+    @Nested
+    class WithTargetAuth {
+
+        ConnectionDescriptorHandler handler;
+
+        @BeforeEach
+        void setup3() {
+            handler = new ConnectionDescriptorHandler(auth, gson);
+            when(auth.validateHttpHeader(Mockito.any()))
+                    .thenReturn(CompletableFuture.completedFuture(true));
+        }
+
+        @Test
+        void shouldUseNoCredentialsWithoutAuthorizationHeader() {
+            String targetId = "fooTarget";
+            Mockito.when(pathParams.get("targetId")).thenReturn(targetId);
+            Mockito.when(headers.contains(Mockito.anyString())).thenReturn(false);
+
+            handler.handle(ctx);
+            ConnectionDescriptor desc = handler.desc;
+
+            MatcherAssert.assertThat(desc.getTargetId(), Matchers.equalTo(targetId));
+            Assertions.assertFalse(desc.getCredentials().isPresent());
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+                strings = {
+                    "",
+                    "credentialsWithoutAuthType",
+                })
+        void shouldThrow427WithMalformedAuthorizationHeader(String authHeader) {
+            String targetId = "fooTarget";
+            Mockito.when(pathParams.get("targetId")).thenReturn(targetId);
+            Mockito.when(
+                            headers.contains(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+                    .thenReturn(true);
+            Mockito.when(
+                            headers.get(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+                    .thenReturn(authHeader);
+
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
+            MatcherAssert.assertThat(
+                    ex.getFailureReason(), Matchers.equalTo("Invalid X-JMX-Authorization format"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+                strings = {
+                    "Type credentials",
+                    "Bearer credentials",
+                })
+        void shouldThrow427WithBadAuthorizationType(String authHeader) {
+            String targetId = "fooTarget";
+            Mockito.when(pathParams.get("targetId")).thenReturn(targetId);
+            Mockito.when(
+                            headers.contains(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+                    .thenReturn(true);
+            Mockito.when(
+                            headers.get(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+                    .thenReturn(authHeader);
+
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+            ex.printStackTrace();
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
+            MatcherAssert.assertThat(
+                    ex.getFailureReason(), Matchers.equalTo("Unacceptable X-JMX-Authorization type"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+                strings = {
+                    "Basic bm9zZXBhcmF0b3I=", // credential value of "noseparator"
+                    "Basic b25lOnR3bzp0aHJlZQ==", // credential value of "one:two:three"
+                })
+        void shouldThrow427WithBadCredentialFormat(String authHeader) {
+            String targetId = "fooTarget";
+            Mockito.when(pathParams.get("targetId")).thenReturn(targetId);
+            Mockito.when(
+                            headers.contains(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+                    .thenReturn(true);
+            Mockito.when(
+                            headers.get(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+                    .thenReturn(authHeader);
+
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
+            MatcherAssert.assertThat(
+                    ex.getFailureReason(),
+                    Matchers.equalTo("Unrecognized X-JMX-Authorization credential format"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+                strings = {
+                    "Basic foo:bar",
+                })
+        void shouldThrow427WithUnencodedCredentials(String authHeader) {
+            String targetId = "fooTarget";
+            Mockito.when(pathParams.get("targetId")).thenReturn(targetId);
+            Mockito.when(
+                            headers.contains(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+                    .thenReturn(true);
+            Mockito.when(
+                            headers.get(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+                    .thenReturn(authHeader);
+
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
+            MatcherAssert.assertThat(
+                    ex.getFailureReason(),
+                    Matchers.equalTo(
+                            "X-JMX-Authorization credentials do not appear to be Base64-encoded"));
+        }
+
+        @Test
+        void shouldIncludeCredentialsFromAppropriateHeader() {
+            String targetId = "fooTarget";
+            Mockito.when(pathParams.get("targetId")).thenReturn(targetId);
+            Mockito.when(
+                            headers.contains(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+                    .thenReturn(true);
+            Mockito.when(
+                            headers.get(
+                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+                    .thenReturn("Basic Zm9vOmJhcg==");
+
+            Assertions.assertDoesNotThrow(() -> handler.handle(ctx));
+            ConnectionDescriptor desc = handler.desc;
+
+            MatcherAssert.assertThat(desc.getTargetId(), Matchers.equalTo(targetId));
+            Assertions.assertTrue(desc.getCredentials().isPresent());
+        }
+    }
+
+    static class AuthenticatedHandler extends AbstractV2RequestHandler<String> {
+        AuthenticatedHandler(AuthManager auth, Gson gson) {
+            super(auth, gson);
+        }
+
+        @Override
+        public ApiVersion apiVersion() {
+            return ApiVersion.V2;
+        }
+
+        @Override
+        boolean requiresAuthentication() {
+            return true;
+        }
+
+        @Override
+        public String path() {
+            return null;
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return null;
+        }
+
+        @Override
+        public HttpMimeType mimeType() {
+            return HttpMimeType.PLAINTEXT;
+        }
+
+        @Override
+        public IntermediateResponse<String> handle(RequestParams params) throws Exception {
+            return new IntermediateResponse<String>().body("OK");
+        }
+    }
+
+    static class ThrowingAuthenticatedHandler extends AuthenticatedHandler {
+        private final Exception thrown;
+
+        ThrowingAuthenticatedHandler(AuthManager auth, Gson gson, Exception thrown) {
+            super(auth, gson);
+            this.thrown = thrown;
+        }
+
+        @Override
+        public IntermediateResponse<String> handle(RequestParams params) throws Exception {
+            throw thrown;
+        }
+    }
+
+    static class ConnectionDescriptorHandler extends AuthenticatedHandler {
+        ConnectionDescriptor desc;
+
+        ConnectionDescriptorHandler(AuthManager auth, Gson gson) {
+            super(auth, gson);
+        }
+
+        @Override
+        public IntermediateResponse<String> handle(RequestParams params) throws Exception {
+            desc = getConnectionDescriptorFromParams(params);
+            return new IntermediateResponse<String>().body("should have thrown");
+        }
+    }
+
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
@@ -69,7 +69,6 @@ import com.redhat.rhjmc.containerjfr.MainModule;
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.net.AuthManager;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
-import com.redhat.rhjmc.containerjfr.net.web.http.AbstractAuthenticatedRequestHandler;
 import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
 import com.redhat.rhjmc.containerjfr.net.web.http.RequestHandler;
 import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiVersion;
@@ -99,7 +98,7 @@ class AbstractV2RequestHandlerTest {
         Mockito.lenient().when(ctx.queryParams()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.lenient().when(ctx.fileUploads()).thenReturn(Collections.emptySet());
 
-        this.headers = Mockito.mock(MultiMap.class);
+        this.headers = MultiMap.caseInsensitiveMultiMap();
 
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.lenient().when(req.headers()).thenReturn(headers);
@@ -209,8 +208,7 @@ class AbstractV2RequestHandlerTest {
         @Test
         void shouldUseNoCredentialsWithoutAuthorizationHeader() {
             String targetId = "fooTarget";
-            Mockito.when(pathParams.get("targetId")).thenReturn(targetId);
-            Mockito.when(headers.contains(Mockito.anyString())).thenReturn(false);
+            Mockito.when(ctx.pathParams()).thenReturn(Map.of("targetId", targetId));
 
             handler.handle(ctx);
             ConnectionDescriptor desc = handler.desc;
@@ -227,13 +225,8 @@ class AbstractV2RequestHandlerTest {
                 })
         void shouldThrow427WithMalformedAuthorizationHeader(String authHeader) {
             String targetId = "fooTarget";
-            Mockito.when(pathParams.get("targetId")).thenReturn(targetId);
-            Mockito.when(
-                            headers.contains(
-                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
-                    .thenReturn(true);
-            Mockito.when(headers.get(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
-                    .thenReturn(authHeader);
+            Mockito.when(ctx.pathParams()).thenReturn(Map.of("targetId", targetId));
+            headers.set(AbstractV2RequestHandler.JMX_AUTHORIZATION_HEADER, authHeader);
 
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
@@ -250,13 +243,8 @@ class AbstractV2RequestHandlerTest {
                 })
         void shouldThrow427WithBadAuthorizationType(String authHeader) {
             String targetId = "fooTarget";
-            Mockito.when(pathParams.get("targetId")).thenReturn(targetId);
-            Mockito.when(
-                            headers.contains(
-                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
-                    .thenReturn(true);
-            Mockito.when(headers.get(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
-                    .thenReturn(authHeader);
+            Mockito.when(ctx.pathParams()).thenReturn(Map.of("targetId", targetId));
+            headers.set(AbstractV2RequestHandler.JMX_AUTHORIZATION_HEADER, authHeader);
 
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
@@ -275,13 +263,8 @@ class AbstractV2RequestHandlerTest {
                 })
         void shouldThrow427WithBadCredentialFormat(String authHeader) {
             String targetId = "fooTarget";
-            Mockito.when(pathParams.get("targetId")).thenReturn(targetId);
-            Mockito.when(
-                            headers.contains(
-                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
-                    .thenReturn(true);
-            Mockito.when(headers.get(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
-                    .thenReturn(authHeader);
+            Mockito.when(ctx.pathParams()).thenReturn(Map.of("targetId", targetId));
+            headers.set(AbstractV2RequestHandler.JMX_AUTHORIZATION_HEADER, authHeader);
 
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
@@ -298,13 +281,8 @@ class AbstractV2RequestHandlerTest {
                 })
         void shouldThrow427WithUnencodedCredentials(String authHeader) {
             String targetId = "fooTarget";
-            Mockito.when(pathParams.get("targetId")).thenReturn(targetId);
-            Mockito.when(
-                            headers.contains(
-                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
-                    .thenReturn(true);
-            Mockito.when(headers.get(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
-                    .thenReturn(authHeader);
+            Mockito.when(ctx.pathParams()).thenReturn(Map.of("targetId", targetId));
+            headers.set(AbstractV2RequestHandler.JMX_AUTHORIZATION_HEADER, authHeader);
 
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
@@ -318,13 +296,8 @@ class AbstractV2RequestHandlerTest {
         @Test
         void shouldIncludeCredentialsFromAppropriateHeader() {
             String targetId = "fooTarget";
-            Mockito.when(pathParams.get("targetId")).thenReturn(targetId);
-            Mockito.when(
-                            headers.contains(
-                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
-                    .thenReturn(true);
-            Mockito.when(headers.get(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
-                    .thenReturn("Basic Zm9vOmJhcg==");
+            Mockito.when(ctx.pathParams()).thenReturn(Map.of("targetId", targetId));
+            headers.set(AbstractV2RequestHandler.JMX_AUTHORIZATION_HEADER, "Basic Zm9vOmJhcg==");
 
             Assertions.assertDoesNotThrow(() -> handler.handle(ctx));
             ConnectionDescriptor desc = handler.desc;
@@ -394,7 +367,7 @@ class AbstractV2RequestHandlerTest {
         @Override
         public IntermediateResponse<String> handle(RequestParams params) throws Exception {
             desc = getConnectionDescriptorFromParams(params);
-            return new IntermediateResponse<String>().body("should have thrown");
+            return new IntermediateResponse<String>().body("");
         }
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
@@ -338,7 +338,7 @@ class AbstractV2RequestHandlerTest {
         }
 
         @Override
-        public IntermediateResponse<String> handle(RequestParams params) throws Exception {
+        public IntermediateResponse<String> handle(RequestParameters params) throws Exception {
             return new IntermediateResponse<String>().body("OK");
         }
     }
@@ -352,7 +352,7 @@ class AbstractV2RequestHandlerTest {
         }
 
         @Override
-        public IntermediateResponse<String> handle(RequestParams params) throws Exception {
+        public IntermediateResponse<String> handle(RequestParameters params) throws Exception {
             throw thrown;
         }
     }
@@ -365,7 +365,7 @@ class AbstractV2RequestHandlerTest {
         }
 
         @Override
-        public IntermediateResponse<String> handle(RequestParams params) throws Exception {
+        public IntermediateResponse<String> handle(RequestParameters params) throws Exception {
             desc = getConnectionDescriptorFromParams(params);
             return new IntermediateResponse<String>().body("");
         }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
@@ -48,16 +48,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import com.google.gson.Gson;
-import com.redhat.rhjmc.containerjfr.MainModule;
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
-import com.redhat.rhjmc.containerjfr.net.AuthManager;
-import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
-import com.redhat.rhjmc.containerjfr.net.web.http.AbstractAuthenticatedRequestHandler;
-import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
-import com.redhat.rhjmc.containerjfr.net.web.http.RequestHandler;
-import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiVersion;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -70,7 +60,19 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 import org.openjdk.jmc.rjmx.ConnectionException;
+
+import com.google.gson.Gson;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
+import com.redhat.rhjmc.containerjfr.net.web.http.AbstractAuthenticatedRequestHandler;
+import com.redhat.rhjmc.containerjfr.net.web.http.HttpMimeType;
+import com.redhat.rhjmc.containerjfr.net.web.http.RequestHandler;
+import com.redhat.rhjmc.containerjfr.net.web.http.api.ApiVersion;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
@@ -112,8 +114,7 @@ class AbstractV2RequestHandlerTest {
         when(auth.validateHttpHeader(Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(false));
 
-        ApiException ex =
-                Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -122,8 +123,7 @@ class AbstractV2RequestHandlerTest {
         when(auth.validateHttpHeader(Mockito.any()))
                 .thenReturn(CompletableFuture.failedFuture(new NullPointerException()));
 
-        ApiException ex =
-                Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 
@@ -179,7 +179,8 @@ class AbstractV2RequestHandlerTest {
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(502));
-            MatcherAssert.assertThat(ex.getFailureReason(), Matchers.equalTo("Target SSL Untrusted"));
+            MatcherAssert.assertThat(
+                    ex.getFailureReason(), Matchers.equalTo("Target SSL Untrusted"));
         }
 
         @Test
@@ -231,9 +232,7 @@ class AbstractV2RequestHandlerTest {
                             headers.contains(
                                     AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(
-                            headers.get(
-                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(headers.get(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
             ApiException ex =
@@ -256,9 +255,7 @@ class AbstractV2RequestHandlerTest {
                             headers.contains(
                                     AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(
-                            headers.get(
-                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(headers.get(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
             ApiException ex =
@@ -266,7 +263,8 @@ class AbstractV2RequestHandlerTest {
             ex.printStackTrace();
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
             MatcherAssert.assertThat(
-                    ex.getFailureReason(), Matchers.equalTo("Unacceptable X-JMX-Authorization type"));
+                    ex.getFailureReason(),
+                    Matchers.equalTo("Unacceptable X-JMX-Authorization type"));
         }
 
         @ParameterizedTest
@@ -282,9 +280,7 @@ class AbstractV2RequestHandlerTest {
                             headers.contains(
                                     AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(
-                            headers.get(
-                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(headers.get(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
             ApiException ex =
@@ -307,9 +303,7 @@ class AbstractV2RequestHandlerTest {
                             headers.contains(
                                     AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(
-                            headers.get(
-                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(headers.get(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
             ApiException ex =
@@ -329,9 +323,7 @@ class AbstractV2RequestHandlerTest {
                             headers.contains(
                                     AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(true);
-            Mockito.when(
-                            headers.get(
-                                    AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
+            Mockito.when(headers.get(AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn("Basic Zm9vOmJhcg==");
 
             Assertions.assertDoesNotThrow(() -> handler.handle(ctx));
@@ -405,5 +397,4 @@ class AbstractV2RequestHandlerTest {
             return new IntermediateResponse<String>().body("should have thrown");
         }
     }
-
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetEventsSearchGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetEventsSearchGetHandlerTest.java
@@ -113,8 +113,8 @@ class TargetEventsSearchGetHandlerTest {
         when(connection.getService()).thenReturn(service);
         when(service.getAvailableEventTypes()).thenReturn(Collections.emptyList());
 
-        RequestParams params =
-                new RequestParams(
+        RequestParameters params =
+                new RequestParameters(
                         Map.of("targetId", "foo:9091", "query", "foo"),
                         MultiMap.caseInsensitiveMultiMap(),
                         MultiMap.caseInsensitiveMultiMap(),
@@ -178,8 +178,8 @@ class TargetEventsSearchGetHandlerTest {
         when(connection.getService()).thenReturn(service);
         when(service.getAvailableEventTypes()).thenReturn((List) events);
 
-        RequestParams params =
-                new RequestParams(
+        RequestParameters params =
+                new RequestParameters(
                         Map.of("targetId", "foo:9091", "query", "foo"),
                         MultiMap.caseInsensitiveMultiMap(),
                         MultiMap.caseInsensitiveMultiMap(),

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetEventsSearchGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetEventsSearchGetHandlerTest.java
@@ -122,7 +122,7 @@ class TargetEventsSearchGetHandlerTest {
 
         IntermediateResponse<List<SerializableEventTypeInfo>> result = handler.handle(params);
 
-        MatcherAssert.assertThat(result.body, Matchers.equalTo(Collections.emptyList()));
+        MatcherAssert.assertThat(result.getBody(), Matchers.equalTo(Collections.emptyList()));
     }
 
     @Test
@@ -187,7 +187,7 @@ class TargetEventsSearchGetHandlerTest {
         IntermediateResponse<List<SerializableEventTypeInfo>> result = handler.handle(params);
 
         MatcherAssert.assertThat(
-                result.body,
+                result.getBody(),
                 Matchers.equalTo(
                         Arrays.asList(
                                 new SerializableEventTypeInfo(infoA),

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetRecordingOptionsListGetHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetRecordingOptionsListGetHandlerTest.java
@@ -50,16 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
-import com.redhat.rhjmc.containerjfr.MainModule;
-import com.redhat.rhjmc.containerjfr.core.log.Logger;
-import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
-import com.redhat.rhjmc.containerjfr.net.AuthManager;
-import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
-import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
-import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,8 +59,20 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 import org.openjdk.jmc.common.unit.IOptionDescriptor;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import com.redhat.rhjmc.containerjfr.MainModule;
+import com.redhat.rhjmc.containerjfr.core.log.Logger;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.net.AuthManager;
+import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
+import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager.ConnectedTask;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
@@ -129,7 +131,8 @@ class TargetRecordingOptionsListGetHandlerTest {
         Mockito.when(ctx.request()).thenReturn(req);
         Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
-        Mockito.when(auth.validateHttpHeader(Mockito.any())).thenReturn(CompletableFuture.completedFuture(true));
+        Mockito.when(auth.validateHttpHeader(Mockito.any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
 
         try {
             handler.handle(ctx);
@@ -157,11 +160,6 @@ class TargetRecordingOptionsListGetHandlerTest {
         expected.put("data", data);
         data.put("result", result);
 
-        MatcherAssert.assertThat(
-                response,
-                Matchers.equalTo(
-                expected
-                    )
-                );
+        MatcherAssert.assertThat(response, Matchers.equalTo(expected));
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetSnapshotPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetSnapshotPostHandlerTest.java
@@ -116,7 +116,7 @@ class TargetSnapshotPostHandlerTest {
         Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
         Mockito.when(ctx.response()).thenReturn(resp);
-        Mockito.when(ctx.pathParam("targetId")).thenReturn("someHost");
+        Mockito.when(ctx.pathParams()).thenReturn(Map.of("targetId", "someHost"));
 
         IRecordingDescriptor recordingDescriptor = createDescriptor("snapshot");
 
@@ -165,18 +165,30 @@ class TargetSnapshotPostHandlerTest {
                         endCaptor.getValue(), new TypeToken<Map<String, Object>>() {}.getType());
 
         Map<String, Object> expected = new HashMap<>();
-        expected.put("name", "snapshot-1");
-        expected.put("id", 1.0);
-        expected.put("downloadUrl", "http://example.com/download");
-        expected.put("reportUrl", "http://example.com/report");
-        expected.put("startTime", 0.0);
-        expected.put("state", "STOPPED");
-        expected.put("duration", 0.0);
-        expected.put("maxAge", 0.0);
-        expected.put("maxSize", 0.0);
-        expected.put("toDisk", false);
-        expected.put("continuous", false);
+        Map<String, Object> meta = new HashMap<>();
+        Map<String, Object> data = new HashMap<>();
+        Map<String, Object> result = new HashMap<>();
+        expected.put("meta", meta);
+        meta.put("type", "text/plain");
+        meta.put("status", "OK");
+        expected.put("data", data);
+        data.put("result", result);
+        result.put("name", "snapshot-1");
+        result.put("id", 1.0);
+        result.put("downloadUrl", "http://example.com/download");
+        result.put("reportUrl", "http://example.com/report");
+        result.put("startTime", 0.0);
+        result.put("state", "STOPPED");
+        result.put("duration", 0.0);
+        result.put("maxAge", 0.0);
+        result.put("maxSize", 0.0);
+        result.put("toDisk", false);
+        result.put("continuous", false);
         MatcherAssert.assertThat(parsed, Matchers.equalTo(expected));
+
+// Expected: <{duration=0.0, maxAge=0.0, toDisk=false, continuous=false, name=snapshot-1, downloadUrl=http://example.com/download, startTime=0.0, maxSize=0.0, id=1.0, reportUrl=http://example.com/report, state=STOPPED}>
+//      but: was <{meta={type=text/plain, status=OK}, data={result={downloadUrl=http://example.com/download, reportUrl=http://example.com/report, id=1.0, name=snapshot-1, state=STOPPED, startTime=0.0, duration=0.0, continuous=false, toD
+// isk=false, maxSize=0.0, maxAge=0.0}}}>
     }
 
     private static IRecordingDescriptor createDescriptor(String name)

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetSnapshotPostHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetSnapshotPostHandlerTest.java
@@ -185,10 +185,6 @@ class TargetSnapshotPostHandlerTest {
         result.put("toDisk", false);
         result.put("continuous", false);
         MatcherAssert.assertThat(parsed, Matchers.equalTo(expected));
-
-// Expected: <{duration=0.0, maxAge=0.0, toDisk=false, continuous=false, name=snapshot-1, downloadUrl=http://example.com/download, startTime=0.0, maxSize=0.0, id=1.0, reportUrl=http://example.com/report, state=STOPPED}>
-//      but: was <{meta={type=text/plain, status=OK}, data={result={downloadUrl=http://example.com/download, reportUrl=http://example.com/report, id=1.0, name=snapshot-1, state=STOPPED, startTime=0.0, duration=0.0, continuous=false, toD
-// isk=false, maxSize=0.0, maxAge=0.0}}}>
     }
 
     private static IRecordingDescriptor createDescriptor(String name)


### PR DESCRIPTION
Fixes #317

This PR introduces a new `AbstractV2RequestHandler` class, similar to the existing `AbstractAuthenticatedRequestHandler`, for all V2 API handlers to extend. Rather than passing in a Vertx `RoutingContext` directly to the handler and having it directly write to the context response, subclasses of this new abstract handler receive a `RequestParams` object which abstracts out the read-only request properties that the handler may require (such as path parameters, headers, query parameters). Rather than writing to the response directly (which is no longer available through the `RequestParams`), subclasses return an instance of `IntermediateResponse`, which encapsulates the response result body as well as an optional status code (default `200`), additional headers, and optional metadata status message. This overall structure is reminiscent of how Command Channel `(Serializable)Command`s are implemented, with the Command/Handler returning a data structure representing their response, and a higher-level class wrapping this response into some metadata, serializing it, and writing out the final representation to the network.

This structure allows all V2 handlers to maintain a consistent overall response format with each other without each needing to implement it individually, including any additions or changes to the overall response format. This also allows for more information about failures to be provided to clients through the metadata fields, without necessarily having to use custom HTTP status codes and messages.

The `WebServer failureHandler` is also modified to handle the new `ApiException` type in such a way that responses generated from this exception type being thrown follow the same response format as the V2 handlers, but with the metadata, data, and HTTP status code/message set to indicate that this is a failure response. The response body contains a JSON object formatted in the same way as a successful response, allowing clients to parse responses in a uniform way in either case.

This does not affect any V1 handlers, which continue to directly receive a `RoutingContext` and write responses directly, and which do not throw the new `ApiException` type (and so the failure behaviour implemented in the `WebServer` is unchanged).