### PR TITLE
Use provided scope for spotbugs-annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,7 @@
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs-annotations</artifactId>
     <version>${com.github.spotbugs.version}</version>
+    <scope>provided</scope>
   </dependency>
 </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
   <com.google.dagger.version>2.26</com.google.dagger.version>
 
-  <com.redhat.rhjmc.containerjfr.core.version>2.2.0</com.redhat.rhjmc.containerjfr.core.version>
+  <com.redhat.rhjmc.containerjfr.core.version>2.2.1</com.redhat.rhjmc.containerjfr.core.version>
 
   <org.apache.commons.lang3.version>3.9</org.apache.commons.lang3.version>
   <org.apache.commons.codec.version>1.13</org.apache.commons.codec.version>


### PR DESCRIPTION
We shouldn't need this included as a runtime dependency.