### PR TITLE
Update web-client to v1.0.0-BETA5 and bump image version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>com.redhat.rhjmc.containerjfr</groupId>
 <artifactId>container-jfr</artifactId>
-<version>1.0.0-BETA4</version>
+<version>1.0.0-BETA5</version>
 <packaging>jar</packaging>
 <name>container-jfr</name>
 <url>http://maven.apache.org</url>


### PR DESCRIPTION
I have pushed this image to `quay.io/andrewazores/container-jfr:1.0.0-BETA5` for testing. This contains the fix for rh-jmc-team/container-jfr-web#170 .