### PR TITLE
web-client build caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -634,7 +634,7 @@
             </execution>
             <execution>
               <id>yarn run build</id>
-              <phase>prepare-package</phase>
+              <phase>compile</phase>
               <goals>
                 <goal>yarn</goal>
               </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -658,6 +658,9 @@
                 <resources>
                   <resource>
                     <directory>web-client/dist</directory>
+                    <excludes>
+                        <exclude>cache/**/*</exclude>
+                    </excludes>
                   </resource>
                 </resources>
                 <outputDirectory>${project.build.directory}/assets/app/resources/com/redhat/rhjmc/containerjfr/net/web</outputDirectory>


### PR DESCRIPTION
See rh-jmc-team/container-jfr-web#169

To test: `mvn package` repeatedly. On subsequent (re)builds, the frontend assets should not be rebuilt - instead, the existing assets in `web-client/dist` should simply be reused from the previous build.