### PR TITLE
Update vulnerable dependencies, add dep-check profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
   <com.github.eirslett.frontend.plugin.version>1.9.1</com.github.eirslett.frontend.plugin.version>
   <org.codehaus.mojo.exec.plugin.version>1.6.0</org.codehaus.mojo.exec.plugin.version>
   <org.codehaus.mojo.license.plugin.version>2.0.0</org.codehaus.mojo.license.plugin.version>
+  <org.owasp.dependency.check.version>6.0.5</org.owasp.dependency.check.version>
   <com.google.cloud.tools.jib.maven.plugin.version>2.6.0</com.google.cloud.tools.jib.maven.plugin.version>
 
   <com.google.dagger.version>2.26</com.google.dagger.version>
@@ -51,11 +52,11 @@
 
   <org.apache.commons.lang3.version>3.9</org.apache.commons.lang3.version>
   <org.apache.commons.codec.version>1.13</org.apache.commons.codec.version>
-  <org.apache.commons.validator.version>1.6</org.apache.commons.validator.version>
+  <org.apache.commons.validator.version>1.7</org.apache.commons.validator.version>
   <org.apache.commons.io.version>2.6</org.apache.commons.io.version>
-  <org.apache.httpcomponents.version>4.5.11</org.apache.httpcomponents.version>
+  <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>
   <io.fabric8.client.version>4.12.0</io.fabric8.client.version>
-  <io.vertx.web.version>3.9.2</io.vertx.web.version>
+  <io.vertx.web.version>3.9.5</io.vertx.web.version>
   <org.slf4j.version>1.7.30</org.slf4j.version>
   <com.google.code.gson.version>2.8.6</com.google.code.gson.version>
   <com.github.ben-manes.caffeine.version>2.8.4</com.github.ben-manes.caffeine.version>
@@ -68,7 +69,7 @@
   <org.jacoco.maven.plugin.version>0.8.5</org.jacoco.maven.plugin.version>
   <com.diffplug.spotless.maven.plugin.version>1.27.0</com.diffplug.spotless.maven.plugin.version>
   <org.jsoup.version>1.12.1</org.jsoup.version>
-  <org.codehaus.plexus.utils.version>3.0.22</org.codehaus.plexus.utils.version>
+  <org.codehaus.plexus.utils.version>3.2.0</org.codehaus.plexus.utils.version>
 </properties>
 
 <dependencies>
@@ -700,6 +701,30 @@
               <goals>
                 <goal>single</goal>
               </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
+  <profile>
+    <id>dep-check</id>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.owasp</groupId>
+          <artifactId>dependency-check-maven</artifactId>
+          <version>${org.owasp.dependency.check.version}</version>
+          <configuration>
+            <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+          </configuration>
+          <executions>
+            <execution>
+              <id>check-for-vulnerable-deps</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>validate</phase>
             </execution>
           </executions>
         </plugin>


### PR DESCRIPTION
This PR adds a `dep-check` profile to run OWASP Dependency Check, which scans our dependencies for vulnerabilities. I tried to accomplish this using Github's built-in Dependabot (sorry about the noise), but that just tried to update even non-vulnerable dependencies. Apparently Dependabot will alert us by default of vulnerabilities, but it's missing those found by this plugin:
```
[ERROR] One or more dependencies were identified with vulnerabilities: 
[ERROR] 
[ERROR] commons-beanutils-1.9.2.jar: CVE-2019-10086
[ERROR] httpclient-4.5.11.jar: CVE-2020-13956
[ERROR] plexus-utils-3.0.22.jar: Possible XML Injection, Directory traversal in org.codehaus.plexus.util.Expand
[ERROR] vertx-core-3.9.2.jar: CVE-2019-17640
```

I've updated those dependencies in this PR as well.