### PR TITLE
Exclude unneeded Caffeine deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,9 +138,19 @@
     <version>${com.google.code.gson.version}</version>
   </dependency>
   <dependency>
-      <groupId>com.github.ben-manes.caffeine</groupId>
-      <artifactId>caffeine</artifactId>
-      <version>${com.github.ben-manes.caffeine.version}</version>
+    <groupId>com.github.ben-manes.caffeine</groupId>
+    <artifactId>caffeine</artifactId>
+    <version>${com.github.ben-manes.caffeine.version}</version>
+    <exclusions>
+      <exclusion>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+      </exclusion>
+      <exclusion>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+      </exclusion>
+    </exclusions>
   </dependency>
   <dependency>
     <groupId>org.jsoup</groupId>


### PR DESCRIPTION
Caffeine has a couple of dependencies that aren't required at runtime and cause some trouble for our downstream builds. We can exclude these transitive dependencies to prevent pulling them into our build. Other projects use the same approach, such as Wildfly.

Related discussion: https://github.com/ben-manes/caffeine/issues/300