### PR TITLE
Add isAsync() for All Handlers

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/AuthPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/AuthPostHandler.java
@@ -72,6 +72,13 @@ class AuthPostHandler extends AbstractAuthenticatedRequestHandler {
         return basePath() + "auth";
     }
 
+    // This handler is not async, but it's simple enough that it doesn't need
+    // to be run in a seperate worker thread.
+    @Override
+    public boolean isAsync() {
+        return true;
+    }
+
     @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         ctx.response().setStatusCode(200);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/ClientUrlGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/ClientUrlGetHandler.java
@@ -89,6 +89,11 @@ class ClientUrlGetHandler implements RequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return true;
+    }
+
+    @Override
     public void handle(RoutingContext ctx) {
         ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
         try {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/GrafanaDashboardUrlGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/GrafanaDashboardUrlGetHandler.java
@@ -85,6 +85,13 @@ class GrafanaDashboardUrlGetHandler implements RequestHandler {
         return HttpMethod.GET;
     }
 
+    // This handler is not async, but it's simple enough that it doesn't need
+    // to be run in a seperate worker thread.
+    @Override
+    public boolean isAsync() {
+        return true;
+    }
+
     @Override
     public void handle(RoutingContext ctx) {
         if (!this.env.hasEnv(GRAFANA_DASHBOARD_ENV)) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/GrafanaDatasourceUrlGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/GrafanaDatasourceUrlGetHandler.java
@@ -85,6 +85,13 @@ class GrafanaDatasourceUrlGetHandler implements RequestHandler {
         return HttpMethod.GET;
     }
 
+    // This handler is not async, but it's simple enough that it doesn't need
+    // to be run in a seperate worker thread.
+    @Override
+    public boolean isAsync() {
+        return true;
+    }
+
     @Override
     public void handle(RoutingContext ctx) {
         if (!this.env.hasEnv(GRAFANA_DATASOURCE_ENV)) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/RecordingDeleteHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/RecordingDeleteHandler.java
@@ -92,6 +92,11 @@ class RecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         String recordingName = ctx.pathParam("recordingName");
         fs.listDirectoryChildren(savedRecordingsPath).stream()

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/RecordingGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/RecordingGetHandler.java
@@ -81,6 +81,11 @@ class RecordingGetHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return true;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         String recordingName = ctx.pathParam("recordingName");
         String filePath =

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/RecordingsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/RecordingsGetHandler.java
@@ -108,6 +108,11 @@ class RecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         if (!fs.exists(savedRecordingsPath)) {
             throw new HttpStatusException(

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetEventsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetEventsGetHandler.java
@@ -88,6 +88,11 @@ class TargetEventsGetHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         List<SerializableEventTypeInfo> templates =
                 connectionManager.executeConnectedTask(

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetRecordingDeleteHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetRecordingDeleteHandler.java
@@ -89,6 +89,11 @@ class TargetRecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         String recordingName = ctx.pathParam("recordingName");
         ConnectionDescriptor connectionDescriptor = getConnectionDescriptorFromContext(ctx);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetRecordingOptionsPatchHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetRecordingOptionsPatchHandler.java
@@ -103,6 +103,11 @@ class TargetRecordingOptionsPatchHandler extends AbstractAuthenticatedRequestHan
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         Pattern bool = Pattern.compile("true|false");
         MultiMap attrs = ctx.request().formAttributes();

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetRecordingsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetRecordingsGetHandler.java
@@ -95,6 +95,11 @@ class TargetRecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         WebServer webServer = webServerProvider.get();
         List<HyperlinkedSerializableRecordingDescriptor> descriptors =

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -135,6 +135,11 @@ class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         MultiMap attrs = ctx.request().formAttributes();
         String recordingName = attrs.get("recordingName");

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetSnapshotPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetSnapshotPostHandler.java
@@ -86,6 +86,11 @@ class TargetSnapshotPostHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         String result =
                 targetConnectionManager.executeConnectedTask(

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetTemplateGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetTemplateGetHandler.java
@@ -81,6 +81,11 @@ class TargetTemplateGetHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         String templateName = ctx.pathParam("templateName");
         TemplateType templateType = TemplateType.valueOf(ctx.pathParam("templateType"));

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetTemplatesGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetTemplatesGetHandler.java
@@ -87,6 +87,11 @@ class TargetTemplatesGetHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         List<Template> templates =
                 connectionManager.executeConnectedTask(

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetsGetHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TargetsGetHandler.java
@@ -81,6 +81,11 @@ class TargetsGetHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         ctx.response().end(gson.toJson(this.platformClient.listDiscoverableServices()));
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TemplateDeleteHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TemplateDeleteHandler.java
@@ -79,6 +79,11 @@ class TemplateDeleteHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         String templateName = ctx.pathParam("templateName");
         try {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TemplatesPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v1/TemplatesPostHandler.java
@@ -96,6 +96,11 @@ class TemplatesPostHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         try {
             for (FileUpload u : ctx.fileUploads()) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetSnapshotPostHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/TargetSnapshotPostHandler.java
@@ -107,6 +107,11 @@ class TargetSnapshotPostHandler
     }
 
     @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
     IntermediateResponse<HyperlinkedSerializableRecordingDescriptor> handle(
             RequestParameters requestParams) throws Exception {
         HyperlinkedSerializableRecordingDescriptor desc =


### PR DESCRIPTION
Fixes #312 

Handler | Async? | Notes
-- | -- | --
`AuthPostHandler` | No | 
`ClientUrlGetHandler` | No | A unit test expects it to be async.
`GrafanaDashboardUrlGetHandler` | No | 
`GrafanaDatasourceUrlGetHandler` | No | 
`RecordingDeleteHandler` | No | 
`RecordingGetHandler` | Yes | `ctx.vertx().filesystem().exists()` is async.
`RecordingsGetHandler` | No | 
`RecordingsPostHandler` | Yes | `validateRecording()` and `saveRecording()` are async, but this handler already has `isAsync()` set to `false`.
`RecordingUploadPostHandler` | No | Already has `isAsync()` set to `false`.
`ReportGetHandler` | No | Already has `isAsync()` set to `false`.
`TargetEventsGetHandler` | No | 
`TargetRecordingDeleteHandler` | No | 
`TargetRecordingGetHandler` | No | Already has `isAsync()` set to `false`.
`TargetRecordingOptionsGetHandler` | No | Already has `isAsync()` set to `false`.
`TargetRecordingOptionsPatchHandler` | No | 
`TargetRecordingPatchHandler` | No | Already has `isAsync()` set to `false`.
`TargetRecordingsGetHandler` | No | 
`TargetRecordingsPostHandler` | No | ~~Already has `isAsync()` set to `false`.~~
`TargetRecordingUploadPostHandler` | No | Already has `isAsync()` set to `false`.
`TargetReportGetHandler` | No | Already has `isAsync()` set to `false`.
`TargetsGetHandler` | No | 
`TargetSnapshotPostHandler` | No | 
`TargetTemplateGetHandler` | No | 
`TargetTemplatesGetHandler` | No | 
`TemplateDeleteHandler` | No | 
`TemplatesPostHandler` | No | 
`CertificatePostHandler` (V2) | No |  Already has `isAsync()` set to `false`.
`TargetEventsSearchGetHandler` (V2) | No |  Already has `isAsync()` set to `false`. 
`TargetRecordingOptionsListGetHandler` (V2) | No |  Already has `isAsync()` set to `false`.
`TargetSnapshotPostHandler` (V2) | No | 


`AuthPostHandler`, `GrafanaDashboardUrlGetHandler`, and `GrafanaDatasourceUrlGetHandler` are not async, but they're all simple handlers, so I've set their `isAsync()` values to `true` anyway, as suggested.

`ClientUrlGetHandler` doesn't seem to be async from what I can tell, but there's a unit test that expects it to be async, so I didn't change it.

`RecordingsPostHandler` seems to have async helper functions, but it already had its `isAsync()` set to `false`, so I didn't change it.

**Edit:** `TargetRecordingsPostHandler` didn't actually have `isAsync()` set to `false` already, but it does appear to be synchronous.