### PR TITLE
Delete correct file on post-generation cleanup

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/ActiveRecordingReportCache.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/ActiveRecordingReportCache.java
@@ -43,7 +43,6 @@ package com.redhat.rhjmc.containerjfr.net.reports;
 
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -54,9 +53,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Named;
 import javax.inject.Provider;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
@@ -69,6 +65,7 @@ import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
 import com.redhat.rhjmc.containerjfr.net.reports.SubprocessReportGenerator.ExitStatus;
+import com.redhat.rhjmc.containerjfr.net.reports.SubprocessReportGenerator.RecordingDescriptor;
 import com.redhat.rhjmc.containerjfr.net.reports.SubprocessReportGenerator.ReportGenerationException;
 import com.redhat.rhjmc.containerjfr.net.web.http.generic.TimeoutHandler;
 
@@ -174,42 +171,6 @@ class ActiveRecordingReportCache {
             if (saveFile != null) {
                 fs.deleteIfExists(saveFile);
             }
-        }
-    }
-
-    static class RecordingDescriptor {
-        final ConnectionDescriptor connectionDescriptor;
-        final String recordingName;
-
-        RecordingDescriptor(ConnectionDescriptor connectionDescriptor, String recordingName) {
-            this.connectionDescriptor = Objects.requireNonNull(connectionDescriptor);
-            this.recordingName = Objects.requireNonNull(recordingName);
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            if (other == null) {
-                return false;
-            }
-            if (other == this) {
-                return true;
-            }
-            if (!(other instanceof RecordingDescriptor)) {
-                return false;
-            }
-            RecordingDescriptor rd = (RecordingDescriptor) other;
-            return new EqualsBuilder()
-                    .append(connectionDescriptor, rd.connectionDescriptor)
-                    .append(recordingName, rd.recordingName)
-                    .isEquals();
-        }
-
-        @Override
-        public int hashCode() {
-            return new HashCodeBuilder()
-                    .append(connectionDescriptor)
-                    .append(recordingName)
-                    .hashCode();
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/SubprocessReportGenerator.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/SubprocessReportGenerator.java
@@ -63,6 +63,9 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Provider;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import org.openjdk.jmc.rjmx.ConnectionException;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
@@ -75,7 +78,6 @@ import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
-import com.redhat.rhjmc.containerjfr.net.reports.ActiveRecordingReportCache.RecordingDescriptor;
 import com.redhat.rhjmc.containerjfr.net.reports.ReportService.RecordingNotFoundException;
 import com.redhat.rhjmc.containerjfr.util.JavaProcess;
 
@@ -337,6 +339,42 @@ public class SubprocessReportGenerator {
         } catch (IOException ioe) {
             ioe.printStackTrace();
             throw new ReportGenerationException(ExitStatus.IO_EXCEPTION);
+        }
+    }
+
+    static class RecordingDescriptor {
+        final ConnectionDescriptor connectionDescriptor;
+        final String recordingName;
+
+        RecordingDescriptor(ConnectionDescriptor connectionDescriptor, String recordingName) {
+            this.connectionDescriptor = Objects.requireNonNull(connectionDescriptor);
+            this.recordingName = Objects.requireNonNull(recordingName);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == null) {
+                return false;
+            }
+            if (other == this) {
+                return true;
+            }
+            if (!(other instanceof RecordingDescriptor)) {
+                return false;
+            }
+            RecordingDescriptor rd = (RecordingDescriptor) other;
+            return new EqualsBuilder()
+                    .append(connectionDescriptor, rd.connectionDescriptor)
+                    .append(recordingName, rd.recordingName)
+                    .isEquals();
+        }
+
+        @Override
+        public int hashCode() {
+            return new HashCodeBuilder()
+                    .append(connectionDescriptor)
+                    .append(recordingName)
+                    .hashCode();
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/SubprocessReportGenerator.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/reports/SubprocessReportGenerator.java
@@ -171,16 +171,16 @@ public class SubprocessReportGenerator {
     }
 
     Future<Path> exec(RecordingDescriptor recordingDescriptor, Duration timeout) throws Exception {
-        // TODO add a FileSystem abstraction around Files.createTemp*
         Path recording =
                 getRecordingFromLiveTarget(
                         recordingDescriptor.recordingName,
                         recordingDescriptor.connectionDescriptor);
-        CompletableFuture<Path> cf = exec(recording, tempFileProvider.get(), timeout);
-        cf.whenCompleteAsync(
+        Path saveFile = tempFileProvider.get();
+        CompletableFuture<Path> cf = exec(recording, saveFile, timeout);
+        cf.whenComplete(
                 (p, t) -> {
                     try {
-                        fs.deleteIfExists(p);
+                        fs.deleteIfExists(recording);
                     } catch (IOException e) {
                         logger.warn(e);
                     }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/reports/ActiveRecordingReportCacheTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/reports/ActiveRecordingReportCacheTest.java
@@ -68,9 +68,9 @@ import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
-import com.redhat.rhjmc.containerjfr.net.reports.ActiveRecordingReportCache.RecordingDescriptor;
 import com.redhat.rhjmc.containerjfr.net.reports.ReportService.RecordingNotFoundException;
 import com.redhat.rhjmc.containerjfr.net.reports.SubprocessReportGenerator.ExitStatus;
+import com.redhat.rhjmc.containerjfr.net.reports.SubprocessReportGenerator.RecordingDescriptor;
 import com.redhat.rhjmc.containerjfr.util.JavaProcess;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/reports/SubprocessReportGeneratorTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/reports/SubprocessReportGeneratorTest.java
@@ -61,7 +61,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 import com.redhat.rhjmc.containerjfr.core.log.Logger;
 import com.redhat.rhjmc.containerjfr.core.net.Credentials;
@@ -70,8 +72,8 @@ import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.net.ConnectionDescriptor;
 import com.redhat.rhjmc.containerjfr.net.TargetConnectionManager;
-import com.redhat.rhjmc.containerjfr.net.reports.ActiveRecordingReportCache.RecordingDescriptor;
 import com.redhat.rhjmc.containerjfr.net.reports.SubprocessReportGenerator.ExitStatus;
+import com.redhat.rhjmc.containerjfr.net.reports.SubprocessReportGenerator.RecordingDescriptor;
 import com.redhat.rhjmc.containerjfr.util.JavaProcess;
 
 @ExtendWith(MockitoExtension.class)
@@ -86,8 +88,9 @@ class SubprocessReportGeneratorTest {
     ConnectionDescriptor connectionDescriptor;
     RecordingDescriptor recordingDescriptor;
     @Mock Path recordingFile;
-    @Mock Path tempFile;
-    Provider<Path> tempFileProvider;
+    @Mock Path tempFile1;
+    @Mock Path tempFile2;
+    @Mock Provider<Path> tempFileProvider;
     SubprocessReportGenerator generator;
 
     @BeforeEach
@@ -96,9 +99,12 @@ class SubprocessReportGeneratorTest {
                 new ConnectionDescriptor("fooHost:1234", new Credentials("someUser", "somePass"));
         recordingDescriptor = new RecordingDescriptor(connectionDescriptor, "testRecording");
 
-        tempFileProvider = () -> tempFile;
-        Mockito.lenient().when(tempFile.toAbsolutePath()).thenReturn(tempFile);
-        Mockito.lenient().when(tempFile.toString()).thenReturn("/dest/serializedtransformers.tmp");
+        tempFileProvider = Mockito.mock(Provider.class);
+        Mockito.lenient().when(tempFileProvider.get()).thenReturn(tempFile1).thenReturn(tempFile2);
+        Mockito.lenient().when(tempFile1.toAbsolutePath()).thenReturn(tempFile1);
+        Mockito.lenient().when(tempFile1.toString()).thenReturn("/tmp/file1.tmp");
+        Mockito.lenient().when(tempFile2.toAbsolutePath()).thenReturn(tempFile2);
+        Mockito.lenient().when(tempFile2.toString()).thenReturn("/tmp/file2.tmp");
         Mockito.lenient().when(recordingFile.toAbsolutePath()).thenReturn(recordingFile);
         Mockito.lenient().when(recordingFile.toString()).thenReturn("/dest/recording.tmp");
 
@@ -253,6 +259,49 @@ class SubprocessReportGeneratorTest {
                             Matchers.containsString(
                                     "Recording /dest/recording.tmp not found in target archives"));
                 });
+    }
+
+    @Test
+    void shouldExecuteProcessAndDeleteRecordingOnCompletion() throws Exception {
+        Mockito.when(proc.waitFor(10_000, TimeUnit.MILLISECONDS)).thenReturn(true);
+        Mockito.when(proc.exitValue()).thenReturn(ExitStatus.OK.code);
+
+        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
+                .then(
+                        new Answer<Path>() {
+                            @Override
+                            public Path answer(InvocationOnMock invocation) throws Throwable {
+                                return tempFileProvider.get();
+                            }
+                        });
+
+        Path result = generator.exec(recordingDescriptor, Duration.ofSeconds(10)).get();
+
+        MatcherAssert.assertThat(result, Matchers.sameInstance(tempFile2));
+        Mockito.verify(fs).deleteIfExists(tempFile1);
+    }
+
+    @Test
+    void shouldExecuteProcessAndDeleteRecordingOnFailure() throws Exception {
+        Mockito.when(proc.waitFor(10_000, TimeUnit.MILLISECONDS)).thenReturn(true);
+        Mockito.when(proc.exitValue()).thenReturn(ExitStatus.NO_SUCH_RECORDING.code);
+
+        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
+                .then(
+                        new Answer<Path>() {
+                            @Override
+                            public Path answer(InvocationOnMock invocation) throws Throwable {
+                                return tempFileProvider.get();
+                            }
+                        });
+
+        Assertions.assertThrows(
+                ExecutionException.class,
+                () -> {
+                    generator.exec(recordingDescriptor, Duration.ofSeconds(10)).get();
+                });
+
+        Mockito.verify(fs).deleteIfExists(tempFile1);
     }
 
     static class TestReportTransformer implements ReportTransformer {


### PR DESCRIPTION
Fixes #364

The file cleanup after an active recording has a report generated erroneously attempts to delete the file which was just written with the report contents. This is done asynchronously, so there may be a race between the cleanup thread and the thread handling the report request (and going through the cache).

This PR simply corrects the cleanup hook to delete the correct file - the temporarily copied flight recording - and does it synchronously since this should be a relatively fast operation anyway, and report generation is expected to be slow.