### PR TITLE
Update kubernetes/openshift-client to 4.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
   <org.apache.commons.validator.version>1.6</org.apache.commons.validator.version>
   <org.apache.commons.io.version>2.6</org.apache.commons.io.version>
   <org.apache.httpcomponents.version>4.5.11</org.apache.httpcomponents.version>
-  <io.fabric8.client.version>4.6.4</io.fabric8.client.version>
+  <io.fabric8.client.version>4.12.0</io.fabric8.client.version>
   <io.vertx.web.version>3.9.2</io.vertx.web.version>
   <org.slf4j.version>1.7.30</org.slf4j.version>
   <com.google.code.gson.version>2.8.6</com.google.code.gson.version>


### PR DESCRIPTION
This PR updates the version of the Fabric8 Kubernetes and OpenShift clients to the 4.12.0 release. Aside from better compatibility with newer versions of Kubernetes/OpenShift [1], this solves some headaches in our downstream builds.

[1] https://github.com/fabric8io/kubernetes-client/tree/v4.12.0#compatibility-matrix