### PR TITLE
Add guice and plexus-utils dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
   <org.apache.maven.plugins.info.reports.version>3.0.0</org.apache.maven.plugins.info.reports.version>
   <org.apache.maven.plugins.clean.version>3.1.0</org.apache.maven.plugins.clean.version>
   <org.apache.maven.plugins.resources.version>3.1.0</org.apache.maven.plugins.resources.version>
-  <org.apache.maven.plugins.dependency.version>3.1.2</org.apache.maven.plugins.dependency.version>
   <com.github.eirslett.frontend.plugin.version>1.9.1</com.github.eirslett.frontend.plugin.version>
   <org.codehaus.mojo.exec.plugin.version>1.6.0</org.codehaus.mojo.exec.plugin.version>
   <org.codehaus.mojo.license.plugin.version>2.0.0</org.codehaus.mojo.license.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,14 @@
   <org.apache.maven.plugins.info.reports.version>3.0.0</org.apache.maven.plugins.info.reports.version>
   <org.apache.maven.plugins.clean.version>3.1.0</org.apache.maven.plugins.clean.version>
   <org.apache.maven.plugins.resources.version>3.1.0</org.apache.maven.plugins.resources.version>
+  <org.apache.maven.plugins.dependency.version>3.1.2</org.apache.maven.plugins.dependency.version>
   <com.github.eirslett.frontend.plugin.version>1.9.1</com.github.eirslett.frontend.plugin.version>
   <org.codehaus.mojo.exec.plugin.version>1.6.0</org.codehaus.mojo.exec.plugin.version>
   <org.codehaus.mojo.license.plugin.version>2.0.0</org.codehaus.mojo.license.plugin.version>
   <com.google.cloud.tools.jib.maven.plugin.version>2.6.0</com.google.cloud.tools.jib.maven.plugin.version>
 
   <com.google.dagger.version>2.26</com.google.dagger.version>
+  <com.google.guice.version>4.1.0</com.google.guice.version>
 
   <com.redhat.rhjmc.containerjfr.core.version>2.0.0</com.redhat.rhjmc.containerjfr.core.version>
 
@@ -66,6 +68,7 @@
   <org.jacoco.maven.plugin.version>0.8.5</org.jacoco.maven.plugin.version>
   <com.diffplug.spotless.maven.plugin.version>1.27.0</com.diffplug.spotless.maven.plugin.version>
   <org.jsoup.version>1.12.1</org.jsoup.version>
+  <org.codehaus.plexus.utils.version>3.0.22</org.codehaus.plexus.utils.version>
 </properties>
 
 <dependencies>
@@ -88,6 +91,11 @@
     <groupId>com.google.dagger</groupId>
     <artifactId>dagger</artifactId>
     <version>${com.google.dagger.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.inject</groupId>
+    <artifactId>guice</artifactId>
+    <version>${com.google.guice.version}</version>
   </dependency>
   <dependency>
     <groupId>org.apache.commons</groupId>
@@ -143,6 +151,11 @@
     <groupId>org.jsoup</groupId>
     <artifactId>jsoup</artifactId>
     <version>${org.jsoup.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.codehaus.plexus</groupId>
+    <artifactId>plexus-utils</artifactId>
+    <version>${org.codehaus.plexus.utils.version}</version>
   </dependency>
 
   <!-- test deps -->


### PR DESCRIPTION
These dependencies are currently brought in with JMC/Eclipse and need to specified explicitly after https://github.com/rh-jmc-team/container-jfr-core/pull/56.