### PR TITLE
Add separate property for Dagger compiler version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
   <com.google.cloud.tools.jib.maven.plugin.version>2.6.0</com.google.cloud.tools.jib.maven.plugin.version>
 
   <com.google.dagger.version>2.26</com.google.dagger.version>
+  <com.google.dagger.compiler.version>2.26</com.google.dagger.compiler.version>
 
   <com.redhat.rhjmc.containerjfr.core.version>2.2.1</com.redhat.rhjmc.containerjfr.core.version>
 
@@ -200,7 +201,7 @@
           <path>
             <groupId>com.google.dagger</groupId>
             <artifactId>dagger-compiler</artifactId>
-            <version>${com.google.dagger.version}</version>
+            <version>${com.google.dagger.compiler.version}</version>
           </path>
         </annotationProcessorPaths>
       </configuration>


### PR DESCRIPTION
While it makes sense to keep the Dagger and Dagger compiler versions in sync. Having a separate property will help with downstream builds where we add a suffix to the Dagger (core) version, but don't want to do this for the compiler.