### PR TITLE
[V1] external container itests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Unit tests can be run with `mvn test`. Integration tests and additional quality
 tools can be run with `mvn verify`.
 
 To re-run integration tests without a rebuild, do
-`mvn exec:exec@start-container failsafe:integration-test
-exec:exec@stop-container`.
+`mvn exec:exec@create-pod exec:exec@start-container exec:exec@wait-for-container
+failsafe:integration-test exec:exec@stop-container exec:exec@destroy-pod`.
 
 An OCI image can be built to your local `podman` image registry using
 `mvn package`. This will normally be a full-fledged image including built

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
   <containerjfr.webPort>8181</containerjfr.webPort>
   <containerjfr.listenPort>9090</containerjfr.listenPort>
   <containerjfr.itest.webPort>8181</containerjfr.itest.webPort>
+  <containerjfr.itest.podName>container-jfr-itests</containerjfr.itest.podName>
 
   <org.apache.maven.plugins.compiler.version>3.6.1</org.apache.maven.plugins.compiler.version>
   <org.apache.maven.plugins.surefire.version>3.0.0-M4</org.apache.maven.plugins.surefire.version>
@@ -212,6 +213,26 @@
       </configuration>
       <executions>
         <execution>
+          <id>create-pod</id>
+          <phase>pre-integration-test</phase>
+          <goals>
+              <goal>exec</goal>
+          </goals>
+          <configuration>
+            <executable>${imageBuilder}</executable>
+            <arguments>
+              <argument>pod</argument>
+              <argument>create</argument>
+              <argument>--replace</argument>
+              <argument>--name=${containerjfr.itest.podName}</argument>
+              <argument>--publish</argument>
+              <argument>${containerjfr.rjmxPort}:${containerjfr.rjmxPort}</argument>
+              <argument>--publish</argument>
+              <argument>${containerjfr.itest.webPort}:${containerjfr.itest.webPort}</argument>
+            </arguments>
+          </configuration>
+        </execution>
+        <execution>
           <id>start-container</id>
           <phase>pre-integration-test</phase>
           <goals>
@@ -221,16 +242,12 @@
             <executable>${imageBuilder}</executable>
             <arguments>
               <argument>run</argument>
-              <argument>--hostname=container-jfr</argument>
+              <argument>--pod=${containerjfr.itest.podName}</argument>
               <argument>--name=container-jfr-itest</argument>
               <argument>--mount</argument>
               <argument>type=tmpfs,target=/flightrecordings</argument>
               <argument>--mount</argument>
               <argument>type=tmpfs,target=/templates</argument>
-              <argument>--publish</argument>
-              <argument>${containerjfr.rjmxPort}:${containerjfr.rjmxPort}</argument>
-              <argument>--publish</argument>
-              <argument>${containerjfr.itest.webPort}:${containerjfr.itest.webPort}</argument>
               <argument>--env</argument>
               <argument>CONTAINER_JFR_DISABLE_JMX_AUTH=true</argument>
               <argument>--env</argument>
@@ -287,6 +304,22 @@
             </arguments>
           </configuration>
         </execution>
+        <execution>
+          <id>destroy-pod</id>
+          <phase>post-integration-test</phase>
+          <goals>
+            <goal>exec</goal>
+          </goals>
+          <configuration>
+            <executable>${imageBuilder}</executable>
+            <arguments>
+              <argument>pod</argument>
+              <argument>rm</argument>
+              <argument>--force</argument>
+              <argument>${containerjfr.itest.podName}</argument>
+            </arguments>
+          </configuration>
+        </execution>
       </executions>
     </plugin>
     <plugin>
@@ -319,6 +352,7 @@
       <configuration>
         <systemPropertyVariables>
           <containerJfrWebPort>${containerjfr.itest.webPort}</containerJfrWebPort>
+          <containerJfrPodName>${containerjfr.itest.podName}</containerJfrPodName>
         </systemPropertyVariables>
       </configuration>
     </plugin>

--- a/src/test/java/itest/BasicCommandChannelIT.java
+++ b/src/test/java/itest/BasicCommandChannelIT.java
@@ -76,7 +76,7 @@ public class BasicCommandChannelIT extends TestBase {
         JsonObject resp = sendMessage("hostname").get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertResponseStatus(resp);
         String hostname = resp.getString("payload");
-        MatcherAssert.assertThat(hostname, Matchers.equalTo("container-jfr"));
+        MatcherAssert.assertThat(hostname, Matchers.equalTo("container-jfr-itests"));
     }
 
     @Test
@@ -119,7 +119,7 @@ public class BasicCommandChannelIT extends TestBase {
                                     new JsonObject(
                                             Map.of(
                                                     "connectUrl",
-                                                    "service:jmx:rmi:///jndi/rmi://container-jfr:9091/jmxrmi",
+                                                    "service:jmx:rmi:///jndi/rmi://container-jfr-itests:9091/jmxrmi",
                                                     "alias",
                                                     "com.redhat.rhjmc.containerjfr.ContainerJfr"));
                             MatcherAssert.assertThat(

--- a/src/test/java/itest/BasicCommandChannelIT.java
+++ b/src/test/java/itest/BasicCommandChannelIT.java
@@ -53,8 +53,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import itest.util.Utils;
 
-public class BasicCommandChannelIT extends ITestBase {
+public class BasicCommandChannelIT extends TestBase {
 
     @Test
     public void shouldGetPingResponse() throws Exception {
@@ -84,9 +85,7 @@ public class BasicCommandChannelIT extends ITestBase {
         assertResponseStatus(resp);
         String url = resp.getString("payload");
         MatcherAssert.assertThat(
-                url,
-                Matchers.equalTo(
-                        String.format("http://0.0.0.0:%d", IntegrationTestUtils.WEB_PORT)));
+                url, Matchers.equalTo(String.format("http://0.0.0.0:%d", Utils.WEB_PORT)));
     }
 
     @Test

--- a/src/test/java/itest/ClientAssetsIT.java
+++ b/src/test/java/itest/ClientAssetsIT.java
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class ClientAssetsIT extends ITestBase {
+public class ClientAssetsIT extends TestBase {
 
     static File file;
     static Document doc;

--- a/src/test/java/itest/ClientUrlIT.java
+++ b/src/test/java/itest/ClientUrlIT.java
@@ -50,8 +50,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.HttpRequest;
+import itest.util.Utils;
 
-public class ClientUrlIT extends ITestBase {
+public class ClientUrlIT extends TestBase {
 
     HttpRequest<Buffer> req;
 
@@ -122,6 +123,6 @@ public class ClientUrlIT extends ITestBase {
                 Matchers.equalTo(
                         String.format(
                                 "{\"clientUrl\":\"ws://0.0.0.0:%d/api/v1/command\"}",
-                                IntegrationTestUtils.WEB_PORT)));
+                                Utils.WEB_PORT)));
     }
 }

--- a/src/test/java/itest/ConnectToExternalTargetsIT.java
+++ b/src/test/java/itest/ConnectToExternalTargetsIT.java
@@ -1,0 +1,117 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package itest;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import io.vertx.core.json.JsonArray;
+import itest.util.Podman;
+
+class ConnectToExternalTargetsIT extends TestBase {
+
+    static final List<String> CONTAINERS = new ArrayList<>();
+
+    @BeforeAll
+    static void setup() throws Exception {
+        Set<String> specs = Set.of("quay.io/andrewazores/vertx-fib-demo:0.3.0");
+        for (String spec : specs) {
+            CONTAINERS.add(Podman.run(spec));
+        }
+        for (String id : CONTAINERS) {
+            Podman.waitForContainerState(id, "running");
+        }
+        Thread.sleep(7_500L); // wait for JDP to discover new containers
+    }
+
+    @AfterAll
+    static void cleanup() throws Exception {
+        for (String id : CONTAINERS) {
+            Podman.rm(id);
+        }
+    }
+
+    @Test
+    void testOtherContainerFound() throws Exception {
+        CompletableFuture<JsonArray> resp = new CompletableFuture<>();
+        webClient
+                .get("/api/v1/targets")
+                .send(
+                        ar -> {
+                            if (assertRequestStatus(ar, resp)) {
+                                resp.complete(ar.result().bodyAsJsonArray());
+                            }
+                        });
+        JsonArray listResp = resp.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        Set<Map<String, String>> actual = new HashSet<>(listResp.getList());
+        // ordering may not be guaranteed so use a Set, but there should be no duplicates and so
+        // size should not change
+        MatcherAssert.assertThat(actual.size(), Matchers.equalTo(listResp.size()));
+        Set<Map<String, String>> expected =
+                Set.of(
+                        Map.of(
+                                "connectUrl",
+                                String.format(
+                                        "service:jmx:rmi:///jndi/rmi://%s:9091/jmxrmi",
+                                        Podman.POD_NAME),
+                                "alias",
+                                "com.redhat.rhjmc.containerjfr.ContainerJfr"),
+                        Map.of(
+                                "connectUrl",
+                                String.format(
+                                        "service:jmx:rmi:///jndi/rmi://%s:9093/jmxrmi",
+                                        Podman.POD_NAME),
+                                "alias",
+                                "es.andrewazor.demo.Main"));
+        MatcherAssert.assertThat(actual, Matchers.equalTo(expected));
+    }
+}

--- a/src/test/java/itest/GrafanaDashboardIT.java
+++ b/src/test/java/itest/GrafanaDashboardIT.java
@@ -51,7 +51,7 @@ import org.junit.jupiter.api.Test;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.HttpRequest;
 
-public class GrafanaDashboardIT extends ITestBase {
+public class GrafanaDashboardIT extends TestBase {
 
     HttpRequest<Buffer> req;
 

--- a/src/test/java/itest/GrafanaDatasourceIT.java
+++ b/src/test/java/itest/GrafanaDatasourceIT.java
@@ -47,10 +47,12 @@ import java.util.concurrent.TimeUnit;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.HttpRequest;
 
-public class GrafanaDatasourceIT extends ITestBase {
+public class GrafanaDatasourceIT extends TestBase {
 
     HttpRequest<Buffer> req;
 
@@ -61,7 +63,8 @@ public class GrafanaDatasourceIT extends ITestBase {
 
     // Disabled for now due to conflict with UploadRecordingIT;
     // See https://github.com/rh-jmc-team/container-jfr/pull/229
-    // @Test
+    @Disabled
+    @Test
     public void shouldFail() throws Exception {
         CompletableFuture<Integer> future = new CompletableFuture<>();
         req.send(

--- a/src/test/java/itest/NoopAuthIT.java
+++ b/src/test/java/itest/NoopAuthIT.java
@@ -51,7 +51,7 @@ import org.junit.jupiter.api.Test;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.HttpRequest;
 
-public class NoopAuthIT extends ITestBase {
+public class NoopAuthIT extends TestBase {
 
     HttpRequest<Buffer> req;
 

--- a/src/test/java/itest/RecordingWorkflowIT.java
+++ b/src/test/java/itest/RecordingWorkflowIT.java
@@ -54,7 +54,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-public class RecordingWorkflowIT extends ITestBase {
+public class RecordingWorkflowIT extends TestBase {
 
     static final String TARGET_ID = "localhost";
     static final String TEST_RECORDING_NAME = "workflow_itest";

--- a/src/test/java/itest/TestBase.java
+++ b/src/test/java/itest/TestBase.java
@@ -65,17 +65,18 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import itest.util.Utils;
 
-public abstract class ITestBase {
+public abstract class TestBase {
 
     static final int REQUEST_TIMEOUT_SECONDS = 30;
-    static final WebClient webClient = IntegrationTestUtils.getWebClient();
+    static final WebClient webClient = Utils.getWebClient();
 
     static CompletableFuture<JsonObject> sendMessage(String command, String... args)
             throws InterruptedException, ExecutionException, TimeoutException {
         CompletableFuture<JsonObject> future = new CompletableFuture<>();
 
-        IntegrationTestUtils.HTTP_CLIENT.webSocket(
+        Utils.HTTP_CLIENT.webSocket(
                 getClientUrl().get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS),
                 ar -> {
                     if (ar.failed()) {
@@ -176,7 +177,7 @@ public abstract class ITestBase {
                                 new Exception(String.format("HTTP %d", resp.statusCode())));
                         return;
                     }
-                    FileSystem fs = IntegrationTestUtils.getFileSystem();
+                    FileSystem fs = Utils.getFileSystem();
                     String file = fs.createTempFileBlocking(filename, fileSuffix);
                     fs.writeFileBlocking(file, ar.result().body());
                     future.complete(Paths.get(file));

--- a/src/test/java/itest/UploadRecordingIT.java
+++ b/src/test/java/itest/UploadRecordingIT.java
@@ -54,7 +54,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
 
-public class UploadRecordingIT extends ITestBase {
+public class UploadRecordingIT extends TestBase {
 
     static final String TARGET_ID = "localhost";
     static final String RECORDING_NAME = "upload_recording_it_rec";

--- a/src/test/java/itest/util/Podman.java
+++ b/src/test/java/itest/util/Podman.java
@@ -1,0 +1,167 @@
+/*-
+ * #%L
+ * Container JFR
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package itest.util;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+
+public abstract class Podman {
+
+    private Podman() {}
+
+    // this can take some time if an image needs to be pulled
+    public static final Duration STARTUP_TIMEOUT = Duration.ofSeconds(60);
+
+    public static final String POD_NAME;
+
+    static {
+        Environment env = new Environment();
+        POD_NAME = env.getProperty("containerJfrPodName");
+    }
+
+    public static String run(String imageSpec) throws Exception {
+        return runCommand("run", "--quiet", "--pod=" + POD_NAME, "--detach", "--rm", imageSpec)
+                .out();
+    }
+
+    public static void waitForContainerState(String id, String state) throws Exception {
+        long start = System.currentTimeMillis();
+        long elapsed = 0;
+        state = String.format("\"%s\"", Objects.requireNonNull(state));
+        while (elapsed < STARTUP_TIMEOUT.toMillis()) {
+            String out =
+                    runCommand("container", "inspect", "--format=\"{{.State.Status}}\"", id).out();
+            if (state.trim().equalsIgnoreCase(out)) {
+                break;
+            }
+            long now = System.currentTimeMillis();
+            long delta = now - start;
+            elapsed += delta;
+            Thread.sleep(2_000L);
+        }
+        if (elapsed >= STARTUP_TIMEOUT.toMillis()) {
+            throw new PodmanException(
+                    String.format(
+                            "Container %s did not reach %s state in %ds",
+                            id, state, STARTUP_TIMEOUT.toSeconds()));
+        }
+    }
+
+    public static String rm(String id) throws Exception {
+        return runCommand("rm", "--force", id).out();
+    }
+
+    private static CommandOutput runCommand(String... args) throws Exception {
+        Process proc = null;
+        try {
+            List<String> argsList = new ArrayList<>();
+            argsList.add("podman");
+            argsList.addAll(Arrays.asList(args));
+            System.out.println(argsList);
+            proc = new ProcessBuilder().command(argsList).start();
+            proc.waitFor(STARTUP_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            CommandOutput co = new CommandOutput(proc);
+            if (StringUtils.isNotBlank(co.out())) {
+                System.out.println(co.out());
+            }
+            if (StringUtils.isNotBlank(co.err())) {
+                System.out.println(co.err());
+            }
+            if (co.exitValue() != 0) {
+                throw new PodmanException(co);
+            }
+            return co;
+        } finally {
+            if (proc != null) {
+                proc.destroyForcibly();
+            }
+        }
+    }
+
+    public static class CommandOutput {
+
+        private final int exitValue;
+        private final String out;
+        private final String err;
+
+        CommandOutput(Process proc) throws IOException {
+            this.exitValue = proc.exitValue();
+            this.out = IOUtils.toString(proc.getInputStream(), "UTF-8").trim();
+            this.err = IOUtils.toString(proc.getErrorStream(), "UTF-8").trim();
+        }
+
+        public int exitValue() {
+            return exitValue;
+        }
+
+        public String out() {
+            return out;
+        }
+
+        public String err() {
+            return err;
+        }
+    }
+
+    public static class PodmanException extends IOException {
+        PodmanException(CommandOutput co) {
+            super(
+                    String.format(
+                            "Exit status %d: out: %s - err: %s",
+                            co.exitValue(), co.out(), co.err()));
+        }
+
+        PodmanException(String reason) {
+            super(reason);
+        }
+    }
+}

--- a/src/test/java/itest/util/Utils.java
+++ b/src/test/java/itest/util/Utils.java
@@ -39,7 +39,7 @@
  * SOFTWARE.
  * #L%
  */
-package itest;
+package itest.util;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.file.FileSystem;
@@ -47,7 +47,7 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.ext.web.client.WebClient;
 
-public class IntegrationTestUtils {
+public class Utils {
 
     public static final int WEB_PORT;
 
@@ -55,7 +55,7 @@ public class IntegrationTestUtils {
         WEB_PORT = Integer.valueOf(System.getProperty("containerJfrWebPort"));
     }
 
-    static final HttpClientOptions HTTP_CLIENT_OPTIONS;
+    public static final HttpClientOptions HTTP_CLIENT_OPTIONS;
 
     static {
         HTTP_CLIENT_OPTIONS =
@@ -69,7 +69,7 @@ public class IntegrationTestUtils {
     }
 
     private static final Vertx VERTX = Vertx.vertx();
-    static final HttpClient HTTP_CLIENT = VERTX.createHttpClient(HTTP_CLIENT_OPTIONS);
+    public static final HttpClient HTTP_CLIENT = VERTX.createHttpClient(HTTP_CLIENT_OPTIONS);
     private static final WebClient WEB_CLIENT_INSTANCE = WebClient.wrap(HTTP_CLIENT);
 
     public static WebClient getWebClient() {


### PR DESCRIPTION
This is a backport of #376 . There was an adjustment to `BasicCommandChannelIT` required, which is included as a separate commit. `main` has this test disabled, so the correction was never made. Otherwise, the patch applied with only one minor merge conflict, also to `BasicCommandChannelIT`.