### PR TITLE
Remove String.format from logger calls to improve performance

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/ContainerJfr.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/ContainerJfr.java
@@ -62,10 +62,7 @@ class ContainerJfr {
 
         logger.trace(String.format("env: %s", environment.getEnv().toString()));
 
-        logger.info(
-                String.format(
-                        "%s started.",
-                        System.getProperty("java.rmi.server.hostname", "container-jfr")));
+        logger.info("{} started.", System.getProperty("java.rmi.server.hostname", "container-jfr"));
 
         Client client = DaggerContainerJfr_Client.builder().build();
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/ContainerJfr.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/ContainerJfr.java
@@ -60,7 +60,7 @@ class ContainerJfr {
         final Logger logger = Logger.INSTANCE;
         final Environment environment = new Environment();
 
-        logger.trace(String.format("env: %s", environment.getEnv().toString()));
+        logger.trace("env: {}", environment.getEnv().toString());
 
         logger.info("{} started.", System.getProperty("java.rmi.server.hostname", "container-jfr"));
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/MainModule.java
@@ -124,7 +124,7 @@ public abstract class MainModule {
     @Named(RECORDINGS_PATH)
     static Path provideSavedRecordingsPath(Logger logger, Environment env) {
         String ARCHIVE_PATH = env.getEnv("CONTAINER_JFR_ARCHIVE_PATH", "/flightrecordings");
-        logger.info(String.format("Local save path for flight recordings set as %s", ARCHIVE_PATH));
+        logger.info("Local save path for flight recordings set as {}", ARCHIVE_PATH);
         return Paths.get(ARCHIVE_PATH);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandRegistryImpl.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/commands/internal/CommandRegistryImpl.java
@@ -104,7 +104,7 @@ class CommandRegistryImpl implements CommandRegistry {
                                                     .getName()
                                                     .equals(annotation.annotationType().getName()));
             if (deprecated) {
-                logger.warn(String.format("Command \"%s\" is deprecated", commandName));
+                logger.warn("Command \"{}\" is deprecated", commandName);
             }
             return c.execute(args);
         } catch (Exception e) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/messaging/MessagingModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/messaging/MessagingModule.java
@@ -112,17 +112,11 @@ public abstract class MessagingModule {
                                     MAX_CONNECTIONS_ENV_VAR,
                                     String.valueOf(DEFAULT_MAX_CONNECTIONS)));
             if (maxConn > MAX_CONNECTIONS) {
-                logger.info(
-                        String.format(
-                                "Requested maximum WebSocket connections %d is too large.",
-                                maxConn));
+                logger.info("Requested maximum WebSocket connections {} is too large.", maxConn);
                 return MAX_CONNECTIONS;
             }
             if (maxConn < MIN_CONNECTIONS) {
-                logger.info(
-                        String.format(
-                                "Requested maximum WebSocket connections %d is too small.",
-                                maxConn));
+                logger.info("Requested maximum WebSocket connections {} is too small.", maxConn);
                 return MIN_CONNECTIONS;
             }
             return maxConn;

--- a/src/main/java/com/redhat/rhjmc/containerjfr/messaging/MessagingServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/messaging/MessagingServer.java
@@ -95,7 +95,7 @@ public class MessagingServer implements AutoCloseable {
     }
 
     public void start() throws SocketException, UnknownHostException {
-        logger.info(String.format("Max concurrent WebSocket connections: %d", maxConnections));
+        logger.info("Max concurrent WebSocket connections: {}", maxConnections);
 
         server.websocketHandler(
                 (sws) -> {
@@ -107,22 +107,18 @@ public class MessagingServer implements AutoCloseable {
                     synchronized (connections) {
                         if (connections.size() >= maxConnections) {
                             logger.info(
-                                    String.format(
-                                            "Dropping remote client %s due to too many concurrent connections",
-                                            remoteAddress));
+                                    "Dropping remote client {} due to too many concurrent connections",
+                                    remoteAddress);
                             sws.reject();
                             sendClientActivityNotification(remoteAddress, "dropped");
                             return;
                         }
-                        logger.info(String.format("Connected remote client %s", remoteAddress));
+                        logger.info("Connected remote client {}", remoteAddress);
 
                         WsClient crw = new WsClient(this.logger, sws);
                         sws.closeHandler(
                                 (unused) -> {
-                                    logger.info(
-                                            String.format(
-                                                    "Disconnected remote client %s",
-                                                    remoteAddress));
+                                    logger.info("Disconnected remote client {}", remoteAddress);
                                     sendClientActivityNotification(remoteAddress, "disconnected");
                                     removeConnection(crw);
                                 });
@@ -173,7 +169,7 @@ public class MessagingServer implements AutoCloseable {
 
     public void writeMessage(WsMessage message) {
         String json = gson.toJson(message);
-        logger.info(String.format("Outgoing WS message: %s", json));
+        logger.info("Outgoing WS message: {}", json);
         synchronized (connections) {
             connections.keySet().forEach(c -> c.writeMessage(json));
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/messaging/WsClient.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/messaging/WsClient.java
@@ -65,7 +65,7 @@ class WsClient implements AutoCloseable, Handler<String> {
 
     @Override
     public void handle(String msg) {
-        logger.info(String.format("(%s): CMD %s", this.sws.remoteAddress().toString(), msg));
+        logger.info("({}): CMD {}", this.sws.remoteAddress().toString(), msg);
         inQ.add(msg);
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/BasicAuthManager.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/BasicAuthManager.java
@@ -146,15 +146,15 @@ class BasicAuthManager extends AbstractAuthManager {
     synchronized void loadConfig() {
         Path properties = fs.pathOf(System.getProperty("user.home"), USER_PROPERTIES_FILENAME);
         if (!fs.exists(properties)) {
-            logger.warn(String.format("User properties file \"%s\" does not exist", properties));
+            logger.warn("User properties file \"{}\" does not exist", properties);
             return;
         }
         if (!fs.isRegularFile(properties)) {
-            logger.warn(String.format("User properties path \"%s\" is not a file", properties));
+            logger.warn("User properties path \"{}\" is not a file", properties);
             return;
         }
         if (!fs.isReadable(properties)) {
-            logger.warn(String.format("User properties file \"%s\" is not readable", properties));
+            logger.warn("User properties file \"{}\" is not readable", properties);
             return;
         }
         try (Reader br = fs.readFile(properties)) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/HttpServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/HttpServer.java
@@ -108,12 +108,11 @@ public class HttpServer {
         future.join(); // wait for async deployment to complete
 
         logger.info(
-                String.format(
-                        "%s service running on %s://%s:%d",
-                        isSsl() ? "HTTPS" : "HTTP",
-                        isSsl() ? "https" : "http",
-                        netConf.getWebServerHost(),
-                        netConf.getExternalWebServerPort()));
+                "{} service running on {}://{}:{}",
+                isSsl() ? "HTTPS" : "HTTP",
+                isSsl() ? "https" : "http",
+                netConf.getWebServerHost(),
+                netConf.getExternalWebServerPort());
         this.isAlive = true;
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/SslConfiguration.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/SslConfiguration.java
@@ -89,7 +89,8 @@ class SslConfiguration {
                 strategy = new KeyCertStrategy(key, cert);
                 logger.info(
                         "Selected SSL KeyCert strategy with key {} and cert {}",
-                        key.toString(), cert.toString());
+                        key.toString(),
+                        cert.toString());
                 return;
             }
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/SslConfiguration.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/SslConfiguration.java
@@ -76,10 +76,7 @@ class SslConfiguration {
             Path path = obtainKeyStorePathIfSpecified();
             if (path != null) {
                 strategy = new KeyStoreStrategy(path, env.getEnv(KEYSTORE_PASS_ENV, ""));
-                logger.info(
-                        String.format(
-                                "Selected SSL KeyStore strategy with keystore %s",
-                                path.toString()));
+                logger.info("Selected SSL KeyStore strategy with keystore {}", path.toString());
                 return;
             }
         }
@@ -91,9 +88,8 @@ class SslConfiguration {
                 Path cert = pair.getRight();
                 strategy = new KeyCertStrategy(key, cert);
                 logger.info(
-                        String.format(
-                                "Selected SSL KeyCert strategy with key %s and cert %s",
-                                key.toString(), cert.toString()));
+                        "Selected SSL KeyCert strategy with key {} and cert {}",
+                        key.toString(), cert.toString());
                 return;
             }
         }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/TargetConnectionManager.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/TargetConnectionManager.java
@@ -132,7 +132,7 @@ public class TargetConnectionManager {
 
     private JFRConnection connect(JMXServiceURL url, Optional<Credentials> credentials)
             throws Exception {
-        logger.trace(String.format("Locking connection %s", url.toString()));
+        logger.trace("Locking connection {}", url.toString());
         lock.lockInterruptibly();
         return jfrConnectionToolkit
                 .get()
@@ -141,11 +141,7 @@ public class TargetConnectionManager {
                         credentials.orElse(null),
                         List.of(
                                 lock::unlock,
-                                () ->
-                                        logger.trace(
-                                                String.format(
-                                                        "Unlocking connection %s",
-                                                        url.toString()))));
+                                () -> logger.trace("Unlocking connection {}", url.toString())));
     }
 
     public interface ConnectedTask<T> {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/ActiveRecordingReportCache.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/ActiveRecordingReportCache.java
@@ -116,10 +116,10 @@ class ActiveRecordingReportCache {
         RecordingDescriptor key = new RecordingDescriptor(connectionDescriptor, recordingName);
         boolean hasKey = cache.asMap().containsKey(key);
         if (hasKey) {
-            logger.trace(String.format("Invalidated active report cache for %s", recordingName));
+            logger.trace("Invalidated active report cache for {}", recordingName);
             cache.invalidate(key);
         } else {
-            logger.trace(String.format("No cache entry for %s to invalidate", recordingName));
+            logger.trace("No cache entry for {} to invalidate", recordingName);
         }
         return hasKey;
     }
@@ -128,9 +128,7 @@ class ActiveRecordingReportCache {
         Path saveFile = null;
         try {
             generationLock.lock();
-            logger.trace(
-                    String.format(
-                            "Active report cache miss for %s", recordingDescriptor.recordingName));
+            logger.trace("Active report cache miss for {}", recordingDescriptor.recordingName);
             try {
                 saveFile =
                         subprocessReportGeneratorProvider
@@ -163,7 +161,7 @@ class ActiveRecordingReportCache {
                                                     .findFirst();
                                     if (clone.isPresent()) {
                                         conn.getService().close(clone.get());
-                                        logger.trace("Cleaned dangling recording " + cloneName);
+                                        logger.trace("Cleaned dangling recording {}", cloneName);
                                     }
                                     return null;
                                 });

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/ArchivedRecordingReportCache.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/ArchivedRecordingReportCache.java
@@ -103,10 +103,7 @@ class ArchivedRecordingReportCache {
                     .findFirst()
                     .ifPresentOrElse(
                             recording -> {
-                                logger.trace(
-                                        String.format(
-                                                "Archived report cache miss for %s",
-                                                recordingName));
+                                logger.trace("Archived report cache miss for {}", recordingName);
                                 try {
                                     Path saveFile =
                                             subprocessReportGeneratorProvider
@@ -143,7 +140,7 @@ class ArchivedRecordingReportCache {
 
     boolean delete(String recordingName) {
         try {
-            logger.trace(String.format("Invalidating archived report cache for %s", recordingName));
+            logger.trace("Invalidating archived report cache for {}", recordingName);
             return fs.deleteIfExists(getCachedReportPath(recordingName));
         } catch (IOException ioe) {
             logger.warn(ioe);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/SubprocessReportGenerator.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/SubprocessReportGenerator.java
@@ -260,10 +260,9 @@ public class SubprocessReportGenerator {
                                 () -> {
                                     long elapsedTime = System.nanoTime() - startTime;
                                     Logger.INSTANCE.info(
-                                            String.format(
-                                                    "%s shutting down after %dms",
-                                                    SubprocessReportGenerator.class.getName(),
-                                                    TimeUnit.NANOSECONDS.toMillis(elapsedTime)));
+                                            "{} shutting down after {}ms",
+                                            SubprocessReportGenerator.class.getName(),
+                                            TimeUnit.NANOSECONDS.toMillis(elapsedTime));
                                 }));
 
         var fs = new FileSystem();

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -178,9 +178,10 @@ public class WebServer {
         requestHandlers.forEach(
                 handler -> {
                     logger.trace(
-                            String.format(
-                                    "Registering request handler (priority %d) for [%s]\t%s",
-                                    handler.getPriority(), handler.httpMethod(), handler.path()));
+                            "Registering request handler (priority {}) for [{}]\t{}",
+                            handler.getPriority(),
+                            handler.httpMethod(),
+                            handler.path());
                     Route route;
                     if (RequestHandler.ALL_PATHS.equals(handler.path())) {
                         route = router.route();
@@ -207,14 +208,13 @@ public class WebServer {
                             .endHandler(
                                     (res) ->
                                             logger.info(
-                                                    String.format(
-                                                            "(%s): %s %s %d %dms",
-                                                            req.remoteAddress().toString(),
-                                                            req.method().toString(),
-                                                            req.path(),
-                                                            req.response().getStatusCode(),
-                                                            Duration.between(start, Instant.now())
-                                                                    .toMillis())));
+                                                    "({}): {} {} {} {}ms",
+                                                    req.remoteAddress().toString(),
+                                                    req.method().toString(),
+                                                    req.path(),
+                                                    req.response().getStatusCode(),
+                                                    Duration.between(start, Instant.now())
+                                                            .toMillis()));
                     router.handle(req);
                 });
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/WebServer.java
@@ -195,9 +195,7 @@ public class WebServer {
                     }
                     route = route.failureHandler(failureHandler);
                     if (!handler.isAvailable()) {
-                        logger.trace(
-                                String.format(
-                                        "%s handler disabled", handler.getClass().getSimpleName()));
+                        logger.trace("{} handler disabled", handler.getClass().getSimpleName());
                         route = route.disable();
                     }
                 });

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/RecordingsPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/RecordingsPostHandler.java
@@ -195,8 +195,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
                                                     HttpMimeType.JSON.mime())
                                             .end(gson.toJson(Map.of("name", res2.result())));
 
-                                    logger.info(
-                                            String.format("Recording saved as %s", res2.result()));
+                                    logger.info("Recording saved as {}", res2.result());
                                 }));
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TemplatesPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TemplatesPostHandler.java
@@ -102,9 +102,7 @@ class TemplatesPostHandler extends AbstractAuthenticatedRequestHandler {
                 Path path = fs.pathOf(u.uploadedFileName());
                 try (InputStream is = fs.newInputStream(path)) {
                     if (!"template".equals(u.name())) {
-                        logger.info(
-                                String.format(
-                                        "Received unexpected file upload named %s", u.name()));
+                        logger.info("Received unexpected file upload named {}", u.name());
                         continue;
                     }
                     templateService.addTemplate(is);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/generic/HealthGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/generic/HealthGetHandler.java
@@ -131,8 +131,7 @@ class HealthGetHandler implements RequestHandler {
                 future.complete(false);
                 return;
             }
-            logger.debug(
-                    String.format("Testing health of %s=%s %s", envName, uri.toString(), path));
+            logger.debug("Testing health of {}={} {}", envName, uri.toString(), path);
             HttpRequest<Buffer> req = webClient.get(uri.getHost(), path);
             if (uri.getPort() != -1) {
                 req = req.port(uri.getPort());

--- a/src/main/java/com/redhat/rhjmc/containerjfr/platform/PlatformModule.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/platform/PlatformModule.java
@@ -84,12 +84,10 @@ public abstract class PlatformModule {
         final String authManagerClass;
         if (env.hasEnv(AUTH_MANAGER_ENV_VAR)) {
             authManagerClass = env.getEnv(AUTH_MANAGER_ENV_VAR);
-            logger.info(String.format("Selecting configured AuthManager \"%s\"", authManagerClass));
+            logger.info("Selecting configured AuthManager \"{}\"", authManagerClass);
         } else {
             authManagerClass = platformStrategy.getAuthManager().getClass().getCanonicalName();
-            logger.info(
-                    String.format(
-                            "Selecting platform default AuthManager \"%s\"", authManagerClass));
+            logger.info("Selecting platform default AuthManager \"{}\"", authManagerClass);
         }
         return authManagers.stream()
                 .filter(mgr -> Objects.equals(mgr.getClass().getCanonicalName(), authManagerClass))
@@ -109,9 +107,7 @@ public abstract class PlatformModule {
         PlatformDetectionStrategy<?> strat = null;
         if (env.hasEnv(PLATFORM_STRATEGY_ENV_VAR)) {
             String platform = env.getEnv(PLATFORM_STRATEGY_ENV_VAR);
-            logger.info(
-                    String.format(
-                            "Selecting configured PlatformDetectionStrategy \"%s\"", platform));
+            logger.info("Selecting configured PlatformDetectionStrategy \"{}\"", platform);
             for (PlatformDetectionStrategy<?> s : strategies) {
                 if (Objects.equals(platform, s.getClass().getCanonicalName())) {
                     strat = s;

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/BasicAuthManagerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/BasicAuthManagerTest.java
@@ -83,7 +83,8 @@ class BasicAuthManagerTest {
             mgr.loadConfig();
 
             ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
-            Mockito.verify(logger).warn(messageCaptor.capture());
+            ArgumentCaptor<Object> objectCaptor = ArgumentCaptor.forClass(Object.class);
+            Mockito.verify(logger).warn(messageCaptor.capture(), objectCaptor.capture());
             MatcherAssert.assertThat(
                     messageCaptor.getValue(),
                     Matchers.stringContainsInOrder("User properties file", "does not exist"));
@@ -103,7 +104,8 @@ class BasicAuthManagerTest {
             mgr.loadConfig();
 
             ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
-            Mockito.verify(logger).warn(messageCaptor.capture());
+            ArgumentCaptor<Object> objectCaptor = ArgumentCaptor.forClass(Object.class);
+            Mockito.verify(logger).warn(messageCaptor.capture(), objectCaptor.capture());
             MatcherAssert.assertThat(
                     messageCaptor.getValue(),
                     Matchers.stringContainsInOrder("User properties path", "is not a file"));
@@ -124,7 +126,8 @@ class BasicAuthManagerTest {
             mgr.loadConfig();
 
             ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
-            Mockito.verify(logger).warn(messageCaptor.capture());
+            ArgumentCaptor<Object> objectCaptor = ArgumentCaptor.forClass(Object.class);
+            Mockito.verify(logger).warn(messageCaptor.capture(), objectCaptor.capture());
             MatcherAssert.assertThat(
                     messageCaptor.getValue(),
                     Matchers.stringContainsInOrder("User properties file", "is not readable"));
@@ -156,7 +159,8 @@ class BasicAuthManagerTest {
         void shouldFailAuthenticationWhenCredentialsMalformed() throws Exception {
             Assertions.assertFalse(mgr.validateToken(() -> "user").get());
             ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
-            Mockito.verify(logger).warn(messageCaptor.capture());
+            ArgumentCaptor<Object> objectCaptor = ArgumentCaptor.forClass(Object.class);
+            Mockito.verify(logger).warn(messageCaptor.capture(), objectCaptor.capture());
             MatcherAssert.assertThat(
                     messageCaptor.getValue(),
                     Matchers.stringContainsInOrder("User properties file", "does not exist"));
@@ -166,7 +170,8 @@ class BasicAuthManagerTest {
         void shouldFailAuthenticationWhenNoMatchFound() throws Exception {
             Assertions.assertFalse(mgr.validateToken(() -> "user:pass").get());
             ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
-            Mockito.verify(logger).warn(messageCaptor.capture());
+            ArgumentCaptor<Object> objectCaptor = ArgumentCaptor.forClass(Object.class);
+            Mockito.verify(logger).warn(messageCaptor.capture(), objectCaptor.capture());
             MatcherAssert.assertThat(
                     messageCaptor.getValue(),
                     Matchers.stringContainsInOrder("User properties file", "does not exist"));


### PR DESCRIPTION
Fixes #358 
There are two or three statements where I left the String.format call because they had several arguments, and it probably doesn't make sense to create functions for that exact number of objects in cjfr-core.