### PR TITLE
Explicitly bind container ports to host ports

### DIFF
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -56,8 +56,9 @@ function runGrafana() {
     configureGrafanaDatasource
 }
 
-if ! podman pod exists container-jfr; then
+function createPod() {
     podman pod create \
+        --replace \
         --hostname container-jfr \
         --name container-jfr \
         --publish 9091:9091 \
@@ -72,8 +73,15 @@ if ! podman pod exists container-jfr; then
     # 3000: grafana
     # 8081: vertx-fib-demo
     # 9093: vertx-fib-demo RJMX
-fi
+}
 
+function destroyPod() {
+    podman pod kill container-jfr
+    podman pod rm container-jfr
+}
+trap destroyPod EXIT
+
+createPod
 runDemoApp
 runJfrDatasource
 runGrafana

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -60,12 +60,12 @@ if ! podman pod exists container-jfr; then
     podman pod create \
         --hostname container-jfr \
         --name container-jfr \
-        --publish 9091 \
-        --publish 8181 \
-        --publish 8080 \
-        --publish 3000 \
-        --publish 8081 \
-        --publish 9093
+        --publish 9091:9091 \
+        --publish 8181:8181 \
+        --publish 8080:8080 \
+        --publish 3000:3000 \
+        --publish 8081:8081 \
+        --publish 9093:9093
     # 9091: ContainerJFR RJMX
     # 8181: ContainerJFR web services
     # 8080: jfr-datasource


### PR DESCRIPTION
Since yesterday I had been unable to run the `smoketest.sh` successfully - the script would get stuck at configuring the jfr-datasource, as the `curl` request to check the Grafana dashboard's `/api/health` would always get a `Connection Refused` response. I determined that the problem was that while the containers were running as expected, the ports they were bound to on the host machine did not match the port numbers expected and used in the script.

This patch simply explicitly binds the inside-the-pod-port-numbers to the same port numbers on the host. This sets the behaviour back in-line with what was intended previously, and which I assume was broken in some recent `podman` (or `libpod` etc.) update.

The alternative would be to allow the host port numbers to be assigned randomly, and then programmatically retrieve them within the script before performing any configuration steps using these numbers. This is more complex but would alleviate any conflicts between `smoketest.sh` and other services that developers may be running on their dev/test machines.