### PR TITLE
Fix assembly for large uid/gid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -644,6 +644,7 @@
             <descriptors>
               <descriptor>src/assembly/dist.xml</descriptor>
             </descriptors>
+            <tarLongFileMode>posix</tarLongFileMode>
           </configuration>
           <executions>
             <execution>

--- a/src/assembly/dist.xml
+++ b/src/assembly/dist.xml
@@ -13,7 +13,7 @@
   </dependencySets>
   <fileSets>
     <fileSet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory />
       <directory>${project.basedir}/src/main/extras</directory>
       <includes>
         <include>${containerjfr.entrypoint}</include>
@@ -21,7 +21,7 @@
       <fileMode>0755</fileMode>
     </fileSet>
     <fileSet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory />
       <directory>${project.build.directory}/assets</directory>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
When building on a system with generated UID/GIDs that can be quite large, you'll may see a build failure due to a limitation on GNU tar:
`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.1.0:single (assemble-dist) on project container-jfr: Execution assemble-dist of goal org.apache.maven.plugins:maven-assembly-plugin:3.1.0:single failed: user id '1060820000' is too big ( > 2097151 ). -> [Help 1]`

The fix is configuring maven-assembly-plugin to use the POSIX tar format instead. [1]

This PR also fixes the following warning, by providing an empty `<outputDirectory>` tag instead of `/`:
`[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /`

This is interpreted as the archive root, so there is no functional difference.

[1] https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#tarFileModes