### PR TITLE
Optionally create distributable image archive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
   <org.apache.maven.plugins.info.reports.version>3.0.0</org.apache.maven.plugins.info.reports.version>
   <org.apache.maven.plugins.clean.version>3.1.0</org.apache.maven.plugins.clean.version>
   <org.apache.maven.plugins.resources.version>3.1.0</org.apache.maven.plugins.resources.version>
+  <org.apache.maven.plugins.assembly.version>3.1.0</org.apache.maven.plugins.assembly.version>
   <com.github.eirslett.frontend.plugin.version>1.9.1</com.github.eirslett.frontend.plugin.version>
   <org.codehaus.mojo.exec.plugin.version>1.6.0</org.codehaus.mojo.exec.plugin.version>
   <org.codehaus.mojo.license.plugin.version>2.0.0</org.codehaus.mojo.license.plugin.version>
@@ -626,6 +627,31 @@
                 </resources>
                 <outputDirectory>${project.build.directory}/assets/app/resources/com/redhat/rhjmc/containerjfr/net/web</outputDirectory>
               </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
+  <profile>
+    <id>dist</id>
+    <build>
+      <plugins>
+        <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${org.apache.maven.plugins.assembly.version}</version>
+          <configuration>
+            <descriptors>
+              <descriptor>src/assembly/dist.xml</descriptor>
+            </descriptors>
+          </configuration>
+          <executions>
+            <execution>
+              <id>assemble-dist</id>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
             </execution>
           </executions>
         </plugin>

--- a/src/assembly/dist.xml
+++ b/src/assembly/dist.xml
@@ -1,0 +1,28 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+  <id>dist</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>app/libs</outputDirectory>
+      <scope>runtime</scope>
+    </dependencySet>
+  </dependencySets>
+  <fileSets>
+    <fileSet>
+      <outputDirectory>/</outputDirectory>
+      <directory>${project.basedir}/src/main/extras</directory>
+      <includes>
+        <include>${containerjfr.entrypoint}</include>
+      </includes>
+      <fileMode>0755</fileMode>
+    </fileSet>
+    <fileSet>
+      <outputDirectory>/</outputDirectory>
+      <directory>${project.build.directory}/assets</directory>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
This adds an assembly descriptor that creates a tar.gz archive of all artifacts needed for the container image. The motivation behind this is for use cases where we can't or don't want to use Jib to create a container image. The structure of the archive is similar to where Jib places things, except for placing the jar of Container JFR itself in the `libs` directory instead of a separate `classes` directory for its class files. This assembly step is only done when its profile is manually enabled (e.g. `mvn -Pdist package`).