### PR TITLE
Use 404 when Target Not Found

### DIFF
--- a/HTTP_API.md
+++ b/HTTP_API.md
@@ -517,8 +517,7 @@
     `200` - The body is a JSON array of event type objects.
 
     The format for an event type is
-    `{"name":"$NAME","typeId":"$TYPE_ID","description":"$DESCRIPTION",
-    "category":[$CATEGORIES],"options":{$OPTIONS}}`
+    `{"name":"$NAME","typeId":"$TYPE_ID","description":"$DESCRIPTION","category":[$CATEGORIES],"options":{$OPTIONS}}`
 
     `401` - User authentication failed. The body is an error message.
     There will be an `X-WWW-Authenticate: $SCHEME` header that indicates
@@ -632,7 +631,7 @@
     100  530k    0  530k    0     0  9303k      0 --:--:-- --:--:-- --:--:-- 9303k
     ```
 
-* ### `TargetRecordingOptionsGetHandler`
+* #### `TargetRecordingOptionsGetHandler`
 
     ###### synopsis
     Returns the default recording options of a target JVM.
@@ -670,7 +669,7 @@
     ```
 
 
-* ### `TargetRecordingOptionsPatchHandler`
+* #### `TargetRecordingOptionsPatchHandler`
 
     ###### synopsis
     Sets the default recording options of a target JVM.
@@ -687,7 +686,7 @@
     `toDisk` - Whether a recording is stored to disk;
     either `true` or `false`.
 
-    **The request must include the following fields:**
+    **The request may include the following fields:**
 
     `maxAge` - The maximum event age of a recording, in seconds.
     A value of zero means there is no maximum event age.

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/SubprocessReportGenerator.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/SubprocessReportGenerator.java
@@ -86,7 +86,7 @@ import com.redhat.rhjmc.containerjfr.net.reports.ActiveRecordingReportCache.Reco
 import com.redhat.rhjmc.containerjfr.net.reports.ReportService.RecordingNotFoundException;
 import com.redhat.rhjmc.containerjfr.util.JavaProcess;
 
-class SubprocessReportGenerator {
+public class SubprocessReportGenerator {
 
     static final String SUBPROCESS_MAX_HEAP_ENV = "CONTAINER_JFR_REPORT_GENERATION_MAX_HEAP";
     static String ENV_USERNAME = "TARGET_USERNAME";
@@ -388,7 +388,7 @@ class SubprocessReportGenerator {
         throw new ReportGenerationException(ExitStatus.NO_SUCH_RECORDING);
     }
 
-    enum ExitStatus {
+    public enum ExitStatus {
         OK(0, ""),
         TARGET_CONNECTION_FAILURE(1, "Connection to target JVM failed."),
         NO_SUCH_RECORDING(2, "No such recording was found."),
@@ -418,15 +418,15 @@ class SubprocessReportGenerator {
         }
     }
 
-    static class ReportGenerationException extends Exception {
+    public static class ReportGenerationException extends Exception {
         private final ExitStatus status;
 
-        ReportGenerationException(ExitStatus status) {
+        public ReportGenerationException(ExitStatus status) {
             super(String.format("[%d] %s", status.code, status.message));
             this.status = status;
         }
 
-        ExitStatus getStatus() {
+        public ExitStatus getStatus() {
             return status;
         }
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/AbstractAuthenticatedRequestHandler.java
@@ -41,6 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.http;
 
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.rmi.ConnectIOException;
 import java.util.Base64;
@@ -94,6 +95,8 @@ public abstract class AbstractAuthenticatedRequestHandler implements RequestHand
             Throwable rootCause = ExceptionUtils.getRootCause(e);
             if (rootCause instanceof ConnectIOException) {
                 throw new HttpStatusException(502, "Target SSL Untrusted", e);
+            } else if (rootCause instanceof UnknownHostException) {
+                throw new HttpStatusException(404, "Target Not Found", e);
             }
             throw new HttpStatusException(500, e);
         } catch (Exception e) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
@@ -41,6 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
 
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.rmi.ConnectIOException;
 import java.util.Base64;
@@ -112,6 +113,8 @@ abstract class AbstractV2RequestHandler<T> implements RequestHandler {
             Throwable rootCause = ExceptionUtils.getRootCause(e);
             if (rootCause instanceof ConnectIOException) {
                 throw new ApiException(502, "Connection Failure", "Target SSL Untrusted", e);
+            } else if (rootCause instanceof UnknownHostException) {
+                throw new ApiException(404, "Connection Failure", "Target Not Found", e);
             }
             throw new ApiException(500, e.getMessage(), e);
         } catch (Exception e) {

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/AbstractAuthenticatedRequestHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/AbstractAuthenticatedRequestHandlerTest.java
@@ -43,6 +43,7 @@ package com.redhat.rhjmc.containerjfr.net.web.http;
 
 import static org.mockito.Mockito.when;
 
+import java.net.UnknownHostException;
 import java.rmi.ConnectIOException;
 import java.util.concurrent.CompletableFuture;
 
@@ -160,6 +161,19 @@ class AbstractAuthenticatedRequestHandlerTest {
                     Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(502));
             MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("Target SSL Untrusted"));
+        }
+
+        @Test
+        void shouldThrow404IfConnectionFailsDueToInvalidTarget() {
+            Exception cause = new UnknownHostException("localhostt");
+            Exception expectedException = new ConnectionException("");
+            expectedException.initCause(cause);
+            handler = new ThrowingAuthenticatedHandler(auth, expectedException);
+
+            HttpStatusException ex =
+                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+            MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("Target Not Found"));
         }
 
         @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
@@ -43,6 +43,7 @@ package com.redhat.rhjmc.containerjfr.net.web.http.api.v2;
 
 import static org.mockito.Mockito.when;
 
+import java.net.UnknownHostException;
 import java.rmi.ConnectIOException;
 import java.util.Collections;
 import java.util.Map;
@@ -180,6 +181,19 @@ class AbstractV2RequestHandlerTest {
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(502));
             MatcherAssert.assertThat(
                     ex.getFailureReason(), Matchers.equalTo("Target SSL Untrusted"));
+        }
+
+        @Test
+        void shouldThrow404IfConnectionFailsDueToInvalidTarget() {
+            Exception cause = new UnknownHostException("localhostt");
+            Exception expectedException = new ConnectionException("");
+            expectedException.initCause(cause);
+            handler = new ThrowingAuthenticatedHandler(auth, gson, expectedException);
+
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+            MatcherAssert.assertThat(ex.getFailureReason(), Matchers.equalTo("Target Not Found"));
         }
 
         @Test


### PR DESCRIPTION
Fixes #353 

For most handlers, adding a check for target-not-found exceptions in the abstract handler class (V1 and V2) was enough.

For `TargetReportGetHandler`, since the exception thrown is different, I made a change in the handler itself. I had to change some of the subprocess classes to public to do this, though I'm not sure if there's a way to avoid that.

Some unrelated small fixes to HTTP API docs.