### PR TITLE
Use URL-safe Base64 encoder/decoder

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/BasicAuthManager.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/BasicAuthManager.java
@@ -112,7 +112,7 @@ class BasicAuthManager extends AbstractAuthManager {
         String b64 = matcher.group(1);
         try {
             String decoded =
-                    new String(Base64.getDecoder().decode(b64), StandardCharsets.UTF_8).trim();
+                    new String(Base64.getUrlDecoder().decode(b64), StandardCharsets.UTF_8).trim();
             return validateToken(() -> decoded);
         } catch (IllegalArgumentException e) {
             return CompletableFuture.completedFuture(false);
@@ -136,7 +136,7 @@ class BasicAuthManager extends AbstractAuthManager {
         String b64 = matcher.group(1);
         try {
             String decoded =
-                    new String(Base64.getDecoder().decode(b64), StandardCharsets.UTF_8).trim();
+                    new String(Base64.getUrlDecoder().decode(b64), StandardCharsets.UTF_8).trim();
             return validateToken(() -> decoded);
         } catch (IllegalArgumentException e) {
             return CompletableFuture.completedFuture(false);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/OpenShiftAuthManager.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/OpenShiftAuthManager.java
@@ -137,7 +137,7 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
         String b64 = matcher.group(1);
         try {
             String decoded =
-                    new String(Base64.getDecoder().decode(b64), StandardCharsets.UTF_8).trim();
+                    new String(Base64.getUrlDecoder().decode(b64), StandardCharsets.UTF_8).trim();
             return validateToken(() -> decoded);
         } catch (IllegalArgumentException e) {
             return CompletableFuture.completedFuture(false);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/AbstractAuthenticatedRequestHandler.java
@@ -129,7 +129,7 @@ public abstract class AbstractAuthenticatedRequestHandler implements RequestHand
                     try {
                         c =
                                 new String(
-                                        Base64.getDecoder().decode(m.group("credentials")),
+                                        Base64.getUrlDecoder().decode(m.group("credentials")),
                                         StandardCharsets.UTF_8);
                     } catch (IllegalArgumentException iae) {
                         ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");

--- a/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/net/web/http/api/v2/AbstractV2RequestHandler.java
@@ -146,7 +146,7 @@ abstract class AbstractV2RequestHandler<T> implements RequestHandler {
                     try {
                         c =
                                 new String(
-                                        Base64.getDecoder().decode(m.group("credentials")),
+                                        Base64.getUrlDecoder().decode(m.group("credentials")),
                                         StandardCharsets.UTF_8);
                     } catch (IllegalArgumentException iae) {
                         params.getHeaders().set(JMX_AUTHENTICATE_HEADER, "Basic");

--- a/src/test/java/com/redhat/rhjmc/containerjfr/net/BasicAuthManagerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/net/BasicAuthManagerTest.java
@@ -308,6 +308,7 @@ class BasicAuthManagerTest {
             Mockito.when(fs.exists(mockPath)).thenReturn(true);
             Mockito.when(fs.isRegularFile(mockPath)).thenReturn(true);
             Mockito.when(fs.isReadable(mockPath)).thenReturn(true);
+            // credentials: "user:pass"
             BufferedReader props =
                     new BufferedReader(
                             new StringReader(
@@ -316,6 +317,56 @@ class BasicAuthManagerTest {
             Assertions.assertTrue(
                     mgr.validateWebSocketSubProtocol(
                                     () -> "basic.authorization.containerjfr.dXNlcjpwYXNz")
+                            .get());
+        }
+
+        @Test
+        void shouldPassKnownCredentialsWithPadding() throws Exception {
+            Path mockPath = Mockito.mock(Path.class);
+            Mockito.when(
+                            fs.pathOf(
+                                    System.getProperty("user.home"),
+                                    BasicAuthManager.USER_PROPERTIES_FILENAME))
+                    .thenReturn(mockPath);
+            Mockito.when(fs.exists(mockPath)).thenReturn(true);
+            Mockito.when(fs.isRegularFile(mockPath)).thenReturn(true);
+            Mockito.when(fs.isReadable(mockPath)).thenReturn(true);
+            // credentials: "user:pass1234"
+            BufferedReader props =
+                    new BufferedReader(
+                            new StringReader(
+                                    "user:bd94dcda26fccb4e68d6a31f9b5aac0b571ae266d822620e901ef7ebe3a11d4f"));
+            Mockito.when(fs.readFile(mockPath)).thenReturn(props);
+            Assertions.assertTrue(
+                    mgr.validateWebSocketSubProtocol(
+                                    () -> "basic.authorization.containerjfr.dXNlcjpwYXNzMTIzNA==")
+                            .get());
+        }
+
+        @Test
+        void shouldPassKnownCredentialsAndStrippedPadding() throws Exception {
+            Path mockPath = Mockito.mock(Path.class);
+            Mockito.when(
+                            fs.pathOf(
+                                    System.getProperty("user.home"),
+                                    BasicAuthManager.USER_PROPERTIES_FILENAME))
+                    .thenReturn(mockPath);
+            Mockito.when(fs.exists(mockPath)).thenReturn(true);
+            Mockito.when(fs.isRegularFile(mockPath)).thenReturn(true);
+            Mockito.when(fs.isReadable(mockPath)).thenReturn(true);
+            // credentials: "user:pass1234"
+            BufferedReader props =
+                    new BufferedReader(
+                            new StringReader(
+                                    "user:bd94dcda26fccb4e68d6a31f9b5aac0b571ae266d822620e901ef7ebe3a11d4f"));
+            Mockito.when(fs.readFile(mockPath)).thenReturn(props);
+            // the subprotocol token part here should be "dXNlcjpwYXNzMTIzNA==", but the '='s are
+            // padding and stripped out. The decoder should treat these as optional, and the client
+            // is likely not to send them since they are not permitted by the WebSocket
+            // specification for the Sec-WebSocket-Protocol header
+            Assertions.assertTrue(
+                    mgr.validateWebSocketSubProtocol(
+                                    () -> "basic.authorization.containerjfr.dXNlcjpwYXNzMTIzNA")
                             .get());
         }
 
@@ -330,6 +381,7 @@ class BasicAuthManagerTest {
             Mockito.when(fs.exists(mockPath)).thenReturn(true);
             Mockito.when(fs.isRegularFile(mockPath)).thenReturn(true);
             Mockito.when(fs.isReadable(mockPath)).thenReturn(true);
+            // credentials: "user:pass"
             BufferedReader props =
                     new BufferedReader(
                             new StringReader(

--- a/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
+++ b/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
@@ -168,7 +168,7 @@ class InterleavedExternalTargetRequestsIT extends TestBase {
                                 .putHeader(
                                         "X-JMX-Authorization",
                                         "Basic "
-                                                + Base64.getEncoder()
+                                                + Base64.getUrlEncoder()
                                                         .encodeToString(
                                                                 "admin:adminpass123".getBytes()))
                                 .sendForm(
@@ -198,7 +198,7 @@ class InterleavedExternalTargetRequestsIT extends TestBase {
                     .putHeader(
                             "X-JMX-Authorization",
                             "Basic "
-                                    + Base64.getEncoder()
+                                    + Base64.getUrlEncoder()
                                             .encodeToString("admin:adminpass123".getBytes()))
                     .send(
                             ar -> {
@@ -242,7 +242,7 @@ class InterleavedExternalTargetRequestsIT extends TestBase {
                                 .putHeader(
                                         "X-JMX-Authorization",
                                         "Basic "
-                                                + Base64.getEncoder()
+                                                + Base64.getUrlEncoder()
                                                         .encodeToString(
                                                                 "admin:adminpass123".getBytes()))
                                 .sendForm(
@@ -272,7 +272,7 @@ class InterleavedExternalTargetRequestsIT extends TestBase {
                     .putHeader(
                             "X-JMX-Authorization",
                             "Basic "
-                                    + Base64.getEncoder()
+                                    + Base64.getUrlEncoder()
                                             .encodeToString("admin:adminpass123".getBytes()))
                     .send(
                             ar -> {


### PR DESCRIPTION
Use encoder which produces, and decoder which expects, the URL-safe Base64 alphabet variant. The decoder is also tolerant of missing padding characters at the end, which the client will not send due to their illegality in the WebSocket Subprotocol header value. There is a corresponding web-client change: https://github.com/rh-jmc-team/container-jfr-web/pull/173 . A temporary commit is included in this PR to update the web-client to use that branch, which will be replaced before this is merged with a commit updating the web-client to a proper tagged release version containing the change.

To test, check out the #417 branch to get the token config file, then:

`CONTAINER_JFR_IMAGE=quay.io/andrewazores/container-jfr:2.0.0-base64url CONTAINER_JFR_AUTH_MANAGER=com.redhat.rhjmc.containerjfr.net.TokenAuthManager sh smoketest.sh` - the image referenced here contains these changes as well as the main change in #417 which adds the `TokenAuthManager`, allowing for easier testing of various auth token values.

`echo -n abc123 | base64` => `YWJjMTIz`, which is a valid "token" both before and after this change.

`echo -n pass1234 | base64` => `cGFzczEyMzQ=`, which contains a padding `=` and thus will cause the WebSocket construction to fail in Chromium-based browsers before this change, but work after.

This image can also be deployed in OpenShift/CRC and tested with the default `OpenShiftAuthManager` to verify that such auth tokens, ex. `sha256~dPZKsUqyZDjJugRI5N_hML81x9ocR1vFp2g2-4e92NI` (base64: `c2hhMjU2fmRQWktzVXF5WkRqSnVnUkk1Tl9oTUw4MXg5b2NSMXZGcDJnMi00ZTkyTkk=`) also work in Chromium browsers with this change.

Related to https://github.com/rh-jmc-team/container-jfr-operator/issues/131